### PR TITLE
chore(monorepo): only do pre-push validation on master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-unicorn": "^9.1.1",
+    "git-branch-is": "^3.0.0",
     "husky": "^3.0.0",
     "jest": "^24.8.0",
     "jest-emotion": "^10.0.14",
@@ -114,8 +115,8 @@
   "husky": {
     "hooks": {
       "pre-commit": "precise-commits",
-      "pre-push": "yarn pre-push",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-push": "if git-branch-is master; then yarn pre-push; fi"
     }
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6573,6 +6573,11 @@ commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0, comma
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.1.tgz#4595aec3530525e671fb6f85fb173df8ff8bf57a"
+  integrity sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -10516,6 +10521,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+git-branch-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/git-branch-is/-/git-branch-is-3.0.0.tgz#bbc5b8495fcce77da60e0eb589e41af70fcd06f7"
+  integrity sha512-HvOU7/TBj25NeXVzmzEMVmsLFYQD8wP/orGkGaHl1unWDx7ZZAiaulPAydUCGd+DPO3IpUjyC4zBAn2oCgaZ7Q==
+  dependencies:
+    commander "^3.0.0"
 
 git-raw-commits@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The pre-push check on branches seems redundant because CircleCI runs the same tests, so forcing it to happen on every push was tedious.  I've modified our pre-push husky hook to only run on the `master` branch for safety there, but otherwise you can still run it manually if you want to.