### PR TITLE
feat(media-object): add support for the as prop and margin top and bottom

### DIFF
--- a/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -76,11 +76,11 @@ exports[`Alert Variant error Should render an error alert 1`] = `
     className="emotion-4"
     role="alert"
   >
-    <div
+    <span
       className="emotion-3"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -108,13 +108,13 @@ exports[`Alert Variant error Should render an error alert 1`] = `
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an error alert
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;
@@ -288,11 +288,11 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
     className="emotion-8"
     role="alert"
   >
-    <div
+    <span
       className="emotion-7"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -320,13 +320,13 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an error alert
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-6"
         display="flex"
       >
@@ -367,8 +367,8 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
             </span>
           </span>
         </button>
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;
@@ -449,11 +449,11 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
     className="emotion-4"
     role="status"
   >
-    <div
+    <span
       className="emotion-3"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -481,13 +481,13 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an alert
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;
@@ -654,11 +654,11 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
     className="emotion-8"
     role="status"
   >
-    <div
+    <span
       className="emotion-7"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -686,13 +686,13 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an alert
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-6"
         display="flex"
       >
@@ -733,8 +733,8 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
             </span>
           </span>
         </button>
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;
@@ -815,11 +815,11 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
     className="emotion-4"
     role="alert"
   >
-    <div
+    <span
       className="emotion-3"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -847,13 +847,13 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an warning alert
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;
@@ -1027,11 +1027,11 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
     className="emotion-8"
     role="alert"
   >
-    <div
+    <span
       className="emotion-7"
       display="flex"
     >
-      <div
+      <span
         className="emotion-1"
         display="flex"
       >
@@ -1059,13 +1059,13 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
             />
           </svg>
         </span>
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-2"
       >
         This is an warning alert
-      </div>
-      <div
+      </span>
+      <span
         className="emotion-6"
         display="flex"
       >
@@ -1106,8 +1106,8 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
             </span>
           </span>
         </button>
