### PR TITLE
fix: "SHIFT" to "OPTION" in "Formatting an icon"

### DIFF
--- a/packages/paste-website/src/pages/icon-system/how-to-add-an-icon.mdx
+++ b/packages/paste-website/src/pages/icon-system/how-to-add-an-icon.mdx
@@ -73,7 +73,7 @@ Written for Sketch 59.1
 ## Formatting an icon
 
 1. Convert your icons to outlines so that the width of the lines stay consistent.
-   1. Select all the layers and press "SHIFT + COMMAND + O", or use Sketch's menu, "Layer > Convert to Outlines".
+   1. Select all the layers and press "OPTION + COMMAND + O", or use Sketch's menu, "Layer > Convert to Outlines".
    2. Make sure each layer now has a fill and not a stroke.
 2. Create a union with all the pieces of your icon. This will merge individual pieces
    together to create one shape. You can find the Union tool in Sketch's toolbar at the


### PR DESCRIPTION
Fix typo in "Formatting an icon" 1.1. Changes "SHIFT" to "OPTION"