### PR TITLE
feat: add info from brown bag questions

### DIFF
--- a/packages/paste-website/src/pages/getting-started/design.mdx
+++ b/packages/paste-website/src/pages/getting-started/design.mdx
@@ -3,6 +3,7 @@ title: Design Guidelines for Paste
 description: This document will highlight our approach for unified design libraries, tips for getting started, and similar resources for Product Designers using Paste.
 ---
 
+import {Anchor} from '@twilio-paste/anchor';
 import {Callout, CalloutTitle, CalloutText} from '../../components/callout';
 import {Grid} from '../../components/grid';
 import { Link } from "gatsby"

--- a/packages/paste-website/src/pages/getting-started/design.mdx
+++ b/packages/paste-website/src/pages/getting-started/design.mdx
@@ -48,7 +48,7 @@ However, this release is not:
 
 ### Basic Terminology
 
-If you’re unfamiliar with Abstract, version control, or git workflows, read through <a href="https://www.goabstract.com/how-it-works/">how it works</a>. Abstract assumes you have working knowledge of version control since they use version control terms. Brushing up on these would be a good first step.
+If you’re unfamiliar with Abstract, version control, or git workflows, read through <a href="https://www.goabstract.com/how-it-works/">how it works</a>. Since Abstract uses version control terms, brushing up on these would be a good first step.
 
 *Some terms you'll encounter:*
 
@@ -62,7 +62,9 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 - *Merge*: The way you combine your branch with the Master files
 
-- *Merge conflict*: This happens when there’s a conflicting version of an artboard with the Master and a branch. Abstract will walk you through which artboards are conflicting so you can choose what you want to appear in Master. The best way to avoid these conflicts would be to plan out and split up the work between your collaborators before making the changes. You can also split up your Sketch files into more granular pieces (*e.g.*, split a Sketch library and product feature work into separate files). Merge conflicts can prevent you from overriding work unintentionally, but can’t tell you which change is the “right” one.
+- *Merge conflict*: This happens when there’s a conflicting version of an artboard with the Master and a branch. Abstract will walk you through which artboards are conflicting so you can choose what you want to appear in Master. To avoid these conflicts, we recommend:
+  - Planning out and splitting up the work between your collaborators before making the changes. Merge conflicts can prevent you from overriding work unintentionally, but can’t tell you which change is the “right” one.
+  - Splitting up your Sketch files into more granular pieces (*e.g.*, split a Sketch library and product feature work into separate files).
 
 - *Paste*: _This_ design system
 
@@ -91,16 +93,26 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 <Callout>
   <CalloutTitle as="h4">Do a quick font check!</CalloutTitle>    
-  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open "Font tester.sketch" in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly. </CalloutText>
+  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open
+    <Anchor href="https://share.goabstract.com/c33c9dd8-5b0a-48a3-ab56-83a6fdffa869?sha=9a058708bfc5c9f741f3e62195e18e2cdc6ba329">
+      Font tester.sketch
+    </Anchor>
+     in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly.</CalloutText>
 </Callout>
 
 You’re all set to work with Abstract and the Paste Sketch Libraries!
 
 ### Your First Commit in Abstract
 
+A commit is the way you save your work so it’s publicly viewable to the rest of the team. Any changes you make before you commit are saved locally to your computer and only viewable by you.
+
+Committing is like saving a snapshot of your work. You can always revert your work back to previous commits when you need to, so get comfortable deleting explorations of work! If you commit before and after you delete a bunch of explorations, you’ll be able to find those explorations in the future. More importantly, your files will be easier to grok for anyone who’s looking for the latest version of the work.
+
+How often you might commit depends on the scope of your project. If the scope is to do an icon color change or a typo fix, you might commit for that change only and close out the branch and project. If the scope is much larger (like creating a new component or laying out a sign-up flow), then commits might bundle more changes together. In general, **Always Be Committing!**
+
 1. To start work in any project, you’ll create a branch. A branch is a copy of the Master file that lets you make any changes without affecting the rest of the team’s work.
 
