### PR TITLE
fix: allow 'auto' for marginLeft and marginRight

### DIFF
--- a/packages/paste-types/src/style-props/spacing.ts
+++ b/packages/paste-types/src/style-props/spacing.ts
@@ -6,9 +6,9 @@ type Spacing = ResponsiveValue<keyof ThemeShape['space']>;
 export interface MarginProps {
   margin?: Spacing;
   marginTop?: Spacing;
-  marginRight?: Spacing;
+  marginRight?: Spacing | 'auto';
   marginBottom?: Spacing;
-  marginLeft?: Spacing;
+  marginLeft?: Spacing | 'auto';
 }
 
 export interface PaddingProps {


### PR DESCRIPTION
Allows the value "auto" for marginLeft and marginRight typings