### PR TITLE
fix: change the version number the website displays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paste",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.3.0",
   "main": "index.js",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
@@ -7,7 +7,7 @@ import {Absolute} from '@twilio-paste/absolute';
 import {ThemeSwitcher} from '../ThemeSwitcher';
 import GithubIcon from '../icons/GithubIcon';
 import {SIDEBAR_WIDTH, HEADER_HEIGHT} from './constants';
-import {version} from '../../../package.json';
+import {version} from '../../../../../package.json';
 
 interface FlexProps {
   justifyContent?: string;

--- a/packages/paste-website/tsconfig.json
+++ b/packages/paste-website/tsconfig.json
@@ -5,6 +5,6 @@
     "target": "esnext",
     "jsx": "preserve"
   },
-  "include": ["./package.json", "./src/**/*", "./types/**/*", "./static/**/*"],
+  "include": ["../../package.json", "./src/**/*", "./types/**/*", "./static/**/*"],
   "exclude": ["node_modules", "public", ".cache"]
 }


### PR DESCRIPTION
Change the version number that the website uses to display from the website package version number to the mono repo package.json version number.