### PR TITLE
fix(website): empty state / 404, component overview tweaks

### DIFF
--- a/packages/paste-website/src/components/codeblock/index.tsx
+++ b/packages/paste-website/src/components/codeblock/index.tsx
@@ -6,6 +6,7 @@ import {CodeblockTheme} from './theme';
 
 const StyledPre = styled.pre(props => ({
   padding: `${themeGet('space.space40')(props)} ${themeGet('space.space60')(props)}`,
+  overflow: 'auto',
 }));
 
 export type Language =

--- a/packages/paste-website/src/components/component-overview-table/index.tsx
+++ b/packages/paste-website/src/components/component-overview-table/index.tsx
@@ -4,19 +4,19 @@ import {Table, Thead, Tbody, Tr, Th, Td} from '../table';
 import {SidebarCategoryRoutes, PackageStatus} from '../../constants';
 import {getPackagePath, getNameFromPackageName} from '../../utils/RouteUtils';
 
-type ComponentNode = {
+interface ComponentNode {
   node: {
     name: string;
     version: string;
     status: string;
   };
-};
+}
 interface ComponentOverviewTableProps {
   children?: React.ReactElement;
   componentsList?: [ComponentNode];
 }
 
-const sortNodeByName = (a: ComponentNode, b: ComponentNode) => (a.node.name > b.node.name ? 1 : -1);
+const sortNodeByName = (a: ComponentNode, b: ComponentNode): number => (a.node.name > b.node.name ? 1 : -1);
 
 const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componentsList}) => {
   if (componentsList == null) {
@@ -63,7 +63,7 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componen
                 </Link>
               </Td>
               <Td>{node.status}</Td>
-              <Td></Td>
+              <Td />
             </Tr>
           );
         })}

--- a/packages/paste-website/src/components/component-overview-table/index.tsx
+++ b/packages/paste-website/src/components/component-overview-table/index.tsx
@@ -4,26 +4,19 @@ import {Table, Thead, Tbody, Tr, Th, Td} from '../table';
 import {SidebarCategoryRoutes, PackageStatus} from '../../constants';
 import {getPackagePath, getNameFromPackageName} from '../../utils/RouteUtils';
 
+type ComponentNode = {
+  node: {
+    name: string;
+    version: string;
+    status: string;
+  };
+};
 interface ComponentOverviewTableProps {
   children?: React.ReactElement;
-  componentsList?: [
-    {
-      node: {
-        name: string;
-        version: string;
-        status: string;
-      };
-    }
-  ];
+  componentsList?: [ComponentNode];
 }
 
