### PR TITLE
chore(heading): add storybook examples for VRT

### DIFF
--- a/packages/paste-core/components/heading/stories/index.stories.tsx
+++ b/packages/paste-core/components/heading/stories/index.stories.tsx
@@ -5,13 +5,55 @@ import {asTags, Heading, HeadingVariants} from '../src';
 
 const headingVariantOptions = ['heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'];
 
-storiesOf('Components|Typography', module)
+storiesOf('Components|Heading', module)
   .addDecorator(withKnobs)
-  .add('Heading', () => {
+  .add('All variants', () => {
     const asOptions = text('as', 'h2') as asTags;
     const headingVariantValue = select('variant', headingVariantOptions, 'heading20') as HeadingVariant;
     return (
       <Heading as={asOptions} variant={headingVariantValue}>
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading10', () => {
+    return (
+      <Heading as="h1" variant="heading10">
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading20', () => {
+    return (
+      <Heading as="h1" variant="heading20">
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading30', () => {
+    return (
+      <Heading as="h1" variant="heading30">
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading40', () => {
+    return (
+      <Heading as="h1" variant="heading40">
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading50', () => {
+    return (
+      <Heading as="h1" variant="heading50">
+        I am a Very Large Heading
+      </Heading>
+    );
+  })
+  .add('heading60', () => {
+    return (
+      <Heading as="h1" variant="heading60">
         I am a Very Large Heading
       </Heading>
     );

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -37,7 +37,7 @@ export const pageQuery = graphql`
   name={props.pageContext.frontmatter.title}
   categoryRoute={SidebarCategoryRoutes.COMPONENTS}
   githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/components/heading"
-  storybookUrl="https://twilio-labs.github.io/paste/?path=/story/components-typography--heading"
+  storybookUrl="http://localhost:9001/?path=/story/components-heading--all-variants"
   data={props.data.allPasteComponent.edges}
 />
 

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -37,7 +37,7 @@ export const pageQuery = graphql`
   name={props.pageContext.frontmatter.title}
   categoryRoute={SidebarCategoryRoutes.COMPONENTS}
   githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/components/heading"
-  storybookUrl="http://localhost:9001/?path=/story/components-heading--all-variants"
+  storybookUrl="https://twilio-labs.github.io/paste/?path=/story/components-heading--all-variants"
   data={props.data.allPasteComponent.edges}
 />
 


### PR DESCRIPTION
Noticed we were missing examples to be checked for visual regression for the heading component, just adding some here.