### PR TITLE
chore: add suggested vscode extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,12 @@
   "search.exclude": {
     "**/dist": true,
     "**/docs": true
-  }
+  },
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "silvenon.mdx",
+    "jpoissonnier.vscode-styled-components",
+    "eamodio.gitlens"
+  ]
 }


### PR DESCRIPTION
VSCode has a neat little feature where you can define suggested extensions to make it easier to work on a project.  I added some I find helpful when working in this repo for fun.  [Read more about the feature](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions)