### PR TITLE
fix: lock prettier version for more predictable builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "lerna": "^3.16.4",
     "lodash": "^4.17.14",
     "precise-commits": "^1.0.2",
-    "prettier": "^1.18.2",
+    "prettier": "1.19.1",
     "react-test-renderer": "^16.8.6",
     "require-context.macro": "^1.0.4",
     "shelljs": "^0.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17746,6 +17746,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
 prettier@^1.17.1, prettier@^1.18.2:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.0.tgz#3bec4489d5eebcd52b95ddd2c22467b5c852fde1"


### PR DESCRIPTION
Prettier ran fine on my machine but fails on master in CI. Trying to lock the version to see if that helps CI. 

Also, notice changes happen over time on certain PRs where the formatting suddenly needs to change.