### PR TITLE
fix(tokens): updates border color to use color box

### DIFF
--- a/packages/paste-types/src/style-props/backgroundColor.ts
+++ b/packages/paste-types/src/style-props/backgroundColor.ts
@@ -2,5 +2,5 @@ import {ThemeShape} from '@twilio-paste/theme-tokens';
 import {ResponsiveValue} from 'styled-system';
 
 export interface BackgroundColorProps {
-  backgroundColor?: ResponsiveValue<keyof ThemeShape['backgroundColors']>;
+  backgroundColor?: ResponsiveValue<keyof ThemeShape['backgroundColors']> | ResponsiveValue<keyof ThemeShape['borderColors']>;
 }

--- a/packages/paste-types/src/style-props/backgroundColor.ts
+++ b/packages/paste-types/src/style-props/backgroundColor.ts
@@ -2,5 +2,5 @@ import {ThemeShape} from '@twilio-paste/theme-tokens';
 import {ResponsiveValue} from 'styled-system';
 
 export interface BackgroundColorProps {
-  backgroundColor?: ResponsiveValue<keyof ThemeShape['backgroundColors']> | ResponsiveValue<keyof ThemeShape['borderColors']>;
+  backgroundColor?: ResponsiveValue<keyof ThemeShape['backgroundColors']>;
 }

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -117,7 +117,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <ColorBox backgroundColor={tokenName as any} />;
+      return <ColorBox backgroundColor={tokenName as keyof ThemeShape['borderColors']} />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -17,10 +17,10 @@ export const ColorBox: React.FC<BackgroundColor> = ({backgroundColor}) => {
   return <Absolute backgroundColor={backgroundColor} padding="space50" preset="fill" />;
 };
 
-type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth' | 'height'>;
-export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth, height}) => {
+type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth'>;
+export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth}) => {
   return (
-    <Box borderStyle="solid" borderColor={borderColor} borderWidth={borderWidth || 'borderWidth20'} height={height} />
+    <Box borderStyle="solid" borderColor={borderColor} borderWidth={borderWidth || 'borderWidth20'} padding="space60" />
   );
 };
 
@@ -117,7 +117,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height="size10" />;
+      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -117,7 +117,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} />;
+      return <ColorBox backgroundColor={tokenName as any} />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -21,10 +21,10 @@ type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth' | 'height'>;
 export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth, height}) => {
   return (
     <Box
-      borderStyle="solid none none none"
+      borderStyle="solid"
       borderColor={borderColor}
       borderWidth={borderWidth || 'borderWidth20'}
-      height={height || undefined}
+      height={height}
     />
   );
 };
@@ -122,7 +122,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height='size60' />;
+      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height='size10' />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -20,12 +20,7 @@ export const ColorBox: React.FC<BackgroundColor> = ({backgroundColor}) => {
 type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth' | 'height'>;
 export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth, height}) => {
   return (
-    <Box
-      borderStyle="solid"
-      borderColor={borderColor}
-      borderWidth={borderWidth || 'borderWidth20'}
-      height={height}
-    />
+    <Box borderStyle="solid" borderColor={borderColor} borderWidth={borderWidth || 'borderWidth20'} height={height} />
   );
 };
 
@@ -122,7 +117,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height='size10' />;
+      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height="size10" />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':

--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -17,10 +17,15 @@ export const ColorBox: React.FC<BackgroundColor> = ({backgroundColor}) => {
   return <Absolute backgroundColor={backgroundColor} padding="space50" preset="fill" />;
 };
 
-type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth'>;
-export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth}) => {
+type BorderBoxProps = Pick<BoxProps, 'borderColor' | 'borderWidth' | 'height'>;
+export const BorderBox: React.FC<BorderBoxProps> = ({borderColor, borderWidth, height}) => {
   return (
-    <Box borderStyle="solid none none none" borderColor={borderColor} borderWidth={borderWidth || 'borderWidth20'} />
+    <Box
+      borderStyle="solid none none none"
+      borderColor={borderColor}
+      borderWidth={borderWidth || 'borderWidth20'}
+      height={height || undefined}
+    />
   );
 };
 
@@ -117,7 +122,7 @@ export const TokenExample: React.FC<TokenExampleProps> = ({token}) => {
     case 'color':
       return <ColorBox backgroundColor={token.value as any} />;
     case 'border-color':
-      return <ColorBox backgroundColor={tokenName as keyof ThemeShape['borderColors']} />;
+      return <BorderBox borderColor={tokenName as keyof ThemeShape['borderColors']} height='size60' />;
     case 'border-width':
       return <BorderBox borderWidth={tokenName as keyof ThemeShape['borderWidths']} />;
     case 'font':


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Fixes #74. Transitioned to use of `ColorBox` (from `BorderBox`) to display Border Color examples, improving readability.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
