### PR TITLE
fix(website): fix missing link in anchors page

### DIFF
--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -72,7 +72,7 @@ You can use an anchor to navigate the user to another webpage.
 
 Anchors should be used in place of a button if you only need to create a hyperlink to some other page or content. Anchors should not be used for submitting a form, closing a modal, moving to the next step in a flow, or any other click action that a button should handle. Buttons perform an action, like submitting a form; Anchors take you somewhere, like to the documentation page.
 
-If you need a click handler, you can use our button component. See the button documentation here.
+If you need a click handler, you can use our [Button component](/components/button).
 
 ### Accessibility
 


### PR DESCRIPTION
Fix a missing link to the button component from the anchor component page.

Capitalized Button because Anchor was capitalized on the opposite end of this link.