### PR TITLE
fix(website): tidy up the button and anchor docs

### DIFF
--- a/packages/paste-website/src/components/Heading.tsx
+++ b/packages/paste-website/src/components/Heading.tsx
@@ -34,7 +34,7 @@ function getHeadingStyles(headingStyle?: HeadingStyle): {} {
     case 'headingStyle40':
       return {
         my: 'space60',
-        fontSize: 'fontSize60',
+        fontSize: 'fontSize30',
         fontWeight: 'fontWeightSemibold',
       };
     case 'headingStyle30':

--- a/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
@@ -15,7 +15,7 @@ interface CodeblockProps {
 }
 
 const StyledPreviewWrapper = styled.div(props => ({
-  marginTop: themeGet('space.space110')(props),
+  marginBottom: themeGet('space.space110')(props),
 }));
 
 // FIXME use tokens for theme and LiveEditor

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -8,6 +8,7 @@ import {graphql} from 'gatsby';
 import {Anchor} from '@twilio-paste/anchor';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {SidebarCategoryRoutes} from '../../../constants';
+import {P} from '../../../components/Typography.tsx';
 
 export const pageQuery = graphql`
   {
@@ -32,24 +33,61 @@ export const pageQuery = graphql`
   data={props.data.allPasteComponent.edges}
 />
 
-<content>
-
-<p>{props.pageContext.frontmatter.description}</p>
-
-<p>Example use cases may include:</p>
-
-<ul>
-  <li>Linking to another page within an app or website</li>
-  <li>Linking to an external domain outside of the current app or website</li>
-</ul>
-
-</content>
-
 ***
 
 <content>
 
-### When to Use an Anchor
+## Guidelines
+
+### About anchors
+
+<P>{props.pageContext.frontmatter.description}</P>
+
+Example use cases may include:
+
+- Linking to another page within an app or website
+- Linking to an external domain outside of the current app or website
+
+#### Anchor vs. Button
+
+Anchors should be used in place of a button if you only need to create a hyperlink to some other page or content. Anchors should not be used for submitting a form, closing a modal, moving to the next step in a flow, or any other click action that a button should handle. Buttons perform an action, like submitting a form; Anchors take you somewhere, like to the documentation page.
+
+If you need a click handler, you can use our [Button component](/components/button).
+
+#### Accessibility
+
+The anchor is built with standard accessible practices in mind. Those include an href attribute, link context, and opening and closing tags.
+
+The title attribute was not included because it’s not exposed to all browsers in an accessible way, meaning most screen readers and touch-only devices will likely never see that information.
+
+## Examples
+
+### Default Anchor
+
+The default anchor is a basic text hyperlink. There are no other anchor variants at this time.
+
+<LivePreview scope={{Anchor}} language="jsx">
+  {`<Anchor href="/components">
+  Go to Paste
+</Anchor>`}
+</LivePreview>
+
+### External Anchor
+
+If an external URL is used for the href, the target and rel will automatically be updated to:
+
+`target=”_blank”`
+`rel=”noreferrer noopener”`
+
+This is done for security purposes. Even though the target and rel are set by default for external anchors, they can be overridden using the target and rel props.
+
+<LivePreview scope={{Anchor}} language="jsx">
+  {`<Anchor href="https://paste.twilio.design">
+  Go to Paste
+</Anchor>`}
+</LivePreview>
+
+## When to Use an Anchor
 You can use an anchor to navigate the user to another webpage.
 
 <DoDont>
@@ -70,35 +108,11 @@ You can use an anchor to navigate the user to another webpage.
   </Dont>
 </DoDont>
 
-### Anchor vs. Button
-
-Anchors should be used in place of a button if you only need to create a hyperlink to some other page or content. Anchors should not be used for submitting a form, closing a modal, moving to the next step in a flow, or any other click action that a button should handle. Buttons perform an action, like submitting a form; Anchors take you somewhere, like to the documentation page.
-
-If you need a click handler, you can use our [Button component](/components/button).
-
-### Accessibility
-
-The anchor is built with standard accessible practices in mind. Those include an href attribute, link context, and opening and closing tags.
-
-The title attribute was not included because it’s not exposed to all browsers in an accessible way, meaning most screen readers and touch-only devices will likely never see that information.
+</content>
 
 ***
 
-## Examples
-
-### Default Anchor
-The default anchor is a basic text hyperlink. There are no other anchor variants at this time.
-
-### External Anchor
-
-If an external URL is used for the href, the target and rel will automatically be updated to:
-
-`target=”_blank”`
-`rel=”noreferrer noopener”`
-
-This is done for security purposes. Even though the target and rel are set by default for external anchors, they can be overridden using the target and rel props.
-
-***
+<content>
 
 ## Installation
 
@@ -115,13 +129,6 @@ import {Anchor} from '@twilio-paste/anchor';
   Go to Paste
 </Anchor>
 ```
-
-<LivePreview scope={{Anchor}} language="jsx">
-  {`<Anchor href="https://paste.twilio.design">
-  Go to Paste
-</Anchor>`}
-</LivePreview>
-
 
 ### Storybook
 

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -8,6 +8,7 @@ import {graphql} from 'gatsby';
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 import {SidebarCategoryRoutes} from '../../../constants';
 
 export const pageQuery = graphql`
@@ -33,6 +34,10 @@ export const pageQuery = graphql`
   data={props.data.allPasteComponent.edges}
 />
 
+***
+
+<content>
+
 ## Guidelines
 
 ### About buttons
@@ -46,7 +51,7 @@ a button include:
   A button can contain an icon and/or text. See Composing a button below
   for more detailed guidelines.
 
-### Button vs. Anchor (Link)
+#### Button vs. Anchor (Link)
 
 **TL;DR** If pressing the trigger results in a URL change, or that resultant
 page makes sense as a whole new browser tab use an **Anchor** element.
@@ -72,7 +77,7 @@ You should:
 
 If you need to link to content, you can use our [Anchor component](/components/anchor).
 
-### Accessibility
+#### Accessibility
 
 For accessibility, the distinction becomes even more important,
 especially for those who are using Assistive Technology (A.T.) such as
@@ -91,41 +96,58 @@ screen readers and dictation software. Here are some quick tips:
   struggle with these as they may say “click button” but the software can’t
   tell what the anchor looks like visually
 
+
 ### Examples
 
 <LivePreview scope={{Button, Box}} language="jsx">
   {`<div>
-  <Box mb="space30">
+  <Box display="inline-block" mr="space30">
     <Button variant="primary">
       Submit
     </Button>
   </Box>
 
-<Box mb="space30">
-  <Button variant="secondary">Submit</Button>
-</Box>
+  <Box display="inline-block" mr="space30">
+    <Button variant="secondary">Submit</Button>
+  </Box>
 
-<Box mb="space30">
-  <Button variant="destructive" size="small">
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive">
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="primary" size="small">
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="secondary" size="small">Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive" size="small">
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="link">Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive_link">Submit</Button>
+  </Box>
+
+  <Button variant="reset" size="reset">
     Submit
   </Button>
-</Box>
-
-<Box mb="space30">
-  <Button variant="link">Submit</Button>
-</Box>
-
-<Box mb="space30">
-  <Button variant="destructive_link">Submit</Button>
-</Box>
-
-<Button variant="reset" size="reset">
-  Submit
-</Button>
 </div>`}
 </LivePreview>
 
-##### Primary button
+#### Primary button
 
 Use a primary button to indicate the most prominent action a customer would
 make on a screen. It should be a safe and if possible, reversible action
@@ -134,7 +156,13 @@ without much cost.
 Try to use only one primary button on a screen. Using multiple might be
 distracting.
 
-##### Secondary button
+<LivePreview scope={{Button}} language="jsx">
+  {`<Button variant="primary">
+  Submit
+</Button>`}
+</LivePreview>
+
+#### Secondary button
 
 The secondary button is the most frequently used button.
 
@@ -142,32 +170,84 @@ Use a secondary button to indicate an action that should be easy for a customer
 to make but isn’t the most prominent on a screen. It should be a safe and if
 possible, reversible action without much cost.
 
-##### Destructive button
+<LivePreview scope={{Button}} language="jsx">
+  {`<Button variant="secondary">
+  Submit
+</Button>`}
+</LivePreview>
+
+#### Destructive button
 
 A destructive button indicates a destructive action, such as “Delete” or
 “Remove”, that might be difficult to reverse. If possible, give users
 the ability to undo the action, or at least, confirm the action.
 
-##### Icon-only button
+<LivePreview scope={{Button}} language="jsx">
+  {`<Button variant="destructive">
+  Submit
+</Button>`}
+</LivePreview>
+
+#### Icon-only button
 
 Use icon-only buttons sparingly.
 
 They should be used only in compact UI situations. Use an icon that can
 only convey a single action.
 
-##### Link-style button
+<LivePreview scope={{Button}} language="jsx">
+  {`<span>Example coming soon</span>`}
+</LivePreview>
+
+#### Link-style button
 
 Use link-style buttons when other types of buttons may be too distracting.
 
-##### Small button
+<Callout>
+  <CalloutTitle as="h4">Hot accessibility tip</CalloutTitle>
+  <CalloutText>To reiterate, be mindful when choosing this variant as dictation software users may experience usability issues. Read the guidelines first. </CalloutText>
+</Callout>
+
+<LivePreview scope={{Button, Box}} language="jsx">
+  {`<div>
+  <Box display="inline-block" mr="space30">
+    <Button variant="link">Submit</Button>
+  </Box>
+  <Button variant="destructive_link">
+    Submit
+  </Button>
+</div>`}
+</LivePreview>
+
+#### Small button
 
 Use small buttons sparingly, only when needed for vertical density.
 Guidelines for using variants in small buttons are the same as in
 their default size.
 
+<LivePreview scope={{Button, Box}} language="jsx">
+  {`<div>
+  <Box display="inline-block" mr="space30">
+    <Button variant="primary" size="small">
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="secondary" size="small">Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive" size="small">
+      Submit
+    </Button>
+  </Box>
+</div>`}
+</LivePreview>
+
 ### States
 
-##### Loading
+#### Loading
 
 Use the loading state if the action doesn’t happen instantly.
 The button is also disabled in this state.
@@ -176,7 +256,11 @@ However, the loading state may make an action appear to take longer
 than it does and doesn’t communicate what’s preventing the action
 from completing. Use it when you can’t move the user to the next state.
 
-##### Disabled
+<LivePreview scope={{Button}} language="jsx">
+  {`<span>Example coming soon</span>`}
+</LivePreview>
+
+#### Disabled
 
 Use the disabled state sparingly.
 
@@ -185,6 +269,54 @@ It should be immediately obvious to the customer why a button
 might be disabled (_e.g._, if it follows a single empty text
 field). Otherwise, show the button in its default state, then
 provide helpful error text after it's pressed.
+
+<LivePreview scope={{Button, Box}} language="jsx">
+  {`<div>
+  <Box display="inline-block" mr="space30">
+    <Button variant="primary" disabled>
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="secondary" disabled>Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive"  disabled>
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="primary" size="small" disabled>
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="secondary" size="small" disabled>Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive" size="small"  disabled>
+      Submit
+    </Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="link" disabled>Submit</Button>
+  </Box>
+
+  <Box display="inline-block" mr="space30">
+    <Button variant="destructive_link" disabled>Submit</Button>
+  </Box>
+
+  <Button variant="reset" size="reset" disabled>
+    Submit
+  </Button>
+</div>`}
+</LivePreview>
 
 ### Composing a button
 
@@ -228,6 +360,12 @@ right in an English-language flow).
   <Do>Write button text that is clear, starts with a verb, and helps users confidently trigger an action.</Do>
   <Dont>Don’t use product or brand icons in buttons since they don’t communicate action.</Dont>
 </DoDont>
+
+</content>
+
+***
+
+<content>
 
 ## API
 
@@ -274,3 +412,5 @@ import {Button} from '@twilio-paste/button';
 | aria-haspopup? | {'true', 'dialog', 'menu'}               | A11y: For modals and menus                                                          | null      |
 | aria-controls? | string                                   | A11y: For modals and menus                                                          | null      |
 | data-test?     | string                                   | To detect the element to run tests against.                                         | null      |
+
+</content>


### PR DESCRIPTION
Fixes https://github.com/twilio-labs/paste/issues/83

- [x] Add more examples to the button page
  - [x] Heading style tweak
  - [x] Heading heirarchy tweak
  - [x] Live demo spacing tweak
- [x] Align anchor page to the button page structure

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
