### PR TITLE
fix(website): changed p to Text

### DIFF
--- a/packages/paste-website/src/components/icons/TwilioIcon.tsx
+++ b/packages/paste-website/src/components/icons/TwilioIcon.tsx
@@ -11,7 +11,7 @@ export interface TwilioIconProps {
 }
 
 const TwilioIcon = React.memo(
-  ({title = 'Twilio Icon', decorative = true, className, color, size, display = 'block'}: TwilioIconProps) => {
+  ({title = 'Twilio Icon', className, color, decorative = true, display, size}: TwilioIconProps) => {
     const uid = useUID();
     return (
       <span style={{color, display, width: size, height: size}} className={className}>

--- a/packages/paste-website/src/components/icons/TwilioIcon.tsx
+++ b/packages/paste-website/src/components/icons/TwilioIcon.tsx
@@ -3,25 +3,28 @@ import {useUID} from 'react-uid';
 
 export interface TwilioIconProps {
   className?: string;
-  size?: number;
   color?: string;
-  title?: string;
   decorative?: boolean;
+  display?: string;
+  size?: number;
+  title?: string;
 }
 
-const TwilioIcon = React.memo(({title = 'Twilio Icon', decorative = true, className, color, size}: TwilioIconProps) => {
-  const uid = useUID();
-  return (
-    <div style={{color, width: size, height: size}} className={className}>
-      <svg role="img" aria-hidden={decorative} aria-labelledby={uid} viewBox="0 0 30 30" width="100%" height="100%">
-        <title id={uid}>{title}</title>
-        <path
-          fill="currentColor"
-          d="M15 0C6.7 0 0 6.7 0 15s6.7 15 15 15 15-6.7 15-15S23.3 0 15 0zm0 26C8.9 26 4 21.1 4 15S8.9 4 15 4s11 4.9 11 11-4.9 11-11 11zm6.8-14.7c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1 1.4-3.1 3.1-3.1 3.1 1.4 3.1 3.1zm0 7.4c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1c0-1.7 1.4-3.1 3.1-3.1s3.1 1.4 3.1 3.1zm-7.4 0c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1c0-1.7 1.4-3.1 3.1-3.1s3.1 1.4 3.1 3.1zm0-7.4c0 1.7-1.4 3.1-3.1 3.1S8.2 13 8.2 11.3s1.4-3.1 3.1-3.1 3.1 1.4 3.1 3.1z"
-        />
-      </svg>
-    </div>
-  );
-});
+const TwilioIcon = React.memo(
+  ({title = 'Twilio Icon', decorative = true, className, color, size, display = 'block'}: TwilioIconProps) => {
+    const uid = useUID();
+    return (
+      <span style={{color, display, width: size, height: size}} className={className}>
+        <svg role="img" aria-hidden={decorative} aria-labelledby={uid} viewBox="0 0 30 30" width="100%" height="100%">
+          <title id={uid}>{title}</title>
+          <path
+            fill="currentColor"
+            d="M15 0C6.7 0 0 6.7 0 15s6.7 15 15 15 15-6.7 15-15S23.3 0 15 0zm0 26C8.9 26 4 21.1 4 15S8.9 4 15 4s11 4.9 11 11-4.9 11-11 11zm6.8-14.7c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1 1.4-3.1 3.1-3.1 3.1 1.4 3.1 3.1zm0 7.4c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1c0-1.7 1.4-3.1 3.1-3.1s3.1 1.4 3.1 3.1zm-7.4 0c0 1.7-1.4 3.1-3.1 3.1s-3.1-1.4-3.1-3.1c0-1.7 1.4-3.1 3.1-3.1s3.1 1.4 3.1 3.1zm0-7.4c0 1.7-1.4 3.1-3.1 3.1S8.2 13 8.2 11.3s1.4-3.1 3.1-3.1 3.1 1.4 3.1 3.1z"
+          />
+        </svg>
+      </span>
+    );
+  }
+);
 
 export {TwilioIcon};

--- a/packages/paste-website/src/components/sidebar/Header.tsx
+++ b/packages/paste-website/src/components/sidebar/Header.tsx
@@ -43,7 +43,7 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = props => {
   return (
     <StyledHeader>
-      <TwilioIcon color={TWILIO_RED} size={30} />
+      <TwilioIcon color={TWILIO_RED} display="block" size={30} />
       <Text as="h2" fontSize="fontSize50" marginTop="space40" marginBottom="space20">
         <StyledLink to="/">{props.siteTitle}</StyledLink>
       </Text>

--- a/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
@@ -60,7 +60,7 @@ const SiteFooter: React.FC<{}> = () => {
         </Flex>
       </Box>
       <StyledCopyright marginTop="space120">
-        <StyledFooterLogo color={TWILIO_BLUE} size={30} />
+        <StyledFooterLogo color={TWILIO_BLUE} display="block" size={30} />
         Copyright &copy; 2019 Twilio, Inc.
       </StyledCopyright>
     </StyledFooter>

--- a/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
@@ -4,6 +4,7 @@ import {themeGet} from 'styled-system';
 
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
+import {Text} from '@twilio-paste/text';
 import {Heading} from '../Heading';
 import {TWILIO_BLUE} from '../../constants';
 import {TwilioIcon} from '../icons/TwilioIcon';
@@ -18,7 +19,7 @@ const Flex = styled.div`
   display: flex;
 `;
 
-const StyledCopyright = styled(Box)`
+const StyledCopyright = styled(Text)`
   text-align: center;
 `;
 

--- a/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteFooter.tsx
@@ -18,8 +18,7 @@ const Flex = styled.div`
   display: flex;
 `;
 
-const StyledCopyright = styled.p`
-  margin-top: ${themeGet('space.space120')};
+const StyledCopyright = styled(Box)`
   text-align: center;
 `;
 
@@ -59,7 +58,7 @@ const SiteFooter: React.FC<{}> = () => {
           </Box>
         </Flex>
       </Box>
-      <StyledCopyright>
+      <StyledCopyright marginTop="space120">
         <StyledFooterLogo color={TWILIO_BLUE} size={30} />
         Copyright &copy; 2019 Twilio, Inc.
       </StyledCopyright>


### PR DESCRIPTION
Error was occurring because a div is used in `TwilioIcon`.

Changed the `p` tag in the footer to use `Text` and changed `TwilioIcon` to use a `span` instead of a `div`. I also added a `display` prop to `TwilioIcon`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
