### PR TITLE
fix(website): display text tokens on the correct inverse bg color

### DIFF
--- a/packages/paste-website/src/components/tokens-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-example/index.tsx
@@ -53,7 +53,7 @@ export const TextColorBox: React.FC<TextColorBoxProps> = ({color, textColor}) =>
   const colorFn = Color(color);
   const isInverse = colorFn.isLight();
   const backgroundColorValue = isInverse
-    ? theme.backgroundColors.colorBackgroundBrand
+    ? theme.backgroundColors.colorBackgroundInverse
     : theme.backgroundColors.colorBackgroundBody;
   const colorCombos = ColorCombos([color, backgroundColorValue]);
   const {accessibility} = colorCombos[1].combinations[0];
@@ -65,7 +65,7 @@ export const TextColorBox: React.FC<TextColorBoxProps> = ({color, textColor}) =>
 
   return (
     <Absolute
-      backgroundColor={isInverse ? 'colorBackgroundBrand' : 'colorBackgroundBody'}
+      backgroundColor={isInverse ? 'colorBackgroundInverse' : 'colorBackgroundBody'}
       padding="space60"
       preset="fill"
       css={{


### PR DESCRIPTION
Realised we were displaying "light" text colors on the brand background instead of the actual inverse background color as intended in real life.

Fixed