-      </div>
-    </div>
+      </span>
+    </span>
   </div>
 </div>
 `;

--- a/packages/paste-core/utilities/media-object/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/utilities/media-object/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,349 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaBody should render 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+  >
+    default
+  </span>
+</div>
+`;
+
+exports[`MediaBody should render as any HTML element 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+<div
+  className="emotion-1"
+>
+  <article
+    className="emotion-0"
+  >
+    default
+  </article>
+</div>
+`;
+
+exports[`MediaFigure should render 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    default
+  </span>
+</div>
+`;
+
+exports[`MediaFigure should render as any HTML element 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-right: 0;
+}
+
+<div
+  className="emotion-1"
+>
+  <a
+    className="emotion-0"
+    display="flex"
+  >
+    default
+  </a>
+</div>
+`;
+
+exports[`MediaFigure should render with spacing on the left for end alignment 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-left: 0.75rem;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    center align
+  </span>
+</div>
+`;
+
+exports[`MediaFigure should render with spacing on the right for default alignment 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-right: 0.75rem;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    center align
+  </span>
+</div>
+`;
+
+exports[`MediaObject should render 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    default
+  </span>
+</div>
+`;
+
+exports[`MediaObject should render as another HTML element 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+<div
+  className="emotion-1"
+>
+  <section
+    className="emotion-0"
+    display="flex"
+  >
+    background single
+  </section>
+</div>
+`;
+
+exports[`MediaObject should render with center aligned children 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    center align
+  </span>
+</div>
+`;

--- a/packages/paste-core/utilities/media-object/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/utilities/media-object/__tests__/__snapshots__/index.spec.tsx.snap
@@ -308,6 +308,88 @@ exports[`MediaObject should render as another HTML element 1`] = `
 </div>
 `;
 
+exports[`MediaObject should render bottom margin 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    background single
+  </span>
+</div>
+`;
+
+exports[`MediaObject should render top margin 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: 0.75rem;
+}
+
+<div
+  className="emotion-1"
+>
+  <span
+    className="emotion-0"
+    display="flex"
+  >
+    background single
+  </span>
+</div>
+`;
+
 exports[`MediaObject should render with center aligned children 1`] = `
 .emotion-1 {
   font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;

--- a/packages/paste-core/utilities/media-object/__tests__/index.spec.tsx
+++ b/packages/paste-core/utilities/media-object/__tests__/index.spec.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import {ReactWrapper, mount} from 'enzyme';
+import {Theme} from '@twilio-paste/theme';
+import {MediaObject, MediaFigure, MediaBody} from '../src';
+
+describe('MediaObject', () => {
+  it('should render', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaObject>default</MediaObject>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render with center aligned children', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaObject verticalAlign="center">center align</MediaObject>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render as another HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<MediaObject as="section">background single</MediaObject>);
+    expect(wrapper.exists('section')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaObject as="section">background single</MediaObject>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('MediaFigure', () => {
+  it('should render', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaFigure>default</MediaFigure>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render as any HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<MediaFigure as="a">default</MediaFigure>);
+    expect(wrapper.exists('a')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaFigure as="a">default</MediaFigure>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render with spacing on the right for default alignment', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaFigure spacing="space40">center align</MediaFigure>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render with spacing on the left for end alignment', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaFigure align="end" spacing="space40">
+            center align
+          </MediaFigure>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('MediaBody', () => {
+  it('should render', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaBody>default</MediaBody>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render as any HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<MediaBody as="article">default</MediaBody>);
+    expect(wrapper.exists('article')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaBody as="article">default</MediaBody>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/paste-core/utilities/media-object/__tests__/index.spec.tsx
+++ b/packages/paste-core/utilities/media-object/__tests__/index.spec.tsx
@@ -40,6 +40,28 @@ describe('MediaObject', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should render bottom margin', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaObject marginBottom="space40">background single</MediaObject>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render top margin', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <MediaObject marginTop="space40">background single</MediaObject>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });
 
 describe('MediaFigure', () => {

--- a/packages/paste-core/utilities/media-object/src/index.tsx
+++ b/packages/paste-core/utilities/media-object/src/index.tsx
@@ -1,27 +1,28 @@
 import * as React from 'react';
-import {Box} from '@twilio-paste/box';
+import {Box, BoxProps} from '@twilio-paste/box';
 import {Space} from '@twilio-paste/style-props';
 
-export interface MediaObjectProps {
+export interface MediaObjectProps extends Pick<BoxProps, 'as'> {
   verticalAlign?: 'center' | 'top';
 }
 
-const MediaObject: React.FC<MediaObjectProps> = ({children, verticalAlign = 'top'}) => {
+const MediaObject: React.FC<MediaObjectProps> = ({as = 'span', children, verticalAlign = 'top'}) => {
   return (
-    <Box display="flex" alignItems={verticalAlign === 'top' ? 'flex-start' : 'center'}>
+    <Box as={as} display="flex" alignItems={verticalAlign === 'top' ? 'flex-start' : 'center'}>
       {children}
     </Box>
   );
 };
 MediaObject.displayName = 'MediaObject';
 
-export interface MediaFigureProps {
+export interface MediaFigureProps extends Pick<BoxProps, 'as'> {
   align?: 'start' | 'end';
   spacing?: Space;
 }
-const MediaFigure: React.FC<MediaFigureProps> = ({children, align, spacing}) => {
+const MediaFigure: React.FC<MediaFigureProps> = ({as = 'span', children, align, spacing}) => {
   return (
     <Box
+      as={as}
       display="flex"
       flexShrink={0}
       marginLeft={align === 'end' ? spacing : undefined}
@@ -37,8 +38,13 @@ MediaFigure.defaultProps = {
   spacing: 'space0',
 };
 
-const MediaBody: React.FC<{}> = ({children}) => {
-  return <Box flex={1}>{children}</Box>;
+export type MediaBodyProps = Pick<BoxProps, 'as'>;
+const MediaBody: React.FC<MediaBodyProps> = ({as = 'span', children}) => {
+  return (
+    <Box as={as} flex={1}>
+      {children}
+    </Box>
+  );
 };
 MediaBody.displayName = 'MediaBody';
 

--- a/packages/paste-core/utilities/media-object/src/index.tsx
+++ b/packages/paste-core/utilities/media-object/src/index.tsx
@@ -2,13 +2,25 @@ import * as React from 'react';
 import {Box, BoxProps} from '@twilio-paste/box';
 import {Space} from '@twilio-paste/style-props';
 
-export interface MediaObjectProps extends Pick<BoxProps, 'as'> {
+export interface MediaObjectProps extends Pick<BoxProps, 'as' | 'marginTop' | 'marginBottom'> {
   verticalAlign?: 'center' | 'top';
 }
 
-const MediaObject: React.FC<MediaObjectProps> = ({as = 'span', children, verticalAlign = 'top'}) => {
+const MediaObject: React.FC<MediaObjectProps> = ({
+  as = 'span',
+  children,
+  marginBottom,
+  marginTop,
+  verticalAlign = 'top',
+}) => {
   return (
-    <Box as={as} display="flex" alignItems={verticalAlign === 'top' ? 'flex-start' : 'center'}>
+    <Box
+      as={as}
+      display="flex"
+      alignItems={verticalAlign === 'top' ? 'flex-start' : 'center'}
+      marginBottom={marginBottom}
+      marginTop={marginTop}
+    >
       {children}
     </Box>
   );

--- a/packages/paste-core/utilities/media-object/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/media-object/stories/index.stories.tsx
@@ -10,10 +10,21 @@ storiesOf('Utilities|Media Object', module)
   .addDecorator(withKnobs)
   .add('Default', () => {
     const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
+    const marginBottomValue = select(
+      'marginBottom',
+      Object.keys(DefaultTheme.space),
+      'space0'
+    ) as keyof ThemeShape['space'];
+    const marginTopValue = select('marginTop', Object.keys(DefaultTheme.space), 'space0') as keyof ThemeShape['space'];
     const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
     const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
     return (
-      <MediaObject as={asValue} verticalAlign={verticalAlignValue}>
+      <MediaObject
+        as={asValue}
+        verticalAlign={verticalAlignValue}
+        marginBottom={marginBottomValue}
+        marginTop={marginTopValue}
+      >
         <MediaFigure as={asValue} spacing={spaceValue}>
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>
@@ -25,10 +36,21 @@ storiesOf('Utilities|Media Object', module)
   })
   .add('Double Figure', () => {
     const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
+    const marginBottomValue = select(
+      'marginBottom',
+      Object.keys(DefaultTheme.space),
+      'space0'
+    ) as keyof ThemeShape['space'];
+    const marginTopValue = select('marginTop', Object.keys(DefaultTheme.space), 'space0') as keyof ThemeShape['space'];
     const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
     const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
     return (
-      <MediaObject as={asValue} verticalAlign={verticalAlignValue}>
+      <MediaObject
+        as={asValue}
+        verticalAlign={verticalAlignValue}
+        marginBottom={marginBottomValue}
+        marginTop={marginTopValue}
+      >
         <MediaFigure as={asValue} spacing={spaceValue}>
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>

--- a/packages/paste-core/utilities/media-object/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/media-object/stories/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
-import {withKnobs, select} from '@storybook/addon-knobs';
+import {withKnobs, select, text} from '@storybook/addon-knobs';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {DefaultTheme, ThemeShape} from '@twilio-paste/theme-tokens';
@@ -11,12 +11,13 @@ storiesOf('Utilities|Media Object', module)
   .add('Default', () => {
     const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
     const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
+    const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
     return (
-      <MediaObject verticalAlign={verticalAlignValue}>
-        <MediaFigure spacing={spaceValue}>
+      <MediaObject as={asValue} verticalAlign={verticalAlignValue}>
+        <MediaFigure as={asValue} spacing={spaceValue}>
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>
-        <MediaBody>
+        <MediaBody as={asValue}>
           <Text as="p">Some media Object body text</Text>
         </MediaBody>
       </MediaObject>
@@ -25,15 +26,16 @@ storiesOf('Utilities|Media Object', module)
   .add('Double Figure', () => {
     const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
     const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
+    const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
     return (
-      <MediaObject verticalAlign={verticalAlignValue}>
-        <MediaFigure spacing={spaceValue}>
+      <MediaObject as={asValue} verticalAlign={verticalAlignValue}>
+        <MediaFigure as={asValue} spacing={spaceValue}>
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>
-        <MediaBody>
+        <MediaBody as={asValue}>
           <Text as="p">Some media Object body text</Text>
         </MediaBody>
-        <MediaFigure align="end" spacing={spaceValue}>
+        <MediaFigure as={asValue} align="end" spacing={spaceValue}>
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>
       </MediaObject>


### PR DESCRIPTION
In creating these alignment examples https://codesandbox.io/s/vertical-alignment-with-text-using-paste-t1bpn it dawned on me that you need the ability to change the element type to be able to create valid semantic markup.

For example you can't nest a `div` inside a heading element. By pass as down to box, you can now change the markup as you desire to support valid HTML. I also set the default to a span as it's the one element that will work in the most places.

Also adding support for setting margin top and bottom to the outer element

