### PR TITLE
chore(lint): built the repo so that linting can happen properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Run build
+          command: yarn build
+      - run:
           name: Run eslint
           command: yarn lint
   prettier:


### PR DESCRIPTION
Turns out that the linting required the build to build the packages that the linting rules were checking for (making sure import paths were correct). Building before linting made it all work