### PR TITLE
test(box): adding snapshot tests

### DIFF
--- a/packages/paste-core/utilities/box/__tests__/__snapshots__/box.test.tsx.snap
+++ b/packages/paste-core/utilities/box/__tests__/__snapshots__/box.test.tsx.snap
@@ -1,0 +1,547 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Backgrounds it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  background-color: #b3d3e9;
+  min-width: 0;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    background-color: #0075c3;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    background responsive
+  </div>
+</div>
+`;
+
+exports[`Backgrounds it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  background-color: #0075c3;
+  min-width: 0;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    background single
+  </div>
+</div>
+`;
+
+exports[`Borders it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  border-width: 1px;
+  border-style: dashed;
+  border-color: colorBorderPrimaryDark;
+  border-radius: 0;
+  border-color: #005ea6;
+  min-width: 0;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    border-width: 2px;
+    border-style: dotted;
+    border-color: colorBorderPrimaryLight;
+    border-radius: 3px;
+  }
+}
+
+@media screen and (min-width:64rem) {
+  .emotion-0 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    border-color: #b3d3e9;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    border responsive
+  </div>
+</div>
+`;
+
+exports[`Borders it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  border-width: 1px;
+  border-style: solid;
+  border-color: colorBorderPrimaryDark;
+  border-radius: 4px;
+  border-color: #005ea6;
+  min-width: 0;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    border single
+  </div>
+</div>
+`;
+
+exports[`Shadows it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  box-shadow: 0 2px 4px 0 rgba(40,42,43,0.3);
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    box-shadow: 0 0 0 4px rgba(0,117,195,0.5);
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    shadow responsive
+  </div>
+</div>
+`;
+
+exports[`Shadows it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  box-shadow: 0 2px 4px 0 rgba(40,42,43,0.3);
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    shadow single
+  </div>
+</div>
+`;
+
+exports[`Sizes it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  width: size10;
+  min-width: 0;
+  max-width: 12rem;
+  height: 5.5rem;
+  min-height: 0;
+  max-height: 12rem;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    width: size20;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    min-width: 5.5rem;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    max-width: 18.5rem;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    height: 12rem;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    min-height: 5.5rem;
+  }
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    max-height: 18.5rem;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+    height={
+      Array [
+        "size10",
+        "size20",
+      ]
+    }
+    width={
+      Array [
+        "size10",
+        "size20",
+      ]
+    }
+  >
+    size responsive
+  </div>
+</div>
+`;
+
+exports[`Sizes it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  width: size10;
+  min-width: 0;
+  max-width: 12rem;
+  height: 5.5rem;
+  min-height: 0;
+  max-height: 12rem;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+    height="size10"
+    width="size10"
+  >
+    size single
+  </div>
+</div>
+`;
+
+exports[`Spaces (A) it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  margin: 0.25rem;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    margin: 0.5rem;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    space responsive 1
+  </div>
+</div>
+`;
+
+exports[`Spaces (A) it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  margin: 0.25rem;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    space single 1
+  </div>
+</div>
+`;
+
+exports[`Spaces (B) it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.25rem;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    space single 2
+  </div>
+</div>
+`;
+
+exports[`Spaces (B)it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.25rem;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.75rem;
+    margin-left: 0.75rem;
+    margin-right: 0.5rem;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    space responsive 2
+  </div>
+</div>
+`;
+
+exports[`ZIndex it should render responsive values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  z-index: 10;
+}
+
+@media screen and (min-width:25rem) {
+  .emotion-0 {
+    z-index: 20;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    z-index responsive
+  </div>
+</div>
+`;
+
+exports[`ZIndex it should render single values 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.15;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  min-width: 0;
+  z-index: 10;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    z-index single
+  </div>
+</div>
+`;

--- a/packages/paste-core/utilities/box/__tests__/box.test.tsx
+++ b/packages/paste-core/utilities/box/__tests__/box.test.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import {Theme} from '@twilio-paste/theme';
+import {Box} from '../src';
+
+describe('Backgrounds', () => {
+  it('it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box backgroundColor="colorBackgroundPrimary">background single</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box backgroundColor={['colorBackgroundPrimaryLight', 'colorBackgroundPrimary']}>background responsive</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Borders', () => {
+  it('it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box
+            borderStyle="solid"
+            borderColor="colorBorderPrimaryDark"
+            borderWidth="borderWidth10"
+            borderRadius="borderRadius20"
+          >
+            border single
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box
+            borderStyle={['dashed', 'dotted', 'solid']}
+            borderColor={['colorBorderPrimaryDark', 'colorBorderPrimaryLight']}
+            borderWidth={['borderWidth10', 'borderWidth20']}
+            borderRadius={['borderRadius0', 'borderRadius10']}
+          >
+            border responsive
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Sizes', () => {
+  it('it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box width="size10" minWidth="size0" maxWidth="size20" height="size10" minHeight="size0" maxHeight="size20">
+            size single
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box
+            width={['size10', 'size20']}
+            minWidth={['size0', 'size10']}
+            maxWidth={['size20', 'size30']}
+            height={['size10', 'size20']}
+            minHeight={['size0', 'size10']}
+            maxHeight={['size20', 'size30']}
+          >
+            size responsive
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Spaces', () => {
+  it('(A) it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box margin="space20">space single 1</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('(A) it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box margin={['space20', 'space30']}>space responsive 1</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('(B) it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box marginTop="space20" marginRight="space20" marginBottom="space30" marginLeft="space30">
+            space single 2
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('(B)it should render responsive values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box
+            marginTop={['space20', 'space30']}
+            marginRight={['space20', 'space30']}
+            marginBottom={['space30', 'space40']}
+            marginLeft={['space30', 'space40']}
+          >
+            space responsive 2
+          </Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Shadows', () => {
+  it('it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box boxShadow="shadowCard">shadow single</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box boxShadow={['shadowCard', 'shadowFocus']}>shadow responsive</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('ZIndex', () => {
+  it('it should render single values', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box zIndex="zIndex10">z-index single</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render responsive values', () => {
+    const tree = renderer
+      .create(
+        <Theme.Provider>
+          <Box zIndex={['zIndex10', 'zIndex20']}>z-index responsive</Box>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -60,8 +60,10 @@
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^10.0.14",
     "@types/color": "^3.0.0",
+    "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.136",
     "@types/react-helmet": "^5.0.9",
+    "@types/react-test-renderer": "^16.9.0",
     "babel-preset-gatsby": "^0.2.8",
     "prettier": "^1.18.2",
     "typescript": "^3.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,7 +3447,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
-"@types/jest@^24.0.15":
+"@types/jest@^24.0.15", "@types/jest@^24.0.18":
   version "24.0.18"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.18.tgz#9c7858d450c59e2164a8a9df0905fc5091944498"
   integrity sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==
@@ -3581,7 +3581,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-test-renderer@^16.8.2":
+"@types/react-test-renderer@^16.8.2", "@types/react-test-renderer@^16.9.0":
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.0.tgz#d60f530ecf4c906721511603cca711b4fa830d41"
   integrity sha512-bN5EyjtuTY35xX7N5j0KP1vg5MpUXHpFTX6tGsqkNOthjNvet4VQOYRxFh+NT5cDSJrATmAFK9NLeYZ4mp/o0Q==


### PR DESCRIPTION
Just adding a few snapshot tests for Box.  You can observe from the tests that `width` isn't being set correctly to token values, as this is a current bug with styled system v4: 

<img width="338" alt="image" src="https://user-images.githubusercontent.com/1592327/66681941-69925700-ec39-11e9-9a8c-bb2c083602d5.png">

Will be fixed in the v5 upgrade and this test will catch that improvement.