### PR TITLE
fix(anchor): fix hover color

### DIFF
--- a/packages/paste-core/components/anchor/__tests__/__snapshots__/anchor.test.tsx.snap
+++ b/packages/paste-core/components/anchor/__tests__/__snapshots__/anchor.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Anchor it should render an anchor 1`] = `
 }
 
 .emotion-0:hover {
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -30,6 +31,7 @@ exports[`Anchor it should render an anchor 1`] = `
 .emotion-0:focus,
 .emotion-0:active {
   box-shadow: 0 0 0 4px rgba(0,117,195,0.5);
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -69,6 +71,7 @@ exports[`Anchor it should render an external anchor 1`] = `
 }
 
 .emotion-0:hover {
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -76,6 +79,7 @@ exports[`Anchor it should render an external anchor 1`] = `
 .emotion-0:focus,
 .emotion-0:active {
   box-shadow: 0 0 0 4px rgba(0,117,195,0.5);
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -117,6 +121,7 @@ exports[`Anchor it should render an external anchor with overwritten target and 
 }
 
 .emotion-0:hover {
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -124,6 +129,7 @@ exports[`Anchor it should render an external anchor with overwritten target and 
 .emotion-0:focus,
 .emotion-0:active {
   box-shadow: 0 0 0 4px rgba(0,117,195,0.5);
+  color: #003e82;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/packages/paste-core/components/anchor/src/styles.ts
+++ b/packages/paste-core/components/anchor/src/styles.ts
@@ -8,21 +8,14 @@ export const StyledAnchor = styled.a`
   outline: none;
 
   &:hover {
-    color: ${themeGet('textColors.colorTextLinkHover')};
+    color: ${themeGet('textColors.colorTextLinkDarker')};
     text-decoration: none;
   }
 
   &:focus,
   &:active {
     box-shadow: ${themeGet('shadows.shadowFocus')};
+    color: ${themeGet('textColors.colorTextLinkDarker')};
     text-decoration: none;
-  }
-
-  &:focus {
-    color: ${themeGet('textColors.colorTextLinkFocus')};
-  }
-
-  &:active {
-    color: ${themeGet('textColors.colorTextLinkActive')};
   }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,7 +3780,7 @@
     "@types/react" "*"
     "@types/webpack-env" "*"
 
-"@types/styled-system@^5.1.2":
+"@types/styled-system@^5.1.2", "@types/styled-system@^5.1.3":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.3.tgz#d840c8369c1b8115b84bff0fb9846fcd494204a5"
   integrity sha512-YLmQz8sNtLBg5JAuCfkdRl0Hf6KB/eM4wVmy+I3HEMWs35rmExF1BOBydEXjcgfiQ3bu/v+7RBu0whkOYtz4WQ==


### PR DESCRIPTION
Update the anchor component for hover state to use the color-text-link-darker token. The text should darken on hover in addition to the underline disappearing.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
