### PR TITLE
fix(website): component header and overview with utilities

### DIFF
--- a/packages/paste-website/src/components/component-overview-table/index.tsx
+++ b/packages/paste-website/src/components/component-overview-table/index.tsx
@@ -13,13 +13,14 @@ interface ComponentNode {
 }
 interface ComponentOverviewTableProps {
   children?: React.ReactElement;
+  categoryRoute?: typeof SidebarCategoryRoutes[keyof typeof SidebarCategoryRoutes];
   componentsList?: [ComponentNode];
 }
 
 const sortNodeByName = (a: ComponentNode, b: ComponentNode): number => (a.node.name > b.node.name ? 1 : -1);
 
-const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componentsList}) => {
-  if (componentsList == null) {
+const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({categoryRoute, componentsList}) => {
+  if (componentsList == null || categoryRoute == null) {
     return null;
   }
 
@@ -45,9 +46,7 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componen
           return (
             <Tr key={node.name}>
               <Td>
-                <Link to={getPackagePath(SidebarCategoryRoutes.COMPONENTS, node.name)}>
-                  {getNameFromPackageName(node.name)}
-                </Link>
+                <Link to={getPackagePath(categoryRoute, node.name)}>{getNameFromPackageName(node.name)}</Link>
               </Td>
               <Td>{node.status}</Td>
               <Td>{node.version}</Td>
@@ -58,9 +57,7 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({componen
           return (
             <Tr key={node.name}>
               <Td>
-                <Link to={getPackagePath(SidebarCategoryRoutes.COMPONENTS, node.name)}>
-                  {getNameFromPackageName(node.name)}
-                </Link>
+                <Link to={getPackagePath(categoryRoute, node.name)}>{getNameFromPackageName(node.name)}</Link>
               </Td>
               <Td>{node.status}</Td>
               <Td />

--- a/packages/paste-website/src/components/shortcodes/component-header/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/component-header/index.tsx
@@ -7,11 +7,16 @@ import {SidebarCategoryRoutes} from '../../../constants';
 import {P} from '../../Typography';
 import {Heading} from '../../Heading';
 
-const ComponentHeaderBasic: React.FC<{name: string}> = ({name}) => (
+const ComponentHeaderBasic: React.FC<{
+  name: string;
+  categoryRoute: typeof SidebarCategoryRoutes[keyof typeof SidebarCategoryRoutes];
+}> = ({name, categoryRoute}) => (
   <>
     <Breadcrumb>
       <BreadcrumbItem to="/">Home</BreadcrumbItem>
-      <BreadcrumbItem to={SidebarCategoryRoutes.COMPONENTS}>Components</BreadcrumbItem>
+      <BreadcrumbItem to={categoryRoute}>
+        {categoryRoute === SidebarCategoryRoutes.COMPONENTS ? 'Components' : 'Utilities'}
+      </BreadcrumbItem>
     </Breadcrumb>
     <Heading as="h1" headingStyle="headingStyle10">
       {name}
@@ -26,6 +31,7 @@ const ExternalLink = styled.a`
 interface ComponentHeaderProps {
   children?: React.ReactElement;
   name: string;
+  categoryRoute: typeof SidebarCategoryRoutes[keyof typeof SidebarCategoryRoutes];
   githubUrl: string;
   storybookUrl: string;
   data?: [
@@ -55,15 +61,15 @@ const PackageLabel = styled.dt(getPackageItemStyles, {
   width: '80px',
 });
 
-const ComponentHeader: React.FC<ComponentHeaderProps> = ({name, githubUrl, storybookUrl, data}) => {
+const ComponentHeader: React.FC<ComponentHeaderProps> = ({name, categoryRoute, githubUrl, storybookUrl, data}) => {
   if (data == null || data[0] == null || data[0].node == null) {
-    return <ComponentHeaderBasic name={name} />;
+    return <ComponentHeaderBasic categoryRoute={categoryRoute} name={name} />;
   }
   const {description, status, name: packageName, version} = data[0].node;
 
   return (
     <>
-      <ComponentHeaderBasic name={name} />
+      <ComponentHeaderBasic categoryRoute={categoryRoute} name={name} />
       <P variant="lead">{description}</P>
       <Box as="dl" mb="space100">
         <Box mb="space20">

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -7,6 +7,7 @@ description: The anchor can be used to hyperlink to another URL. It accepts both
 import {graphql} from 'gatsby';
 import {Anchor} from '@twilio-paste/anchor';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {SidebarCategoryRoutes} from '../../../constants';
 
 export const pageQuery = graphql`
   {
@@ -25,6 +26,7 @@ export const pageQuery = graphql`
 
 <ComponentHeader
   name={props.pageContext.frontmatter.title}
+  categoryRoute={SidebarCategoryRoutes.COMPONENTS}
   githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/components/anchor"
   storybookUrl="https://twilio-labs.github.io/paste/?path=/story/components-anchor--default"
   data={props.data.allPasteComponent.edges}

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -7,6 +7,7 @@ description: Buttons are hot
 import {graphql} from 'gatsby';
 import {Button} from '@twilio-paste/button';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {SidebarCategoryRoutes} from '../../../constants';
 
 export const pageQuery = graphql`
   {
@@ -25,6 +26,7 @@ export const pageQuery = graphql`
 
 <ComponentHeader
   name="Button"
+  categoryRoute={SidebarCategoryRoutes.COMPONENTS}
   githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/components/button"
   storybookUrl="https://twilio-labs.github.io/paste/?path=/story/components-button--text-only"
   data={props.data.allPasteComponent.edges}

--- a/packages/paste-website/src/pages/components/index.mdx
+++ b/packages/paste-website/src/pages/components/index.mdx
@@ -9,6 +9,7 @@ import {Heading} from '../../components/Heading.tsx';
 import {P} from '../../components/Typography.tsx';
 import {ComponentOverviewTable} from '../../components/component-overview-table';
 import {Breadcrumb, BreadcrumbItem} from '../../components/breadcrumb';
+import {SidebarCategoryRoutes} from '../../constants';
 
 <Breadcrumb>
   <BreadcrumbItem to="/">Home</BreadcrumbItem>
@@ -27,7 +28,10 @@ requests are accepted for the design system. We’ll have guidelines soon for wh
 supported.
 
 
-<ComponentOverviewTable componentsList={props.data.allPasteComponent.edges} />
+<ComponentOverviewTable 
+  categoryRoute={SidebarCategoryRoutes.COMPONENTS} 
+  componentsList={props.data.allPasteComponent.edges} 
+/>
 
 export const pageQuery = graphql`
   {

--- a/packages/paste-website/src/pages/utilities/box/index.mdx
+++ b/packages/paste-website/src/pages/utilities/box/index.mdx
@@ -3,6 +3,31 @@ title: Box - Utilities
 description: One of our primitive components.
 ---
 
-Im a box
+import {graphql} from 'gatsby';
+import {SidebarCategoryRoutes} from '../../../constants';
 
-|=|
+export const pageQuery = graphql`
+  {
+    allPasteUtility(filter: {name: {eq: "@twilio-paste/box"}}) {
+      edges {
+        node {
+          name
+          description
+          status
+          version
+        }
+      }
+    }
+  }
+`;
+
+<ComponentHeader
+  name="Box"
+  categoryRoute={SidebarCategoryRoutes.UTILITIES}
+  githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/utilities/box"
+  storybookUrl="http://localhost:57128/?path=/story/utilities-box--default"
+  data={props.data.allPasteUtility.edges}
+/>
+
+
+## WIP

--- a/packages/paste-website/src/pages/utilities/index.mdx
+++ b/packages/paste-website/src/pages/utilities/index.mdx
@@ -5,10 +5,14 @@ description: Our utilities are rad
 
 import {graphql} from 'gatsby';
 import {ComponentOverviewTable} from '../../components/component-overview-table';
+import {SidebarCategoryRoutes} from '../../constants';
 
 # Utilities Overview
 
-<ComponentOverviewTable componentsList={props.data.allPasteUtility.edges} />
+<ComponentOverviewTable 
+  categoryRoute={SidebarCategoryRoutes.UTILITIES} 
+  componentsList={props.data.allPasteUtility.edges} 
+/>
 
 export const pageQuery = graphql`
   {


### PR DESCRIPTION
Fixes ComponentOverviewTable and ComponentHeader to work with `utility` components. I add ComponentHeader into the Box documentation page to test it out.

Fixes https://github.com/twilio-labs/paste/issues/61

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
