### PR TITLE
fix(website): change breadcrumb slash from aside to span

### DIFF
--- a/packages/paste-website/src/components/breadcrumb/index.tsx
+++ b/packages/paste-website/src/components/breadcrumb/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {themeGet} from 'styled-system';
 import {Link} from 'gatsby';
 
-const CrumbSlashStyled = styled.aside(props => ({
+const CrumbSlashStyled = styled.span(props => ({
   padding: `0 ${themeGet('space.space20')(props)}`,
   display: 'inline',
   color: themeGet('textColors.colorTextWeak')(props),


### PR DESCRIPTION
The slashes on breadcrumbs shouldn't be `aside`, `span` at best

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
