### PR TITLE
chore: fix the token formatter tests

### DIFF
--- a/.jest/setupFilesAfterEnv.js
+++ b/.jest/setupFilesAfterEnv.js
@@ -1,6 +1,7 @@
-const {serializer} = require('jest-emotion');
+const emotion = require('emotion');
+const {createSerializer} = require('jest-emotion');
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
-expect.addSnapshotSerializer(serializer);
+expect.addSnapshotSerializer(createSerializer(emotion));
 Enzyme.configure({adapter: new Adapter()});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.15",
     "@emotion/styled": "^10.0.15",
+    "emotion": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-uid": "^2.2.0",

--- a/packages/paste-design-tokens/formatters/__tests__/d.ts.spec.ts
+++ b/packages/paste-design-tokens/formatters/__tests__/d.ts.spec.ts
@@ -18,9 +18,11 @@ describe('dTSFormatter', () => {
         },
       })
       .then((dTS: string) => {
-        expect(dTS).toMatchSnapshot();
-        return true;
+        return expect(dTS).toMatchSnapshot();
       })
-      .catch((error: string) => console.log(`Something went wrong: ${error}`));
+      .catch((error: string) => {
+        console.log(`Something  went wrong: ${error}`);
+        throw new Error('[dTSFormatter test]: should return typescript definitions formatted tokens threw');
+      });
   });
 });

--- a/packages/paste-design-tokens/formatters/__tests__/es6.spec.ts
+++ b/packages/paste-design-tokens/formatters/__tests__/es6.spec.ts
@@ -18,9 +18,11 @@ describe('es6Formatter', () => {
         },
       })
       .then((es6JS: string) => {
-        expect(es6JS).toMatchSnapshot();
-        return true;
+        return expect(es6JS).toMatchSnapshot();
       })
-      .catch((error: string) => console.log(`Something went wrong: ${error}`));
+      .catch((error: string) => {
+        console.log(`Something  went wrong: ${error}`);
+        throw new Error('[es6Formatter test]: should return es6 formatted tokens');
+      });
   });
 });

--- a/packages/paste-design-tokens/formatters/__tests__/sketchpalette.spec.ts
+++ b/packages/paste-design-tokens/formatters/__tests__/sketchpalette.spec.ts
@@ -18,9 +18,11 @@ describe('sketchPaletteTokenFormatter', () => {
         },
       })
       .then((sketchPalette: string) => {
-        expect(sketchPalette).toMatchSnapshot();
-        return true;
+        return expect(sketchPalette).toMatchSnapshot();
       })
-      .catch((error: string) => console.log(`Something went wrong: ${error}`));
+      .catch((error: string) => {
+        console.log(`Something  went wrong: ${error}`);
+        throw new Error('[sketchpalette test]: should return sketch palette color formatted tokens threw');
+      });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,7 +1122,7 @@
     "@emotion/babel-plugin-jsx-pragmatic" "^0.1.3"
     babel-plugin-emotion "^10.0.17"
 
-"@emotion/cache@^10.0.17", "@emotion/cache@^10.0.9":
+"@emotion/cache@^10.0.14", "@emotion/cache@^10.0.17", "@emotion/cache@^10.0.9":
   version "10.0.19"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.19.tgz#d258d94d9c707dcadaf1558def968b86bb87ad71"
   integrity sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==
@@ -7066,6 +7066,16 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-emotion@^10.0.14:
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.14.tgz#4c140aaef6a9588ed47c926f9c4679e4719be43e"
+  integrity sha512-5G4naKMxokOur+94eDz7iPKBfwzy4wa/+0isnPhxXyosIQHBq7yvBy4jjdZw/nnRm7G3PM7P9Ug8mUmtoqcaHg==
+  dependencies:
+    "@emotion/cache" "^10.0.14"
+    "@emotion/serialize" "^0.11.8"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -8291,6 +8301,14 @@ emotion-theming@^10.0.10, emotion-theming@^10.0.14:
     "@babel/runtime" "^7.5.5"
     "@emotion/weak-memoize" "0.2.4"
     hoist-non-react-statics "^3.3.0"
+
+emotion@^10.0.17:
+  version "10.0.17"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.17.tgz#d71e99d2b01204dda109c13d069af4b191e70445"
+  integrity sha512-nShD/a7PKZ77hr517KfzKkHo1v26uPJBImRiYrl8IwIA4KRmI3vxVEA5pzw1TQTXD1iZl6YQtWhjOiiE+QPmTQ==
+  dependencies:
+    babel-plugin-emotion "^10.0.17"
+    create-emotion "^10.0.14"
 
 encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add back in emotion in the serializer to fix the tests. 

Also, throw so the tests actually fail when it errors next time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
