### PR TITLE
Added the License section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Build things 🎉
 | yarn build:dev       | Builds the compiled JS into `/dist` in dev mode                                                                          |
 | yarn build           | Builds the compiled JS into `/dist`                                                                                      |
 | yarn pre-push        | A series of commands that are run as a pre-commit hook.                                                                  |
+
+## License
+[MIT](/LICENSE)


### PR DESCRIPTION
<!-- Describe your Pull Request -->
### Description

Most `README.md` files have a license section and this repo didn't have one. I know this might not be big deal but now the documentation looks better.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
