### PR TITLE
feat: add as support to flex and grid

### DIFF
--- a/packages/paste-core/utilities/flex/__tests__/__snapshots__/flex.test.tsx.snap
+++ b/packages/paste-core/utilities/flex/__tests__/__snapshots__/flex.test.tsx.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Flex Display it should render as any HTML element 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<div
+  className="emotion-1"
+>
+  <article
+    className="emotion-0"
+    display="flex"
+  >
+    child
+  </article>
+</div>
+`;
+
 exports[`Flex Display it should set a display: flex property 1`] = `
 .emotion-2 {
   font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;

--- a/packages/paste-core/utilities/flex/__tests__/flex.test.tsx
+++ b/packages/paste-core/utilities/flex/__tests__/flex.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
+import {ReactWrapper, mount} from 'enzyme';
 import {Theme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
 import {
@@ -202,6 +203,20 @@ describe('Flex Display', () => {
           <Flex>
             <Box padding="space30" backgroundColor="colorBackgroundBrand" width="100%" minHeight="size10" />
           </Flex>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render as any HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<Flex as="article">child</Flex>);
+    expect(wrapper.exists('article')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Flex as="article">child</Flex>
         </Theme.Provider>
       )
       .toJSON();

--- a/packages/paste-core/utilities/flex/src/index.tsx
+++ b/packages/paste-core/utilities/flex/src/index.tsx
@@ -22,6 +22,7 @@ type WrapOptions = boolean;
 export type Wrap = ResponsiveValue<WrapOptions>;
 
 export interface FlexProps extends LayoutProps, MarginProps, PaddingProps {
+  as?: keyof JSX.IntrinsicElements;
   display?: Display;
   vertical?: Vertical;
   vAlignContent?: VerticalAlign;
@@ -188,6 +189,7 @@ const getFlexStyles = (props: FlexProps): FlexboxProps => {
 };
 
 const Flex: React.FC<FlexProps> = ({
+  as,
   basis,
   children,
   display,
@@ -218,6 +220,7 @@ const Flex: React.FC<FlexProps> = ({
     <Box
       {...FlexStyles}
       {...safelySpreadBoxProps(props)}
+      as={as}
       display={display}
       marginTop={marginTop}
       marginRight={marginRight}
@@ -237,6 +240,7 @@ const Flex: React.FC<FlexProps> = ({
 };
 
 Flex.propTypes = {
+  as: PropTypes.string as any,
   display: PropTypes.oneOfType([
     PropTypes.oneOf(['flex', 'inline-flex']),
     PropTypes.arrayOf(PropTypes.oneOf(['flex', 'inline-flex'])),

--- a/packages/paste-core/utilities/flex/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/flex/stories/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
-import {withKnobs, select, boolean, number} from '@storybook/addon-knobs';
+import {withKnobs, select, boolean, number, text} from '@storybook/addon-knobs';
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
 import {Paragraph} from '@twilio-paste/paragraph';
@@ -13,12 +13,14 @@ const flexHorizontalAlignOptions = ['left', 'center', 'right', 'around', 'betwee
 storiesOf('Utilities|Flex', module)
   .addDecorator(withKnobs)
   .add('Flex Alignment Options', () => {
+    const asValue = text('as', 'div') as keyof JSX.IntrinsicElements;
     const flexDisplayValue = select('display', flexDisplayOptions, 'flex') as Display;
     const flexVerticalAlignValue = select('vAlignContent', flexVerticalAlignOptions, 'top') as VerticalAlign;
     const flexHorizontalAlignValue = select('hAlignContent', flexHorizontalAlignOptions, 'left') as HorizontalAlign;
     return (
       <Box padding="space30" borderStyle="solid">
         <Flex
+          as={asValue}
           display={flexDisplayValue}
           vertical={boolean('vertical', false)}
           hAlignContent={flexHorizontalAlignValue}

--- a/packages/paste-core/utilities/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/paste-core/utilities/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -1196,6 +1196,68 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
 </div>
 `;
 
+exports[`Column render it should render 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  width: 8.333333333333332%;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+    width="8.333333333333332%"
+  >
+    child
+  </div>
+</div>
+`;
+
+exports[`Column render it should render as any HTML element 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  width: 8.333333333333332%;
+}
+
+<div
+  className="emotion-2"
+>
+  <article
+    className="emotion-0 emotion-1"
+    width="8.333333333333332%"
+  >
+    child
+  </article>
+</div>
+`;
+
 exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
 .emotion-5 {
   font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
@@ -1491,5 +1553,97 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
       width="50%"
     />
   </div>
+</div>
+`;
+
+exports[`Grid render it should render 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+<div
+  className="emotion-1"
+>
+  <div
+    className="emotion-0"
+    display="flex"
+  >
+    child
+  </div>
+</div>
+`;
+
+exports[`Grid render it should render as any HTML element 1`] = `
+.emotion-1 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-1 *,
+.emotion-1 *::after,
+.emotion-1 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+<div
+  className="emotion-1"
+>
+  <section
+    className="emotion-0"
+    display="flex"
+  >
+    child
+  </section>
 </div>
 `;

--- a/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
+++ b/packages/paste-core/utilities/grid/__tests__/grid.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
+import {ReactWrapper, mount} from 'enzyme';
 import {Theme} from '@twilio-paste/theme';
 import {Grid, Column} from '../src';
 import {getOuterGutterPull, getStackedColumns, getColumnGutters, getColumnOffset, getColumnSpan} from '../src/helpers';
@@ -105,6 +106,60 @@ describe('Grid Unit Tests', () => {
       span: [3, 6, 3],
     };
     expect(getColumnSpan(mockSpan)).toStrictEqual(['25%', '50%', '25%']);
+  });
+});
+
+describe('Grid render', () => {
+  it('it should render', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Grid>child</Grid>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render as any HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<Grid as="section">child</Grid>);
+    expect(wrapper.exists('section')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Grid as="section">child</Grid>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Column render', () => {
+  it('it should render', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Column>child</Column>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it should render as any HTML element', (): void => {
+    const wrapper: ReactWrapper = mount(<Column as="article">child</Column>);
+    expect(wrapper.exists('article')).toEqual(true);
+
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Column as="article">child</Column>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });
 

--- a/packages/paste-core/utilities/grid/src/Column.tsx
+++ b/packages/paste-core/utilities/grid/src/Column.tsx
@@ -36,7 +36,7 @@ const StyledColumn = styled.div(
   )
 ) as React.FC<ColumnProps>;
 
-const Column: React.FC<ColumnProps> = ({children, count, gutter, offset, span, vertical}) => {
+const Column: React.FC<ColumnProps> = ({as, children, count, gutter, offset, span, vertical}) => {
   const theme = useTheme();
 
   const ColumnStyles = React.useMemo(() => getColumnStyles(theme, {count, gutter, offset, span, vertical}), [
@@ -46,10 +46,15 @@ const Column: React.FC<ColumnProps> = ({children, count, gutter, offset, span, v
     span,
     vertical,
   ]);
-  return <StyledColumn {...ColumnStyles}>{children}</StyledColumn>;
+  return (
+    <StyledColumn {...ColumnStyles} as={as}>
+      {children}
+    </StyledColumn>
+  );
 };
 
 Column.propTypes = {
+  as: PropTypes.string as any,
   offset: PropTypes.oneOfType([
     PropTypes.oneOfType([PropTypes.number]),
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number])),

--- a/packages/paste-core/utilities/grid/src/Grid.tsx
+++ b/packages/paste-core/utilities/grid/src/Grid.tsx
@@ -17,7 +17,7 @@ const getGridStyles = (theme: ThemeShape, gutter?: Space): MarginProps => {
   return marginStyles;
 };
 
-const Grid: React.FC<GridProps> = ({children, gutter, marginTop, marginBottom, vertical, ...props}) => {
+const Grid: React.FC<GridProps> = ({as, children, gutter, marginTop, marginBottom, vertical, ...props}) => {
   const theme = useTheme();
 
   const GridColumns = React.useMemo(
@@ -36,6 +36,7 @@ const Grid: React.FC<GridProps> = ({children, gutter, marginTop, marginBottom, v
     <Flex
       {...GridStyles}
       {...safelySpreadBoxProps(props)}
+      as={as}
       marginTop={marginTop}
       marginBottom={marginBottom}
       vertical={vertical}
@@ -46,6 +47,7 @@ const Grid: React.FC<GridProps> = ({children, gutter, marginTop, marginBottom, v
 };
 
 Grid.propTypes = {
+  as: PropTypes.string as any,
   children: PropTypes.node.isRequired,
   vertical: PropTypes.oneOfType([
     PropTypes.oneOfType([PropTypes.bool]),

--- a/packages/paste-core/utilities/grid/src/types.ts
+++ b/packages/paste-core/utilities/grid/src/types.ts
@@ -3,6 +3,7 @@ import {LayoutProps, PaddingProps, Space, SpaceProps} from '@twilio-paste/style-
 import {Vertical} from '@twilio-paste/flex';
 
 export interface GridProps extends SpaceProps {
+  as?: keyof JSX.IntrinsicElements;
   children: NonNullable<React.ReactNode>;
   gutter?: Space;
   vertical?: Vertical;
@@ -22,6 +23,7 @@ export interface ColumnStyleProps extends Omit<LayoutProps, 'minWidth' | 'width'
 }
 
 export interface ColumnProps extends ColumnStyleProps {
+  as?: keyof JSX.IntrinsicElements;
   count?: number;
   gutter?: Space;
   offset?: ColumnOffset;

--- a/packages/paste-core/utilities/grid/stories/index.stories.tsx
+++ b/packages/paste-core/utilities/grid/stories/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
-import {withKnobs, select} from '@storybook/addon-knobs';
+import {withKnobs, select, text} from '@storybook/addon-knobs';
 import {DefaultTheme, ThemeShape} from '@twilio-paste/theme-tokens';
 import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
@@ -14,65 +14,66 @@ const spaceOptions = Object.keys(DefaultTheme.space);
 storiesOf('Utilities|Grid', module)
   .addDecorator(withKnobs)
   .add('Grid - 12 Column and Gutter Support', () => {
+    const asValue = text('as', 'div') as keyof JSX.IntrinsicElements;
     const gutterValue = select('gutter', spaceOptions, 'space0') as keyof ThemeShape['space'];
     return (
-      <Grid gutter={gutterValue}>
-        <Column>
+      <Grid as={asValue} gutter={gutterValue}>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             1
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             2
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             3
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             4
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             5
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             6
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             7
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             8
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             9
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             10
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLighter" height="size40">
             11
           </Box>
         </Column>
-        <Column>
+        <Column as={asValue}>
           <Box backgroundColor="colorBackgroundPrimaryLight" height="size40">
             12
           </Box>

--- a/packages/paste-website/src/pages/utilities/flex/index.mdx
+++ b/packages/paste-website/src/pages/utilities/flex/index.mdx
@@ -321,6 +321,7 @@ import {Flex} from '@twilio-paste/flex';
 
 | Prop           | Type                                                | Description                   | Default |
 | ---------------| ----------------------------------------------------| ----------------------------- | ------- |
+| as?            | `keyof JSX.IntrinsicElements`                       | A custom HTML tag             | `div`   |
 | display?       | `string, ResponsiveValue<'flex', 'inline-flex'>`    | Display property              | 'flex'  |
 | basis?         | `string, number, ResponsiveValue<string, number>`   | Flex basis property           |         |
 | grow?          | `boolean, number, ResponsiveValue<boolean, number>` | Flex grow property            |         |


### PR DESCRIPTION
In creating these alignment examples https://codesandbox.io/s/vertical-alignment-with-text-using-paste-t1bpn it dawned on me that you need the ability to change the element type to be able to create valid semantic markup.

In the example it would have been handy to change the rendered div of `Flex` to be a span so it can be nested in a heading correctly.

Decided to apply the same to `Grid` as I can see you may need to play with the rendered element to create valid HTML in your compositions