### PR TITLE
fix(storybook): fix vrt on loading button

### DIFF
--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -10,6 +10,13 @@ const ButtonSizeOptions = ['', 'default', 'small', 'icon', 'reset'];
 const ButtonVariantOptions = ['primary', 'secondary', 'destructive', 'destructive_link', 'link', 'reset'];
 const ButtonTabIndexOptions = [0, -1];
 
+const IS_VRT_ENV = (() => {
+  if (!window || !window.location || !window.location.href) {
+    return true;
+  }
+  return Boolean(new URL(window.location.href).searchParams.get('eyes-storybook'));
+})();
+
 storiesOf('Components|Button', module)
   .addDecorator(withKnobs)
   .add('Text only', () => {
@@ -83,7 +90,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size={size}>
             Primary
           </Button>
-          <Button variant="primary" size={size} loading>
+          <Button variant="primary" size={size} loading={!IS_VRT_ENV}>
             Primary
           </Button>
           <Button variant="primary" size={size} disabled>
@@ -95,7 +102,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="small">
             Primary
           </Button>
-          <Button variant="primary" size="small" loading>
+          <Button variant="primary" size="small" loading={!IS_VRT_ENV}>
             Primary
           </Button>
           <Button variant="primary" size="small" disabled>
@@ -107,7 +114,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="primary" size="icon" loading>
+          <Button variant="primary" size="icon" loading={!IS_VRT_ENV}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="primary" size="icon" disabled>
@@ -119,7 +126,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="reset">
             Primary
           </Button>
-          <Button variant="primary" size="reset" loading>
+          <Button variant="primary" size="reset" loading={!IS_VRT_ENV}>
             Primary
           </Button>
           <Button variant="primary" size="reset" disabled>
@@ -131,7 +138,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size={size}>
             Secondary
           </Button>
-          <Button variant="secondary" size={size} loading>
+          <Button variant="secondary" size={size} loading={!IS_VRT_ENV}>
             Secondary
           </Button>
           <Button variant="secondary" size={size} disabled>
@@ -143,7 +150,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="small">
             Secondary
           </Button>
-          <Button variant="secondary" size="small" loading>
+          <Button variant="secondary" size="small" loading={!IS_VRT_ENV}>
             Secondary
           </Button>
           <Button variant="secondary" size="small" disabled>
@@ -155,7 +162,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="secondary" size="icon" loading>
+          <Button variant="secondary" size="icon" loading={!IS_VRT_ENV}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="secondary" size="icon" disabled>
@@ -167,7 +174,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="reset">
             Secondary
           </Button>
-          <Button variant="secondary" size="reset" loading>
+          <Button variant="secondary" size="reset" loading={!IS_VRT_ENV}>
             Secondary
           </Button>
           <Button variant="secondary" size="reset" disabled>
@@ -179,7 +186,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size={size}>
             Destructive
           </Button>
-          <Button variant="destructive" size={size} loading>
+          <Button variant="destructive" size={size} loading={!IS_VRT_ENV}>
             Destructive
           </Button>
           <Button variant="destructive" size={size} disabled>
@@ -191,7 +198,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="small">
             Destructive
           </Button>
-          <Button variant="destructive" size="small" loading>
+          <Button variant="destructive" size="small" loading={!IS_VRT_ENV}>
             Destructive
           </Button>
           <Button variant="destructive" size="small" disabled>
@@ -203,7 +210,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="destructive" size="icon" loading>
+          <Button variant="destructive" size="icon" loading={!IS_VRT_ENV}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="destructive" size="icon" disabled>
@@ -215,7 +222,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="reset">
             Destructive
           </Button>
-          <Button variant="destructive" size="reset" loading>
+          <Button variant="destructive" size="reset" loading={!IS_VRT_ENV}>
             Destructive
           </Button>
           <Button variant="destructive" size="reset" disabled>
@@ -227,7 +234,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size={size}>
             Link
           </Button>
-          <Button variant="link" size={size} loading>
+          <Button variant="link" size={size} loading={!IS_VRT_ENV}>
             Link
           </Button>
           <Button variant="link" size={size} disabled>
@@ -239,7 +246,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="small">
             Link
           </Button>
-          <Button variant="link" size="small" loading>
+          <Button variant="link" size="small" loading={!IS_VRT_ENV}>
             Link
           </Button>
           <Button variant="link" size="small" disabled>
@@ -251,7 +258,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="link" size="icon" loading>
+          <Button variant="link" size="icon" loading={!IS_VRT_ENV}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="link" size="icon" disabled>
@@ -263,7 +270,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="reset">
             Link
           </Button>
-          <Button variant="link" size="reset" loading>
+          <Button variant="link" size="reset" loading={!IS_VRT_ENV}>
             Link
           </Button>
           <Button variant="link" size="reset" disabled>
@@ -275,7 +282,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size={size}>
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size={size} loading>
+          <Button variant="destructive_link" size={size} loading={!IS_VRT_ENV}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size={size} disabled>
@@ -287,7 +294,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="small">
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size="small" loading>
+          <Button variant="destructive_link" size="small" loading={!IS_VRT_ENV}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size="small" disabled>
@@ -299,7 +306,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="destructive_link" size="icon" loading>
+          <Button variant="destructive_link" size="icon" loading={!IS_VRT_ENV}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="destructive_link" size="icon" disabled>
@@ -311,7 +318,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="reset">
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size="reset" loading>
+          <Button variant="destructive_link" size="reset" loading={!IS_VRT_ENV}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size="reset" disabled>
@@ -322,7 +329,7 @@ storiesOf('Components|Button', module)
           <Button variant="reset" size="reset">
             Reset
           </Button>
-          <Button variant="reset" size="reset" loading>
+          <Button variant="reset" size="reset" loading={!IS_VRT_ENV}>
             Reset
           </Button>
           <Button variant="reset" size="reset" disabled>


### PR DESCRIPTION
Currently, our VRT tests keep failing on every PR because Applitools Eyes is capturing a screenshot of the Button story page at different times.  This causes the spinner icon to be visually different on each test, even if the test is a few miliseconds off.  

The current recommended approach to solve the issue is to check if we're in the testing environment and modifying the behavior: https://github.com/applitools/eyes-storybook#dealing-with-dynamic-data

This change only modifies the story, so production code doesn't have to carry the burden.  I think ideally, the VRT tools could provide the reduced motion media query and we can leverage that on animations.  Until then, to regain our sanity, this is a hack fix.