### PR TITLE
chore(core): prevent uncommitted changes when building core package

### DIFF
--- a/packages/paste-core/core-bundle/src/index.tsx
+++ b/packages/paste-core/core-bundle/src/index.tsx
@@ -14,3 +14,4 @@ export * from '@twilio-paste/screen-reader-only';
 export * from '@twilio-paste/spinner';
 export * from '@twilio-paste/text';
 export * from '@twilio-paste/truncate';
+

--- a/packages/paste-core/core-bundle/src/index.tsx
+++ b/packages/paste-core/core-bundle/src/index.tsx
@@ -14,4 +14,3 @@ export * from '@twilio-paste/screen-reader-only';
 export * from '@twilio-paste/spinner';
 export * from '@twilio-paste/text';
 export * from '@twilio-paste/truncate';
-

--- a/packages/paste-core/core-bundle/tools/generate.js
+++ b/packages/paste-core/core-bundle/tools/generate.js
@@ -48,8 +48,8 @@ function getAllCorePackages(packageList) {
   // Sort the list so we don't get inconsistent ordering each rebuild
   const sortedPackageList = sortBy(filteredPackageList, ['name']);
 
-  // Write into core's index file ending with a new line
-  const indexOutput = `${generateIndexFromPackageList(sortedPackageList)}\n`;
+  // Write into core's index file
+  const indexOutput = generateIndexFromPackageList(sortedPackageList);
   writeToFile(CORE_BUNDLE_INDEX_PATH, indexOutput, {
     successMessage: `[@twilio-paste/core] Exports have been successfully updated within: ${CORE_BUNDLE_INDEX_PATH}`,
   });

--- a/packages/paste-core/core-bundle/tools/generate.js
+++ b/packages/paste-core/core-bundle/tools/generate.js
@@ -48,8 +48,8 @@ function getAllCorePackages(packageList) {
   // Sort the list so we don't get inconsistent ordering each rebuild
   const sortedPackageList = sortBy(filteredPackageList, ['name']);
 
-  // Write into core's index file
-  const indexOutput = generateIndexFromPackageList(sortedPackageList);
+  // Write into core's index file ending with a new line
+  const indexOutput = `${generateIndexFromPackageList(sortedPackageList)}\n`;
   writeToFile(CORE_BUNDLE_INDEX_PATH, indexOutput, {
     successMessage: `[@twilio-paste/core] Exports have been successfully updated within: ${CORE_BUNDLE_INDEX_PATH}`,
   });
@@ -58,8 +58,9 @@ function getAllCorePackages(packageList) {
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const packageJson = require(CORE_BUNDLE_PACKAGE_PATH);
   const newPackageJson = {...packageJson, dependencies: generateDependenciesFromPackageList(sortedPackageList)};
-  writeToFile(CORE_BUNDLE_PACKAGE_PATH, newPackageJson, {
-    formatJson: true,
+  // formatted with a new ending line for prettier
+  const newPackageJsonString = `${JSON.stringify(newPackageJson, null, 2)}\n`;
+  writeToFile(CORE_BUNDLE_PACKAGE_PATH, newPackageJsonString, {
     successMessage: `[@twilio-paste/core] Successfully updated dependencies.`,
   });
 })();


### PR DESCRIPTION
When building the core package, as part of the generation step the package.json file is generated with no ending new line. 

This causes uncommitted changes to be created for the package.json file due to it being committed with a newline by prettier already. By adding a new line upon generation, we should remove this.

This makes it possible to do continual deployment.