### PR TITLE
chore(icons): remove unnecessary peerDependency

### DIFF
--- a/packages/paste-icons/package.json
+++ b/packages/paste-icons/package.json
@@ -21,7 +21,6 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.14",
-    "@twilio-paste/theme-tokens": "^0.4.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-uid": "^2.2.0",
@@ -34,7 +33,6 @@
     "@svgr/plugin-jsx": "^4.1.0",
     "@svgr/plugin-svgo": "^4.0.3",
     "@twilio-labs/svg-to-react": "^1.0.1",
-    "@twilio-paste/theme-tokens": "^0.5.0",
     "@types/loadable__component": "^5.6.0",
     "@types/promise-timeout": "^1.3.0",
     "commander": "^2.20.0",

--- a/packages/paste-icons/tsconfig.build.json
+++ b/packages/paste-icons/tsconfig.build.json
@@ -4,12 +4,6 @@
     "outDir": ".",
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*"
-  ],
-  "references": [
-    {
-      "path": "../paste-theme-tokens"
-    }
-  ]
+  "include": ["src/**/*"],
+  "references": []
 }


### PR DESCRIPTION
Icons doesn't need the `paste-theme-tokens` peerDependency.  This also fixes the issue where `paste-theme-tokens` was being built directly into the src folder hopefully 😕 

To test, please run `yarn clearn` and a couple `yarn build`s locally and see if you still get the dump of `js` files in the wrong place.