### PR TITLE
fix(grid): set useTheme as const to fix hook error

### DIFF
--- a/packages/paste-core/utilities/grid/src/Grid.tsx
+++ b/packages/paste-core/utilities/grid/src/Grid.tsx
@@ -36,6 +36,8 @@ const getGridStyles = (theme: ThemeShape, gutter?: Space): MarginProps => {
 };
 
 const Grid: React.FC<GridProps> = ({children, gutter, marginTop, marginBottom, vertical, ...props}) => {
+  const theme = useTheme();
+
   const GridColumns = React.useMemo(
     () =>
       React.Children.map(children, child =>
@@ -46,7 +48,7 @@ const Grid: React.FC<GridProps> = ({children, gutter, marginTop, marginBottom, v
     [children]
   );
 
-  const GridStyles = React.useMemo(() => getGridStyles(useTheme(), gutter), [gutter]);
+  const GridStyles = React.useMemo(() => getGridStyles(theme, gutter), [gutter]);
 
   return (
     <Flex


### PR DESCRIPTION
Found a React hook error in `Grid`, because we used `useTheme()` inside `useMemo()`. This moves `useTheme()` to a const in order to fix the issue.