-To create a branch, click *Master* in the left sidebar and then click *New Branch…* in the upper right.
+   To create a branch, click *Master* in the left sidebar and then click *New Branch…* in the upper right.
 
 <Callout variant="warning">
   <CalloutTitle as="h4">Early Access! Early Access! Early Access!</CalloutTitle>  
@@ -121,18 +133,11 @@ For example:
 
 3. To start working in Sketch, return to Files and double-click on a Sketch file.
 
-4. Once you’ve made changes, you’ll commit your work. It does not affect the Master branch. **Always Be Committing!**
+4. Once you’ve made changes, you’ll commit your work. It does not affect the Master branch.
 
-**Changes in Abstract are tracked per artboard.** If you don’t want to lose track of an Abstract comment thread on an artboard, make sure you don’t delete it (even if you rename another artboard with the same name), or don’t copy-and-paste it and start working off the duplicate.
+   **Changes in Abstract are tracked per artboard.** If you don’t want to lose track of an Abstract comment thread on an artboard, make sure you don’t delete it (even if you rename another artboard with the same name), or don’t copy-and-paste it and start working off the duplicate.
 
-<Callout>
-  <CalloutTitle as="h4">What's a Commit?</CalloutTitle>
-  <CalloutText>A commit is the way you save your work so it’s publicly viewable to the rest of the team. Any changes you make before you commit are saved locally to your computer and only viewable by you.</CalloutText> 
-  <CalloutText marginTop="space40">Committing is like saving a snapshot of your work, so you can revert your work back to previous commits when you need to. So get comfortable deleting explorations of work! If you commit before and after you delete a bunch of explorations, you’ll be able to find those explorations in the future. More importantly, your files will be easier to grok for anyone who’s looking for the latest version of the work.</CalloutText>
-  <CalloutText marginTop="space40">How often you might commit depends on the scope of your project. If the scope is to do an icon color change or a typo fix, you might commit for that change only and close out the branch and project. If the scope is much larger (like creating a new component or laying out a sign-up flow), then commits might bundle more changes together.</CalloutText>
-</Callout>
-
-To commit, click *Commit Changes* on the Abstract plugin in Sketch. When working on design system projects, please follow our commit message conventions below.
+   To commit, click *Commit Changes* on the Abstract plugin in Sketch. When working on design system projects, please follow our commit message conventions below.
 
 ### Commit Message Conventions
 

--- a/packages/paste-website/src/pages/getting-started/design.mdx
+++ b/packages/paste-website/src/pages/getting-started/design.mdx
@@ -48,7 +48,7 @@ However, this release is not:
 
 ### Basic Terminology
 
-If you’re unfamiliar with Abstract, version control, or git workflows, read through <a href="https://www.goabstract.com/how-it-works/">how it works</a>.
+If you’re unfamiliar with Abstract, version control, or git workflows, read through <a href="https://www.goabstract.com/how-it-works/">how it works</a>. Abstract assumes you have working knowledge of version control since they use version control terms. Brushing up on these would be a good first step.
 
 *Some terms you'll encounter:*
 
@@ -62,11 +62,11 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 - *Merge*: The way you combine your branch with the Master files
 
-- *Merge conflict*: This happens when there’s a conflicting version of an artboard with the Master and a branch. Abstract will walk you through which artboards are conflicting so you can choose what want to appear in Master.
+- *Merge conflict*: This happens when there’s a conflicting version of an artboard with the Master and a branch. Abstract will walk you through which artboards are conflicting so you can choose what you want to appear in Master. The best way to avoid these conflicts would be to plan out and split up the work between your collaborators before making the changes. You can also split up your Sketch files into more granular pieces (*e.g.*, split a Sketch library and product feature work into separate files). Merge conflicts can prevent you from overriding work unintentionally, but can’t tell you which change is the “right” one.
 
-- *Paste: _This_ design system
+- *Paste*: _This_ design system
 
-- *Console / Flex / SendGrid Components*: The Sketch library for the Twilio Console / Flex / SendGrid (some of this may not be available yet).
+- *Console / Flex / SendGrid components*: The Sketch libraries for the Twilio Console / Flex / SendGrid (some of this may not be available yet).
 
 ### Joining or Creating a New Project in Abstract
 
