### PR TITLE
fix(spinner): export the prop types with the component

### DIFF
--- a/packages/paste-core/components/spinner/src/index.tsx
+++ b/packages/paste-core/components/spinner/src/index.tsx
@@ -29,7 +29,7 @@ const SpinningWrapper = styled.div<SpinnerWrapperProps>(
   })
 );
 
-interface SpinnerProps extends LoadingIconProps {
+export interface SpinnerProps extends LoadingIconProps {
   title: string;
   size?: IconSize;
 }
@@ -45,4 +45,4 @@ Spinner.defaultProps = {
 };
 
 Spinner.displayName = 'Spinner';
-export {Spinner, SpinnerProps};
+export {Spinner};

--- a/packages/paste-core/components/spinner/src/index.tsx
+++ b/packages/paste-core/components/spinner/src/index.tsx
@@ -45,4 +45,4 @@ Spinner.defaultProps = {
 };
 
 Spinner.displayName = 'Spinner';
-export {Spinner};
+export {Spinner, SpinnerProps};


### PR DESCRIPTION
Each component should export it's prop types so a consumer can extend them or use them in dynamic prop setting situations.
