### PR TITLE
fix(website): adding spaces around font tester file link

### DIFF
--- a/packages/paste-website/src/pages/getting-started/design.mdx
+++ b/packages/paste-website/src/pages/getting-started/design.mdx
@@ -94,11 +94,11 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 <Callout>
   <CalloutTitle as="h4">Do a quick font check!</CalloutTitle>    
-  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open 
+  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open{' '}
     <Anchor href="https://share.goabstract.com/c33c9dd8-5b0a-48a3-ab56-83a6fdffa869?sha=9a058708bfc5c9f741f3e62195e18e2cdc6ba329">
       Font tester.sketch
     </Anchor> 
-     in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly.</CalloutText>
+    {' '}in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly.</CalloutText>
 </Callout>
 
 You’re all set to work with Abstract and the Paste Sketch Libraries!

--- a/packages/paste-website/src/pages/getting-started/design.mdx
+++ b/packages/paste-website/src/pages/getting-started/design.mdx
@@ -94,10 +94,10 @@ If you’re unfamiliar with Abstract, version control, or git workflows, read th
 
 <Callout>
   <CalloutTitle as="h4">Do a quick font check!</CalloutTitle>    
-  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open
+  <CalloutText>Now is a good time to test your fonts to ensure that the components look right! In Abstract, go to the DesignOps project and open 
     <Anchor href="https://share.goabstract.com/c33c9dd8-5b0a-48a3-ab56-83a6fdffa869?sha=9a058708bfc5c9f741f3e62195e18e2cdc6ba329">
       Font tester.sketch
-    </Anchor>
+    </Anchor> 
      in untracked mode. Use the Font Tester artboard to make sure your font files have been installed correctly.</CalloutText>
 </Callout>
 


### PR DESCRIPTION
Adding spaces around "Font tester.sketch" link.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
