### PR TITLE
chore(icons): bump svg-to-react version

### DIFF
--- a/packages/paste-icons/package.json
+++ b/packages/paste-icons/package.json
@@ -32,7 +32,7 @@
     "@svgr/cli": "^4.1.0",
     "@svgr/plugin-jsx": "^4.1.0",
     "@svgr/plugin-svgo": "^4.0.3",
-    "@twilio-labs/svg-to-react": "^1.0.1",
+    "@twilio-labs/svg-to-react": "^2.0.0",
     "@types/loadable__component": "^5.6.0",
     "@types/promise-timeout": "^1.3.0",
     "commander": "^2.20.0",


### PR DESCRIPTION
No changes in this repo, but wanting to keep our versions in sync with the `svg-to-react` repo.

The `svg-to-react` had a major version change because I modified the default template in that lib, which doesn't affect this repo since we provide a custom template.