### PR TITLE
fix(grid): remove column flex styles

### DIFF
--- a/packages/paste-core/utilities/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/paste-core/utilities/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -36,38 +36,10 @@ exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
 
 .emotion-2 {
   width: 25%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 41.66666666666667%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -79,12 +51,10 @@ exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="41.66666666666667%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="25%"
     />
   </div>
@@ -127,38 +97,10 @@ exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid
 
 .emotion-4 {
   width: 16.666666666666664%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 41.66666666666667%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -170,17 +112,14 @@ exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="41.66666666666667%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="41.66666666666667%"
     />
     <div
       className="emotion-4 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
   </div>
@@ -223,20 +162,6 @@ exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
 
 .emotion-0 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -248,12 +173,10 @@ exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -296,38 +219,10 @@ exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
 
 .emotion-0 {
   width: 66.66666666666666%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-2 {
   width: 33.33333333333333%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -339,12 +234,10 @@ exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="66.66666666666666%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="33.33333333333333%"
     />
   </div>
@@ -387,38 +280,10 @@ exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
 
 .emotion-2 {
   width: 25%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 75%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -430,12 +295,10 @@ exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="75%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="25%"
     />
   </div>
@@ -478,38 +341,10 @@ exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = 
 
 .emotion-2 {
   width: 16.666666666666664%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 83.33333333333334%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -521,12 +356,10 @@ exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="83.33333333333334%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
   </div>
@@ -569,38 +402,10 @@ exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = 
 
 .emotion-2 {
   width: 8.333333333333332%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 91.66666666666666%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -612,12 +417,10 @@ exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="91.66666666666666%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
   </div>
@@ -660,38 +463,10 @@ exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = 
 
 .emotion-2 {
   width: 16.666666666666664%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 91.66666666666666%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -703,12 +478,10 @@ exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="91.66666666666666%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
   </div>
@@ -751,20 +524,6 @@ exports[`12 Column Options it should render a grid with 1 column 1`] = `
 
 .emotion-0 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -776,7 +535,6 @@ exports[`12 Column Options it should render a grid with 1 column 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="100%"
     />
   </div>
@@ -819,20 +577,6 @@ exports[`12 Column Options it should render a grid with 2 columns 1`] = `
 
 .emotion-0 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -844,12 +588,10 @@ exports[`12 Column Options it should render a grid with 2 columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -892,20 +634,6 @@ exports[`12 Column Options it should render a grid with 3 columns 1`] = `
 
 .emotion-0 {
   width: 33.33333333333333%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -917,17 +645,14 @@ exports[`12 Column Options it should render a grid with 3 columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="33.33333333333333%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="33.33333333333333%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="33.33333333333333%"
     />
   </div>
@@ -970,20 +695,6 @@ exports[`12 Column Options it should render a grid with 4 columns 1`] = `
 
 .emotion-0 {
   width: 25%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -995,22 +706,18 @@ exports[`12 Column Options it should render a grid with 4 columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="25%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="25%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="25%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="25%"
     />
   </div>
@@ -1053,20 +760,6 @@ exports[`12 Column Options it should render a grid with 6 columns 1`] = `
 
 .emotion-0 {
   width: 16.666666666666664%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1078,32 +771,26 @@ exports[`12 Column Options it should render a grid with 6 columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
   </div>
@@ -1146,20 +833,6 @@ exports[`12 Column Options it should render a grid with 12 columns 1`] = `
 
 .emotion-0 {
   width: 8.333333333333332%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1171,62 +844,50 @@ exports[`12 Column Options it should render a grid with 12 columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="8.333333333333332%"
     />
   </div>
@@ -1270,28 +931,10 @@ exports[`Column Offset Prop it should render two columns, one with a offset 1`] 
 .emotion-0 {
   width: 16.666666666666664%;
   margin-left: 66.66666666666666%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-2 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1303,12 +946,10 @@ exports[`Column Offset Prop it should render two columns, one with a offset 1`] 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="16.666666666666664%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -1351,29 +992,11 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
 
 .emotion-2 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-0 {
   width: 16.666666666666664%;
   margin-left: 66.66666666666666%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 @media screen and (min-width:25rem) {
@@ -1399,7 +1022,6 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width={
         Array [
           "16.666666666666664%",
@@ -1410,7 +1032,6 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -1453,20 +1074,6 @@ exports[`Column Span Prop it should render two columns with different responsive
 
 .emotion-0 {
   width: 66.66666666666666%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 @media screen and (min-width:25rem) {
@@ -1483,20 +1090,6 @@ exports[`Column Span Prop it should render two columns with different responsive
 
 .emotion-2 {
   width: 33.33333333333333%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 @media screen and (min-width:25rem) {
@@ -1520,7 +1113,6 @@ exports[`Column Span Prop it should render two columns with different responsive
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width={
         Array [
           "66.66666666666666%",
@@ -1531,7 +1123,6 @@ exports[`Column Span Prop it should render two columns with different responsive
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width={
         Array [
           "33.33333333333333%",
@@ -1580,38 +1171,10 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
 
 .emotion-0 {
   width: 66.66666666666666%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .emotion-2 {
   width: 33.33333333333333%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1623,12 +1186,10 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="66.66666666666666%"
     />
     <div
       className="emotion-2 emotion-1"
-      display="flex"
       width="33.33333333333333%"
     />
   </div>
@@ -1673,20 +1234,6 @@ exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
   width: 50%;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1698,12 +1245,10 @@ exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -1762,20 +1307,6 @@ exports[`Grid Gutter Prop it should render two columns with responsive gutters 1
   width: 50%;
   padding-left: 0.125rem;
   padding-right: 0.125rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 @media screen and (min-width:25rem) {
@@ -1801,12 +1332,10 @@ exports[`Grid Gutter Prop it should render two columns with responsive gutters 1
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -1868,22 +1397,8 @@ exports[`Grid Vertical Prop it should render two columns stacked only on mobile 
 
 .emotion-0 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   min-width: 100%;
   margin-left: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 @media screen and (min-width:25rem) {
@@ -1907,12 +1422,10 @@ exports[`Grid Vertical Prop it should render two columns stacked only on mobile 
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>
@@ -1958,22 +1471,8 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
 
 .emotion-0 {
   width: 50%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   min-width: 100%;
   margin-left: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <div
@@ -1985,12 +1484,10 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
     <div
       className="emotion-0 emotion-1"
-      display="flex"
       width="50%"
     />
   </div>

--- a/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
+++ b/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import {DefaultTheme} from '@twilio-paste/theme-tokens';
 import {Theme} from '@twilio-paste/theme';
-import {Space} from '@twilio-paste/style-props';
 import {Grid, Column} from '../src';
 import {getOuterGutterPull, getStackedColumns, getColumnGutters, getColumnOffset, getColumnSpan} from '../src/helpers';
 

--- a/packages/paste-core/utilities/grid/src/Column.tsx
+++ b/packages/paste-core/utilities/grid/src/Column.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {useTheme} from '@twilio-paste/theme';
 import {ThemeShape} from '@twilio-paste/theme-tokens';
-import {compose, layout, space, flexbox} from 'styled-system';
+import {compose, layout, space} from 'styled-system';
 import {ColumnProps, ColumnStyleProps} from './types';
 import {getStackedColumns, getColumnGutters, getColumnOffset, getColumnSpan} from './helpers';
 
@@ -15,12 +15,6 @@ const getColumnStyles = (theme: ThemeShape, props: ColumnProps): ColumnStyleProp
   if (props.gutter) {
     columnStyles.paddingLeft = getColumnGutters(theme, props.gutter);
     columnStyles.paddingRight = getColumnGutters(theme, props.gutter);
-  }
-
-  if (!props.offset) {
-    columnStyles.flexGrow = 1;
-    columnStyles.flexShrink = 1;
-    columnStyles.flexBasis = 'auto';
   }
 
   if (props.offset) {
@@ -38,8 +32,7 @@ const getColumnStyles = (theme: ThemeShape, props: ColumnProps): ColumnStyleProp
 const StyledColumn = styled.div(
   compose(
     space,
-    layout,
-    flexbox
+    layout
   )
 ) as React.FC<ColumnProps>;
 
@@ -53,11 +46,7 @@ const Column: React.FC<ColumnProps> = ({children, count, gutter, offset, span, v
     span,
     vertical,
   ]);
-  return (
-    <StyledColumn {...ColumnStyles} display="flex">
-      {children}
-    </StyledColumn>
-  );
+  return <StyledColumn {...ColumnStyles}>{children}</StyledColumn>;
 };
 
 Column.propTypes = {

--- a/packages/paste-core/utilities/grid/src/types.ts
+++ b/packages/paste-core/utilities/grid/src/types.ts
@@ -1,6 +1,6 @@
 import {ResponsiveValue} from 'styled-system';
-import {FlexboxProps, LayoutProps, PaddingProps, Space, SpaceProps} from '@twilio-paste/style-props';
-import {FlexProps, Vertical} from '@twilio-paste/flex';
+import {LayoutProps, PaddingProps, Space, SpaceProps} from '@twilio-paste/style-props';
+import {Vertical} from '@twilio-paste/flex';
 
 export interface GridProps extends SpaceProps {
   children: NonNullable<React.ReactNode>;
@@ -15,15 +15,13 @@ export type ColumnOffset = ResponsiveValue<ColumnOffsetOptions>;
 export type ColumnSpanOptions = number;
 export type ColumnSpan = ResponsiveValue<ColumnSpanOptions>;
 
-export interface ColumnStyleProps extends Omit<LayoutProps, 'minWidth' | 'width'>, FlexboxProps, PaddingProps {
+export interface ColumnStyleProps extends Omit<LayoutProps, 'minWidth' | 'width'>, PaddingProps {
   marginLeft?: ResponsiveValue<string>;
   minWidth?: ColumnMinWidth;
   width?: ColumnWidthSpan;
 }
 
-export interface ColumnProps
-  extends Omit<FlexProps, 'display' | 'width' | 'minWidth' | 'marginLeft'>,
-    ColumnStyleProps {
+export interface ColumnProps extends ColumnStyleProps {
   count?: number;
   gutter?: Space;
   offset?: ColumnOffset;

--- a/packages/paste-core/utilities/grid/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/grid/stories/index.stories.tsx
@@ -14,62 +14,62 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter={gutterValue}>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             5
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             6
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             7
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             8
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             9
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             10
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             11
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             12
           </Box>
         </Column>
@@ -80,7 +80,7 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
@@ -91,12 +91,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
@@ -107,17 +107,17 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
@@ -128,22 +128,22 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
@@ -154,32 +154,32 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             5
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             6
           </Box>
         </Column>
@@ -190,17 +190,17 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={5}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             5
           </Box>
         </Column>
         <Column span={5}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             5
           </Box>
         </Column>
         <Column span={2}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             2
           </Box>
         </Column>
@@ -211,12 +211,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={6}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             6
           </Box>
         </Column>
         <Column span={6}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             6
           </Box>
         </Column>
@@ -227,12 +227,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={8}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             8
           </Box>
         </Column>
         <Column span={4}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
@@ -243,12 +243,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={9}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             9
           </Box>
         </Column>
         <Column span={3}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             3
           </Box>
         </Column>
@@ -259,12 +259,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={10}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             10
           </Box>
         </Column>
         <Column span={2}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
@@ -275,12 +275,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={11}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             11
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
@@ -291,57 +291,57 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={2}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             2
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
@@ -352,27 +352,27 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={8}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             8
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
         <Column span={1}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             1
           </Box>
         </Column>
@@ -383,7 +383,7 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid>
         <Column span={[12, 6, 8]} offset={[0, 3, 2]}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             8
           </Box>
         </Column>
@@ -394,12 +394,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={[12, 6, 6]} offset={[0, 2, 2]}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             6
           </Box>
         </Column>
         <Column span={4}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
@@ -410,12 +410,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid>
         <Column span={4}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             4
           </Box>
         </Column>
         <Column span={4} offset={4}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
@@ -426,12 +426,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid>
         <Column span={2} offset={2}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             2
           </Box>
         </Column>
         <Column span={2} offset={6}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
@@ -442,12 +442,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20">
         <Column span={3}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
         <Column span={9}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             9
           </Box>
         </Column>
@@ -458,17 +458,17 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space60">
         <Column span={3}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
         <Column span={9}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             9
           </Box>
         </Column>
         <Column span={3}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
@@ -479,12 +479,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter={['space20', 'space60', 'space90']}>
         <Column span={[2, 6, 8]}>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             Responsive Column Size
           </Box>
         </Column>
         <Column span={[10, 6, 4]}>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             Responsive Column Size
           </Box>
         </Column>
@@ -495,12 +495,12 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space20" vertical={[true, false, false]}>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             Responsive Column Size
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             Responsive Column Size
           </Box>
         </Column>
@@ -511,20 +511,20 @@ storiesOf('Utilities|Grid', module)
     return (
       <Grid gutter="space40">
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
         <Column>
-          <Box height="size40" width="100%">
+          <Box height="size40">
             <Grid gutter="space20">
               <Column>
-                <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+                <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
                   Nested Column 1
                 </Box>
               </Column>
               <Column>
-                <Box backgroundColor="colorBackgroundPrimaryLight" height="size40" width="100%">
+                <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
                   Nested Column 2
                 </Box>
               </Column>
@@ -532,7 +532,7 @@ storiesOf('Utilities|Grid', module)
           </Box>
         </Column>
         <Column>
-          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40" width="100%">
+          <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>

--- a/packages/paste-core/utilities/grid/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/grid/stories/index.stories.tsx
@@ -3,6 +3,10 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs, select} from '@storybook/addon-knobs';
 import {DefaultTheme, ThemeShape} from '@twilio-paste/theme-tokens';
 import {Box} from '@twilio-paste/box';
+import {Card} from '@twilio-paste/card';
+import {Heading} from '@twilio-paste/heading';
+import {Paragraph} from '@twilio-paste/paragraph';
+import {Text} from '@twilio-paste/text';
 import {Grid, Column} from '../src';
 
 const spaceOptions = Object.keys(DefaultTheme.space);
@@ -535,6 +539,54 @@ storiesOf('Utilities|Grid', module)
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
+        </Column>
+      </Grid>
+    );
+  })
+  .add('Grid - 3 Column Card Layout', () => {
+    return (
+      <Grid gutter="space70" vertical={[true, false, false]}>
+        <Column>
+          <Card padding="space70">
+            <Heading as="h2">Card Heading</Heading>
+            <Text as="p">Body</Text>
+          </Card>
+        </Column>
+        <Column>
+          <Card padding="space70">
+            <Heading as="h2">Card Heading</Heading>
+            <Text as="p">Body</Text>
+          </Card>
+        </Column>
+        <Column>
+          <Card padding="space70">
+            <Heading as="h2">Card Heading</Heading>
+            <Text as="p">Body</Text>
+          </Card>
+        </Column>
+      </Grid>
+    );
+  })
+  .add('Grid - 2 Column Content with Card', () => {
+    return (
+      <Grid gutter="space70" vertical={[true, false, false]}>
+        <Column span={8}>
+          <Heading as="h2">Content Heading</Heading>
+          <Paragraph>
+            Kale chips distillery authentic, portland etsy cloud bread vinyl gentrify drinking vinegar viral meh hot
+            chicken bitters fashion axe palo santo. Chillwave fixie sustainable <i>helvetica</i> etsy.
+          </Paragraph>
+          <Paragraph>
+            Prism whatever ethical, gochujang <strong>edison bulb</strong> put a bird on it kitsch. Pop-up 90&apos;s la
+            croix tumeric, palo santo chia try-hard direct trade tote bag roof party scenester kitsch stumptown
+            intelligentsia. Literally heirloom blue bottle etsy.
+          </Paragraph>
+        </Column>
+        <Column span={4}>
+          <Card padding="space70">
+            <Heading as="h2">Card Heading</Heading>
+            <Text as="p">Body</Text>
+          </Card>
         </Column>
       </Grid>
     );


### PR DESCRIPTION
@SiTaggart discovered we were using `flex` improperly in `Column`. `Flex` was interfering with children `block` elements an not allowing them to be full width. The `flex` styles are unnecessary because we're calculating a width for each `Column`.

This removes the `Column` `flex` styles, which allows children `block` elements to be 100% width.