@@ -75,9 +75,9 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
   <CalloutText>This section will be updated in the future for specific guidance for SendGrid and Flex Product Designers.</CalloutText>
 </Callout>
 
-1. After installing Abstract, sync the Console Components project. You may also want to sync all the other projects to be able to easily review and study your peer designer' work. Once they are synced, they should appear with their icons colored in. **You can star projects to pin them to the top of your projects list**
+1. After installing Abstract, sync the Console Components project. You may also want to sync all the other projects to be able to easily review and study your peer designers’ work. **You can star projects to pin them to the top of your projects list.**
 
-2. To find the right project for the product you’ll be working on, search through existing ones. To create a project, click New Project in Abstract and give your project a name. If it already exists, feel free to skip to Test Your Fonts.
+2. To find the right project for the product you’ll be working on, search through existing ones. To create a project, click *New Project* in Abstract and give your project a name. If it already exists, feel free to skip to "Do a quick font check!"
 
 <Callout>
   <CalloutText>Guidance on how to name your projects will be provided in a future release.</CalloutText>
@@ -85,68 +85,62 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 3. After creating your project, click into it and create a Sketch file.
 
-4. **Now it's time to import a Sketch Library!** Console components is the Sketch library for Paste, the Twilio design system. To use console symbols in your project, you’ll have to link the Console component Sketch libraries. To do that in your project, click on Add File, then Link Library...
+4. **Now it's time to import a Sketch Library!** To use console symbols in your project, you’ll have to link the *Console components* Sketch libraries. To do that in your project, click on *Add File*, then *Link Sketch Library...*
 
-5. Select *all the* Console component files, then click Link Libraries...
+5. Select all the Console components files, then click *Link Library*
 
 <Callout>
   <CalloutTitle as="h4">Do a quick font check!</CalloutTitle>    
-  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open *Font tester.sketch* in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly. </CalloutText>
+  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open "Font tester.sketch" in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly. </CalloutText>
 </Callout>
 
-You're all set to work with Abstract and Paste Sketch Libraries!
+You’re all set to work with Abstract and the Paste Sketch Libraries!
 
 ### Your First Commit in Abstract
 
 1. To start work in any project, you’ll create a branch. A branch is a copy of the Master file that lets you make any changes without affecting the rest of the team’s work.
 
-To create a branch, click Master in the left sidebar and then click New Branch… in the upper right.
+To create a branch, click *Master* in the left sidebar and then click *New Branch…* in the upper right.
 
 <Callout variant="warning">
   <CalloutTitle as="h4">Early Access! Early Access! Early Access!</CalloutTitle>  
   <CalloutText>This section will be updated in the future with specific guidance for Flex &amp; SendGrid.</CalloutText>
 </Callout>
 
-When you’re working in the Console component library, the branch naming convention is:
+When you’re working in the Console components library, the branch naming convention is:
 
 ```
-Product Designer Initials - [JIRA ticket] [description]
+[JIRA ticket] [description]
 
 For example:
 
-AI - [PROJ-1234] Added a new button
+[PROJ-1234] Added a new button
 ```
 
 2. Once you’ve created your branch, go to the Overview tab and add a link to your documentation in the Summary section and a description for context.
 
 3. To start working in Sketch, return to Files and double-click on a Sketch file.
 
-4. Once you’ve made changes, you’ll commit your work. It does not affect the Master branch. Always Be Committing!
+4. Once you’ve made changes, you’ll commit your work. It does not affect the Master branch. **Always Be Committing!**
 
-
-Any changes you make before you commit are saved locally to your computer and only viewable by you.
-
-To commit, click Commit Changes on the Abstract plugin in Sketch.
-
-When working on design system projects, please follow our commit message conventions below.
-
+**Changes in Abstract are tracked per artboard.** If you don’t want to lose track of an Abstract comment thread on an artboard, make sure you don’t delete it (even if you rename another artboard with the same name), or don’t copy-and-paste it and start working off the duplicate.
 
 <Callout>
   <CalloutTitle as="h4">What's a Commit?</CalloutTitle>
