### PR TITLE
fix(anchor): set children as non-nullable, remove child null error

### DIFF
--- a/packages/paste-core/components/anchor/src/index.tsx
+++ b/packages/paste-core/components/anchor/src/index.tsx
@@ -8,7 +8,7 @@ const EXTERNAL_REL_DEFAULT = 'noreferrer noopener';
 
 const isExternalUrl = (url: string): boolean => EXTERNAL_LINK_REGEX.test(url);
 
-const handlePropValidation = ({href, tabIndex, children}: AnchorProps): void => {
+const handlePropValidation = ({href, tabIndex}: AnchorProps): void => {
   const hasHref = href != null && href !== '';
   const hasTabIndex = tabIndex != null;
 
@@ -16,10 +16,6 @@ const handlePropValidation = ({href, tabIndex, children}: AnchorProps): void => 
     throw new Error(
       `[Paste: Anchor] Missing href prop for anchor. Maybe you're looking for the [Paste: Button] component.`
     );
-  }
-
-  if (children == null) {
-    throw new Error(`[Paste: Anchor] Must have non-null children.`);
   }
 
   if (hasTabIndex && !(tabIndex === 0 || tabIndex === -1)) {

--- a/packages/paste-core/components/anchor/src/index.tsx
+++ b/packages/paste-core/components/anchor/src/index.tsx
@@ -8,7 +8,7 @@ const EXTERNAL_REL_DEFAULT = 'noreferrer noopener';
 
 const isExternalUrl = (url: string): boolean => EXTERNAL_LINK_REGEX.test(url);
 
-const handlePropValidation = ({href, tabIndex}: AnchorProps): void => {
+const handlePropValidation = ({href, tabIndex, children}: AnchorProps): void => {
   const hasHref = href != null && href !== '';
   const hasTabIndex = tabIndex != null;
 
@@ -16,6 +16,10 @@ const handlePropValidation = ({href, tabIndex}: AnchorProps): void => {
     throw new Error(
       `[Paste: Anchor] Missing href prop for anchor. Maybe you're looking for the [Paste: Button] component.`
     );
+  }
+
+  if (children == null) {
+    throw new Error(`[Paste: Anchor] Must have non-null children.`);
   }
 
   if (hasTabIndex && !(tabIndex === 0 || tabIndex === -1)) {

--- a/packages/paste-core/components/anchor/src/types.ts
+++ b/packages/paste-core/components/anchor/src/types.ts
@@ -9,7 +9,7 @@ export interface AnchorProps {
   target?: AnchorTargets;
   rel?: string;
 
-  children: React.ReactNode;
+  children: NonNullable<React.ReactNode>;
 
   onClick?(event: React.MouseEvent<HTMLElement>): void;
   onFocus?(event: React.FocusEvent<HTMLElement>): void;


### PR DESCRIPTION
- [x] Change anchor children to non-nullable type
- [x] Remove child null error

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
