### PR TITLE
fix(grid): add getColumnGutters function to process token value

### DIFF
--- a/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
+++ b/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
@@ -4,7 +4,7 @@ import {DefaultTheme} from '@twilio-paste/theme-tokens';
 import {Theme} from '@twilio-paste/theme';
 import {Space} from '@twilio-paste/style-props';
 import {Grid, Column} from '../src';
-import {getOuterGutterPull, getStackedColumns, getColumnOffset, getColumnSpan} from '../src/helpers';
+import {getOuterGutterPull, getStackedColumns, getColumnGutters, getColumnOffset, getColumnSpan} from '../src/helpers';
 
 describe('Grid Unit Tests', () => {
   const mockTheme = {
@@ -22,8 +22,16 @@ describe('Grid Unit Tests', () => {
     expect(getOuterGutterPull(mockTheme, mockGutter)).toStrictEqual('-4px');
   });
 
-  it('should return a responsive set of negative margin values', (): void => {
+  it('it should return a responsive set of negative margin values', (): void => {
     expect(getOuterGutterPull(mockTheme, mockGutters)).toStrictEqual(['-2px', '-6px', '-4px']);
+  });
+
+  it('it should return a single padding', (): void => {
+    expect(getColumnGutters(mockTheme, mockGutter)).toStrictEqual('4px');
+  });
+
+  it('it should return a responsive set of padding values', (): void => {
+    expect(getColumnGutters(mockTheme, mockGutters)).toStrictEqual(['2px', '6px', '4px']);
   });
 
   it('it should return a vertical value of 0', (): void => {

--- a/packages/paste-core/utilities/grid/src/Column.tsx
+++ b/packages/paste-core/utilities/grid/src/Column.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import {useTheme} from '@twilio-paste/theme';
+import {ThemeShape} from '@twilio-paste/theme-tokens';
 import {compose, layout, space, flexbox} from 'styled-system';
 import {ColumnProps, ColumnStyleProps} from './types';
-import {getStackedColumns, getColumnOffset, getColumnSpan} from './helpers';
+import {getStackedColumns, getColumnGutters, getColumnOffset, getColumnSpan} from './helpers';
 
-const getColumnStyles = (props: ColumnProps): ColumnStyleProps => {
+const getColumnStyles = (theme: ThemeShape, props: ColumnProps): ColumnStyleProps => {
   const columnStyles: ColumnStyleProps = {
     width: getColumnSpan(props),
   };
 
   if (props.gutter) {
-    columnStyles.paddingLeft = props.gutter;
-    columnStyles.paddingRight = props.gutter;
+    columnStyles.paddingLeft = getColumnGutters(theme, props.gutter);
+    columnStyles.paddingRight = getColumnGutters(theme, props.gutter);
   }
 
   if (!props.offset) {
@@ -42,7 +44,9 @@ const StyledColumn = styled.div(
 ) as React.FC<ColumnProps>;
 
 const Column: React.FC<ColumnProps> = ({children, count, gutter, offset, span, vertical}) => {
-  const ColumnStyles = React.useMemo(() => getColumnStyles({count, gutter, offset, span, vertical}), [
+  const theme = useTheme();
+
+  const ColumnStyles = React.useMemo(() => getColumnStyles(theme, {count, gutter, offset, span, vertical}), [
     count,
     gutter,
     offset,

--- a/packages/paste-core/utilities/grid/src/helpers.tsx
+++ b/packages/paste-core/utilities/grid/src/helpers.tsx
@@ -38,7 +38,7 @@ export const getColumnGutters = (theme: ThemeShape, gutter?: Space): Padding => 
     return `${theme.space[gutter as SpaceOptions]}` as SpaceOptions;
   }
 
-  return 'space0';
+  return `${theme.space[0]}` as SpaceOptions;
 };
 
 // Gets the vertical prop and returns 100% or 0 to be used as Column minWidths

--- a/packages/paste-core/utilities/grid/src/helpers.tsx
+++ b/packages/paste-core/utilities/grid/src/helpers.tsx
@@ -1,6 +1,6 @@
 import {ThemeShape} from '@twilio-paste/theme-tokens';
 import {ResponsiveValue} from 'styled-system';
-import {Margin, Space, SpaceOptions} from '@twilio-paste/style-props';
+import {Margin, Padding, Space, SpaceOptions} from '@twilio-paste/style-props';
 import {Vertical} from '@twilio-paste/flex';
 import {
   ColumnOffset,
@@ -11,7 +11,7 @@ import {
   ColumnWidthSpan,
 } from './types';
 
-// Gets the gutter and returns the value to be used a negative margin to Grid
+// Gets the gutter and returns the value to be used as negative margin to Grid
 export const getOuterGutterPull = (theme: ThemeShape, gutter?: Space): Margin => {
   if (Array.isArray(gutter)) {
     return (gutter as SpaceOptions[]).map((value: SpaceOptions) => {
@@ -24,6 +24,21 @@ export const getOuterGutterPull = (theme: ThemeShape, gutter?: Space): Margin =>
   }
 
   return 'auto';
+};
+
+// Gets the gutter and returns the value to be used as padding for Columns
+export const getColumnGutters = (theme: ThemeShape, gutter?: Space): Padding => {
+  if (Array.isArray(gutter)) {
+    return (gutter as SpaceOptions[]).map((value: SpaceOptions) => {
+      return `${theme.space[value]}` as SpaceOptions;
+    });
+  }
+
+  if (gutter) {
+    return `${theme.space[gutter as SpaceOptions]}` as SpaceOptions;
+  }
+
+  return 'space0';
 };
 
 // Gets the vertical prop and returns 100% or 0 to be used as Column minWidths


### PR DESCRIPTION
Currently the `Column`'s aren't setting the padding value correctly. It's coming through as the token value, i.e. `space20`. I've added a function to process the token value into the correct padding values.

- [x] added `getColumnGutters` function
- [x] added test for function

Tested locally via the website.