-  <CalloutText>A commit is the way you save your work so it’s publicly viewable to the rest of the team. Committing is like saving a snapshot of your work, so you can revert your work back to previous commits when you need to.</CalloutText> 
-  <CalloutText marginTop="space40">Any changes you make before you commit are saved locally to your computer and only viewable by you. To commit, click Commit Changes on the Abstract plugin in Sketch.</CalloutText>
+  <CalloutText>A commit is the way you save your work so it’s publicly viewable to the rest of the team. Any changes you make before you commit are saved locally to your computer and only viewable by you.</CalloutText> 
+  <CalloutText marginTop="space40">Committing is like saving a snapshot of your work, so you can revert your work back to previous commits when you need to. So get comfortable deleting explorations of work! If you commit before and after you delete a bunch of explorations, you’ll be able to find those explorations in the future. More importantly, your files will be easier to grok for anyone who’s looking for the latest version of the work.</CalloutText>
+  <CalloutText marginTop="space40">How often you might commit depends on the scope of your project. If the scope is to do an icon color change or a typo fix, you might commit for that change only and close out the branch and project. If the scope is much larger (like creating a new component or laying out a sign-up flow), then commits might bundle more changes together.</CalloutText>
 </Callout>
 
-5. **Changes in Abstract are tracked per artboard.** If you don't want to lose track of an Abstract comment thread on an artboard, make sure you don't delete it (even if you rename another artboard with the same name).
-
+To commit, click *Commit Changes* on the Abstract plugin in Sketch. When working on design system projects, please follow our commit message conventions below.
 
 ### Commit Message Conventions
 
-Commit messages are important. You may be tempted to write "updates" as your commit's description while you're working hard, but will that be useful in six months when you're trying to find a specific exploration? We recommend using the `conventional commit` format for messages, which attaches a strict style to commits, and makes them readable: not just for you, but also for your peers!
+Commit messages are important. You may be tempted to write "updates" as your commit’s description while you're working hard, but will that be useful in six months when you’re trying to find a specific exploration? We recommend using the `conventional commit` format for messages, which attaches a strict style to commits, and makes them readable: not just for you, but also for your peers!
 
 <Callout variant="warning">
   <CalloutTitle as="h4">Commit Message Conventions are Mandatory for Design System Contributions</CalloutTitle>  
-  <CalloutText>While we can only **strongly recommend** what you do in your own Abstract projects, following this convention is mandatory for Design System projects. We'll have to ask you to redo your branch, so please follow this format! </CalloutText>
+  <CalloutText>While we can only strongly recommend what you do in your own Abstract projects, following this convention is mandatory for Design System projects. We'll have to ask you to redo your branch, so please follow this format! </CalloutText>
 </Callout>
 
 | Commit type | Commit message syntax | Example |
@@ -162,7 +156,7 @@ Commit messages are important. You may be tempted to write "updates" as your com
   <CalloutText>This section will be updated in a future release.</CalloutText>
 </Callout>
 
-As your projects become more and more complex (or you start working on multiple projects), it may be useful for you to create your own local symbol library. Before you do this, we recommend reaching out to the Design System team for guidance.
+As your projects become more and more complex (or you start working on multiple projects), it may be useful for you to create your own local symbol library for compositions that are specific to your product. We recommend reaching out to the Design System team for guidance.
 
 ## Coming Soon
 
@@ -173,7 +167,7 @@ As your projects become more and more complex (or you start working on multiple 
 
 ## Give us Feedback on this Page
 
-As you use Paste, you'll likely encounter things that _don't seem right_. Please reach out with your feedback! Here's some prompts to consider: 
+As you use Paste, you’ll likely encounter things that _don’t seem right_. Please reach out with your feedback! Here are some prompts to consider: 
 
 - Is this page easy for me to consume?
 - Is the information supporting it sufficient / well-described?


### PR DESCRIPTION
- Added information people asked questions about from the Abstract demo brown bag into their appropriate sections. Didn't add any info related to collections, reviews, and other design tooling since that isn't covered in this guide yet.
- Fixed a few typos

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
