### PR TITLE
fix(website): correct nesting for principles sidenav link

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
@@ -99,9 +99,6 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
             Getting Started
             <SiteNavAnchorArrow isOpen={gettingStartedOpen} />
           </SiteNavButton>
-          <SiteNavItem>
-            <SiteNavAnchor to="/principles">Principles</SiteNavAnchor>
-          </SiteNavItem>
           <SiteNavNestList isOpen={gettingStartedOpen}>
             <SiteNavItem>
               <SiteNavAnchor to="/getting-started/">General Guidelines</SiteNavAnchor>
@@ -113,6 +110,9 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
               <SiteNavAnchor to="/getting-started/engineering">Engineering Guidelines</SiteNavAnchor>
             </SiteNavItem>
           </SiteNavNestList>
+        </SiteNavItem>
+        <SiteNavItem>
+          <SiteNavAnchor to="/principles">Principles</SiteNavAnchor>
         </SiteNavItem>
         <SiteNavItem>
           <SiteNavButton onClick={() => setTokensOpen(!tokensOpen)} isOpen={tokensOpen}>


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This PR addresses the nesting issue for the Principles sidenav link (#119).

Before:
![Screenshot before](https://user-images.githubusercontent.com/5178445/66238993-625dcd00-e6be-11e9-82d2-f63a727ea31f.gif)

After:
![Screenshot after](https://user-images.githubusercontent.com/5178445/66242887-2891c400-e6c8-11e9-92e5-9acaa58c2ab1.gif)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
