### PR TITLE
chore(website): update the roadmap and remove changelog item

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
@@ -224,9 +224,6 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
         <SiteNavItem>
           <SiteNavAnchor to="/roadmap">Roadmap</SiteNavAnchor>
         </SiteNavItem>
-        <SiteNavItem>
-          <SiteNavAnchor to="/changelog">Changelog</SiteNavAnchor>
-        </SiteNavItem>
       </SiteNavList>
     </SiteNav>
   );

--- a/packages/paste-website/src/pages/roadmap/index.mdx
+++ b/packages/paste-website/src/pages/roadmap/index.mdx
@@ -49,7 +49,6 @@ TBD
 **Other**
 
 - Add an icon list to the [icon system guidelines](/icon-system) with more design guidelines. Right now, you can access our <Anchor href="https://twilio-labs.github.io/paste/?path=/story/overview-icons--list"> full icon list on Storybook</Anchor>.
-- Make this website responsive 📱
 
 ---
 

--- a/packages/paste-website/src/pages/roadmap/index.mdx
+++ b/packages/paste-website/src/pages/roadmap/index.mdx
@@ -38,18 +38,18 @@ Release date: February 25, 2020
 
 **Design releases**
 
-- Design a Toast component. 🍞
-- Design Overlay components (Modal, Alert dialog, and Overlay). 🕴
-- Design a Form footer component. 📝
+- Design more form field components (Select, Checkbox and Checkbox group, and Radio and Radio Group). 📝
 - Design a Form composition component. 📝
+- Design a Toast component. 🍞
 
 **Engineering releases**
 
-- Ship a Toast component. 🍞
+TBD
 
 **Other**
 
-- Make this website responsive. 📱
+- Add an icon list to the [icon system guidelines](/icon-system) with more design guidelines. Right now, you can access our <Anchor href="https://twilio-labs.github.io/paste/?path=/story/overview-icons--list"> full icon list on Storybook</Anchor>.
+- Make this website responsive 📱
 
 ---
 
@@ -59,8 +59,7 @@ Release date: April 7, 2020
 
 **Design releases**
 
-- Design a Page header component. 🎩
-- Design a Breadcrumb component.
+- Design Overlay components (Modal, Alert dialog, and Overlay). 🕴
 - Design a Tab component.
 - Design a Table component.
 - Define our icon-naming schema.

--- a/packages/paste-website/src/pages/roadmap/index.mdx
+++ b/packages/paste-website/src/pages/roadmap/index.mdx
@@ -32,57 +32,7 @@ export const pageQuery = graphql`
 
 <Box>
 
-## Release 0.4
-
-Release date: December 3, 2019
-
-**Design releases**
-
-- Flex tokens will be added to our Design System Sketch files.
-- Alerts will be design-ready and built in an upcoming release. 🔔
-- Grids will be design-ready and built in an upcoming release.
-
-**Engineering releases**
-
-- Buttons will be productionized 🎉 and usable on SendGrid / Console.
-- Anchors will be productionized too! 🔗
-- The icon system will also be on the production train 🚝
-
-**Other**
-
-- The theme switcher will work as intended, allowing all styles to be viewable based on SendGrid and Console Themes.
-
-
----
-
-## Release 0.5
-
-Release date: January 14, 2020
-
-**Design releases**
-
-- Design and ship the first set of form field components (Label, Input, Textarea, and Inline error). 📝
-- Design more form field components (Select, Checkbox and Checkbox group, Radio and Radio Group, and Toggle). 📝
-- Design a Button group component.
-- Apply unified design language for alpha.
-
-**Engineering releases**
-
-- Ship an Alert component. 🔔
-- Ship a Grid component.
-- Ship more Typography components (Heading and Lists).
-- Implement continuous deployment of Paste packages. 
-
-**Other**
-
-- Add an icon list to the [icon system guidelines](/icon-system) with more design guidelines. Right now, you can access our  
-  <Anchor href="https://twilio-labs.github.io/paste/?path=/story/overview-icons--list">
-    full icon list on Storybook
-  </Anchor>.
-
----
-
-## Release 0.6
+## Release 2020.02.25
 
 Release date: February 25, 2020
 
@@ -103,7 +53,7 @@ Release date: February 25, 2020
 
 ---
 
-## Release 0.7
+## Release 2020.04.07
 
 Release date: April 7, 2020
 


### PR DESCRIPTION
Update the roadmap page with new version numbering system.

Hide the changelog item from the sidebar for now