### PR TITLE
fix(types): add @types/styled-system dependency

### DIFF
--- a/packages/paste-types/package.json
+++ b/packages/paste-types/package.json
@@ -24,6 +24,9 @@
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@types/styled-system": "^5.1.3"
+  },
   "peerDependencies": {
     "@twilio-paste/theme-tokens": "^1.0.0",
     "styled-system": "^5.1.2"


### PR DESCRIPTION
Box props (and others) aren't typed correctly.  Hover over the `marginBottom` on line 17 here https://codesandbox.io/s/paste-starter-kit-rj7yy

Cmd + click it, then hover.  CMD click all the way until you get to `Space`.  Even that is typed as `any`.  `ThemeShape` is correctly typed, but `ResponsiveValue` is not typed at all.  

I'm not sure why `ResponsiveValue` isn't being typed correctly. My hunch is that we need to move `styled-system` as a dependency.  Any other advice is appreciated.  If no one has a better guess, I'd be willing to push this out to test and see if it fixes anything.