-function getPackageRoute(name: string, status: string): string | React.ReactNode {
-  if (status === PackageStatus.BACKLOG) {
-    return getNameFromPackageName(name);
-  }
-
-  return <Link to={getPackagePath(SidebarCategoryRoutes.COMPONENTS, name)}>{getNameFromPackageName(name)}</Link>;
-}
+const sortNodeByName = (a: ComponentNode, b: ComponentNode) => (a.node.name > b.node.name ? 1 : -1);
 
 const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componentsList}) => {
   if (componentsList == null) {
@@ -31,7 +24,12 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componen
   }
 
   // Sort backlog items to the bottom of the list
-  const sortedComponentsList = componentsList.sort(({node}) => (node.status === PackageStatus.BACKLOG ? 1 : -1));
+  const sortedBacklogList = componentsList
+    .filter(({node}) => node.status === PackageStatus.BACKLOG)
+    .sort(sortNodeByName);
+  const sortedComponentsList = componentsList
+    .filter(({node}) => node.status !== PackageStatus.BACKLOG)
+    .sort(sortNodeByName);
 
   return (
     <Table>
@@ -46,9 +44,26 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componen
         {sortedComponentsList.map(({node}) => {
           return (
             <Tr key={node.name}>
-              <Td>{getPackageRoute(node.name, node.status)}</Td>
+              <Td>
+                <Link to={getPackagePath(SidebarCategoryRoutes.COMPONENTS, node.name)}>
+                  {getNameFromPackageName(node.name)}
+                </Link>
+              </Td>
               <Td>{node.status}</Td>
-              <Td>{node.status === PackageStatus.BACKLOG ? '' : node.version}</Td>
+              <Td>{node.version}</Td>
+            </Tr>
+          );
+        })}
+        {sortedBacklogList.map(({node}) => {
+          return (
+            <Tr key={node.name}>
+              <Td>
+                <Link to={getPackagePath(SidebarCategoryRoutes.COMPONENTS, node.name)}>
+                  {getNameFromPackageName(node.name)}
+                </Link>
+              </Td>
+              <Td>{node.status}</Td>
+              <Td></Td>
             </Tr>
           );
         })}

--- a/packages/paste-website/src/components/empty-state/Error404.tsx
+++ b/packages/paste-website/src/components/empty-state/Error404.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import {InDevelopment} from './InDevelopment';
 import {NotBuilt} from './NotBuilt';
 import {NotFound} from './NotFound';
-import {SidebarCategoryRoutes} from '../../constants';
+import {SidebarCategoryRoutes, PackageStatus} from '../../constants';
 
 interface Error404Props {
   pathname: string;
-  componentList: {name: string; version: string}[];
-  utilitityList: {name: string; version: string}[];
+  componentList: {name: string; status: string}[];
+  utilitityList: {name: string; status: string}[];
 }
 
 const Error404 = ({pathname, componentList, utilitityList}: Error404Props): React.ReactNode => {
@@ -17,7 +17,7 @@ const Error404 = ({pathname, componentList, utilitityList}: Error404Props): Reac
   const packageObj = [...componentList, ...utilitityList].find(({name}) => name === packageName);
 
   if (packageObj != null) {
-    const isInDevelopment = packageObj.version !== '0.0.0';
+    const isInDevelopment = packageObj.status !== PackageStatus.BACKLOG;
 
     if (pathname.includes(SidebarCategoryRoutes.COMPONENTS)) {
       if (isInDevelopment) {

--- a/packages/paste-website/src/components/empty-state/InDevelopment.tsx
+++ b/packages/paste-website/src/components/empty-state/InDevelopment.tsx
@@ -32,8 +32,8 @@ const InDevelopment: React.FC<InDevelopmentProps> = ({type, name}) => {
       <Box>
         <Text>This {type} is in active development, but we haven&apos;t gotten to the docs yet.</Text>
         <Text>
-          Feel free to <Anchor href="https://github.com/twilio-labs/paste/issues">file a ticket</Anchor> to help us
-          prioritize writing the docs if you need this.
+          Feel free to <Anchor href="https://github.com/twilio-labs/paste/issues">file a feature request</Anchor> with
+          details on how you want to use this {type} and we&apos;ll respond to you directly.
         </Text>
       </Box>
     </>

--- a/packages/paste-website/src/components/sidebar/Navigation.tsx
+++ b/packages/paste-website/src/components/sidebar/Navigation.tsx
@@ -105,6 +105,9 @@ const Navigation: React.FC<NavigationProps> = () => {
             <SiteNavItem>
               <SiteNavAnchor to="/getting-started/design">Design Guidelines</SiteNavAnchor>
             </SiteNavItem>
+            <SiteNavItem>
+              <SiteNavAnchor to="/getting-started/engineering">Engineering Guidelines</SiteNavAnchor>
+            </SiteNavItem>
           </SiteNavNestList>
         </SiteNavItem>
         <SiteNavItem>

--- a/packages/paste-website/src/pages/404/index.mdx
+++ b/packages/paste-website/src/pages/404/index.mdx
@@ -17,13 +17,13 @@ export const pageQuery = graphql`
   allPasteComponent {
     nodes {
       name
-      version
+      status
     }
   }
   allPasteUtility {
     nodes {
       name
-      version
+      status
     }
   }
 }`;

--- a/packages/paste-website/src/pages/components/index.mdx
+++ b/packages/paste-website/src/pages/components/index.mdx
@@ -18,15 +18,15 @@ import {Breadcrumb, BreadcrumbItem} from '../../components/breadcrumb';
 </Heading>
 
 <P>
-  Components listed here are on the Paste roadmap or are available today.
+  The components listed here are on our roadmap.  Only a few of them are available today.
 </P>
 
 <P>
-  If you’re planning on using an alpha or beta component, please check in with the Paste team through ???.
+  If you’re planning on using an alpha or beta component, please check in with the Paste team through the <strong>#help-design-system</strong> channel on Slack.
 </P>
 
 <P>
-  Don't see a component you need listed here? Create an issue on GitHub, and we'll evaluate it. Not all component
+  Don't see a component you need listed here? <Anchor href="https://github.com/twilio-labs/paste/issues">Create an issue on GitHub</Anchor>, and we'll evaluate it. Not all component
   requests are accepted for the design system. We’ll have guidelines soon for what to do if your component isn’t
   supported.
 </P>

--- a/packages/paste-website/src/pages/getting-started/engineering.mdx
+++ b/packages/paste-website/src/pages/getting-started/engineering.mdx
@@ -1,0 +1,57 @@
+---
+title: Engineering Guidelines for Paste
+description: This document will highlight our approach for unified design libraries, tips for getting started, and similar resources for Engineers using Paste.
+---
+
+import DogVideo from "../../assets/quickstart_alpha.mp4"
+
+
+## Installation
+
+Currently, every package is standalone in the paste project.  While this means you only get what you need, it makes it a little more tedious to get started.  We hope to address this in the near future, but for now you can run:
+
+#### External dependencies
+
+```shell
+yarn add @emotion/core @emotion/styled styled-system@4.1.0 react-uid
+```
+
+#### System packages
+
+```shell
+yarn add @twilio-paste/theme @twilio-paste/design-tokens @twilio-paste/theme-tokens @twilio-paste/box @twilio-paste/icons @twilio-paste/spinner @twilio-paste/text @twilio-paste/button @twilio-paste/anchor @twilio-paste/absolute @twilio-paste/screen-reader-only @twilio-paste/media-object
+```
+
+
+## 8 minute video walkthrough
+
+Be gentle :P  - this was recorded in one take on zoom.
+
+<video controls width="640px" height="480px">
+    <source src={DogVideo} type="video/mp4" />
+</video>
+
+
+## Usage
+
+```jsx
+import {Theme} from '@twilio-paste/theme';
+
+// Wrap your root component with the Theme.Provider like so:
+<Theme.Provider theme="default">
+    // other stuff here
+</Theme.Provider>
+```
+
+Now you can use our themed and tokenized components anywhere in your app:
+
+```jsx
+import {Box} from '@twilio-paste/box';
+
+<Box margin="space20" backgroundColor="colorBackground">
+    Hello Paste!
+</Box>
+```
+
+Our tokens are readily available on our components and typescript typings are provided. 
+

--- a/packages/paste-website/src/pages/getting-started/engineering.mdx
+++ b/packages/paste-website/src/pages/getting-started/engineering.mdx
@@ -3,7 +3,7 @@ title: Engineering Guidelines for Paste
 description: This document will highlight our approach for unified design libraries, tips for getting started, and similar resources for Engineers using Paste.
 ---
 
-import DogVideo from "../../assets/quickstart_alpha.mp4"
+import QuickstartVideo from "../../assets/quickstart_alpha.mp4"
 
 
 ## Installation
@@ -28,7 +28,7 @@ yarn add @twilio-paste/theme @twilio-paste/design-tokens @twilio-paste/theme-tok
 Be gentle :P  - this was recorded in one take on zoom.
 
 <video controls width="640px" height="480px">
-    <source src={DogVideo} type="video/mp4" />
+    <source src={QuickstartVideo} type="video/mp4" />
 </video>
 
 


### PR DESCRIPTION
- [x] Sort component overview rows so they don't render in different orders each refresh
- [x] 404 page should check against package status rather than version (now that we had to bump backlog to 0.0.1)
- [x] Rework the text on the component overview page, replacing `???` with actual text
- [x] Tweak a sentence in the 404 page
- [x] Fix codeblock text overflow by adding `overflow: auto`
- [x] Add a quick engineering guidelines page with a video demo


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
