### PR TITLE
feat(heading): add marginBottom prop to remove margin

### DIFF
--- a/packages/paste-core/components/heading/__tests__/__snapshots__/heading.test.tsx.snap
+++ b/packages/paste-core/components/heading/__tests__/__snapshots__/heading.test.tsx.snap
@@ -281,3 +281,138 @@ exports[`Heading it should render an italic H2 at fontSize50 1`] = `
   </h2>
 </div>
 `;
+
+exports[`Heading it should render with no margin 1`] = `
+.emotion-6 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-6 *,
+.emotion-6 *::after,
+.emotion-6 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 2rem;
+  font-weight: 500;
+  line-height: 2.5rem;
+  display: block;
+  color: #282a2b;
+}
+
+.emotion-1 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 2rem;
+  display: block;
+  color: #282a2b;
+}
+
+.emotion-2 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.75rem;
+  display: block;
+  color: #282a2b;
+}
+
+.emotion-3 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.75rem;
+  display: block;
+  color: #282a2b;
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  display: block;
+  color: #282a2b;
+}
+
+.emotion-5 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  display: block;
+  color: #282a2b;
+}
+
+<div
+  className="emotion-6"
+>
+  <h2
+    className="emotion-0"
+    display="block"
+    fontSize="fontSize90"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+  <h2
+    className="emotion-1"
+    display="block"
+    fontSize="fontSize70"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+  <h2
+    className="emotion-2"
+    display="block"
+    fontSize="fontSize60"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+  <h2
+    className="emotion-3"
+    display="block"
+    fontSize="fontSize40"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+  <h2
+    className="emotion-4"
+    display="block"
+    fontSize="fontSize30"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+  <h2
+    className="emotion-5"
+    display="block"
+    fontSize="fontSize20"
+    fontWeight="fontWeightSemibold"
+  >
+    no margin heading
+  </h2>
+</div>
+`;

--- a/packages/paste-core/components/heading/__tests__/heading.test.tsx
+++ b/packages/paste-core/components/heading/__tests__/heading.test.tsx
@@ -97,6 +97,34 @@ describe('Heading', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('it should render with no margin', (): void => {
+    const tree = renderer
+      .create(
+        <Theme.Provider theme="console">
+          <Heading as="h2" marginBottom="space0" variant="heading10">
+            no margin heading
+          </Heading>
+          <Heading as="h2" marginBottom="space0" variant="heading20">
+            no margin heading
+          </Heading>
+          <Heading as="h2" marginBottom="space0" variant="heading30">
+            no margin heading
+          </Heading>
+          <Heading as="h2" marginBottom="space0" variant="heading40">
+            no margin heading
+          </Heading>
+          <Heading as="h2" marginBottom="space0" variant="heading50">
+            no margin heading
+          </Heading>
+          <Heading as="h2" marginBottom="space0" variant="heading60">
+            no margin heading
+          </Heading>
+        </Theme.Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should have no accessibility violations', async () => {
     const container = document.createElement('div');
     document.body.append(container);

--- a/packages/paste-core/components/heading/src/index.tsx
+++ b/packages/paste-core/components/heading/src/index.tsx
@@ -9,42 +9,43 @@ export interface HeadingProps {
   as: asTags;
   id?: string;
   className?: never;
+  marginBottom?: 'space0';
   variant?: HeadingVariants;
 }
 
-function getHeadingProps(headingVariant?: HeadingVariants): {} {
+function getHeadingProps(headingVariant?: HeadingVariants, marginBottom?: 'space0'): {} {
   switch (headingVariant) {
     case 'heading10':
       return {
-        marginBottom: 'space70',
+        marginBottom: marginBottom || 'space70',
         fontSize: 'fontSize90',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight90',
       };
     case 'heading30':
       return {
-        marginBottom: 'space50',
+        marginBottom: marginBottom || 'space50',
         fontSize: 'fontSize60',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight60',
       };
     case 'heading40':
       return {
-        marginBottom: 'space40',
+        marginBottom: marginBottom || 'space40',
         fontSize: 'fontSize40',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight40',
       };
     case 'heading50':
       return {
-        marginBottom: 'space30',
+        marginBottom: marginBottom || 'space30',
         fontSize: 'fontSize30',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight30',
       };
     case 'heading60':
       return {
-        marginBottom: 'space30',
+        marginBottom: marginBottom || 'space30',
         fontSize: 'fontSize20',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight20',
@@ -56,7 +57,7 @@ function getHeadingProps(headingVariant?: HeadingVariants): {} {
     case 'heading20':
     default:
       return {
-        marginBottom: 'space60',
+        marginBottom: marginBottom || 'space60',
         fontSize: 'fontSize70',
         fontWeight: 'fontWeightSemibold',
         lineHeight: 'lineHeight70',
@@ -64,9 +65,9 @@ function getHeadingProps(headingVariant?: HeadingVariants): {} {
   }
 }
 
-const Heading: React.FC<HeadingProps> = ({as, children, id, variant}) => {
+const Heading: React.FC<HeadingProps> = ({as, children, id, marginBottom, variant}) => {
   return (
-    <Text {...getHeadingProps(variant)} as={as} display="block" id={id} textColor="colorText">
+    <Text {...getHeadingProps(variant, marginBottom)} as={as} display="block" id={id} textColor="colorText">
       {children}
     </Text>
   );
@@ -74,6 +75,7 @@ const Heading: React.FC<HeadingProps> = ({as, children, id, variant}) => {
 
 Heading.propTypes = {
   as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'] as asTags[]).isRequired,
+  marginBottom: PropTypes.oneOf(['space0']),
   variant: PropTypes.oneOf(['heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60']),
 };
 

--- a/packages/paste-core/components/heading/stories/index.stories.tsx
+++ b/packages/paste-core/components/heading/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withKnobs, text, select} from '@storybook/addon-knobs';
+import {Card} from '@twilio-paste/card';
 import {asTags, Heading, HeadingVariants} from '../src';
 
 const headingVariantOptions = ['heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'];
@@ -9,9 +10,10 @@ storiesOf('Components|Heading', module)
   .addDecorator(withKnobs)
   .add('All variants', () => {
     const asOptions = text('as', 'h2') as asTags;
-    const headingVariantValue = select('variant', headingVariantOptions, 'heading20') as HeadingVariant;
+    const headingVariantValue = select('variant', headingVariantOptions, 'heading20') as HeadingVariants;
+    const marginBottomValue = select('marginBottom', [null, 'space0'], null);
     return (
-      <Heading as={asOptions} variant={headingVariantValue}>
+      <Heading as={asOptions} marginBottom={marginBottomValue} variant={headingVariantValue}>
         I am a Very Large Heading
       </Heading>
     );
@@ -56,5 +58,59 @@ storiesOf('Components|Heading', module)
       <Heading as="h1" variant="heading60">
         I am a Very Large Heading
       </Heading>
+    );
+  })
+  .add('heading10 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading10">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
+    );
+  })
+  .add('heading20 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading20">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
+    );
+  })
+  .add('heading30 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading30">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
+    );
+  })
+  .add('heading40 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading40">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
+    );
+  })
+  .add('heading50 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading50">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
+    );
+  })
+  .add('heading60 no margin', () => {
+    return (
+      <Card>
+        <Heading as="h1" marginBottom="space0" variant="heading60">
+          I am a Very Large Heading
+        </Heading>
+      </Card>
     );
   });

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -6,6 +6,7 @@ description: Headings are words or phrases that are intended to introduce sectio
 
 import {graphql} from 'gatsby';
 import {Box} from '@twilio-paste/box';
+import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
@@ -102,7 +103,7 @@ It is important to not skip one or more heading levels as it is common for scree
 </div>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading10` variant
+### Heading as h2 with heading10 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading10">
@@ -110,7 +111,7 @@ It is important to not skip one or more heading levels as it is common for scree
 </Heading>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading20` variant
+### Heading as h2 with heading20 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading20">
@@ -118,7 +119,7 @@ It is important to not skip one or more heading levels as it is common for scree
 </Heading>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading30` variant
+### Heading as h2 with heading30 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading30">
@@ -126,7 +127,7 @@ It is important to not skip one or more heading levels as it is common for scree
 </Heading>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading40` variant
+### Heading as h2 with heading40 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading40">
@@ -134,7 +135,7 @@ It is important to not skip one or more heading levels as it is common for scree
 </Heading>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading50` variant
+### Heading as h2 with heading50 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading50">
@@ -142,12 +143,22 @@ It is important to not skip one or more heading levels as it is common for scree
 </Heading>`}
 </LivePreview>
 
-#### Heading as `h2` with `heading60` variant
+### Heading as h2 with heading60 variant
 
 <LivePreview scope={{Heading}} language="jsx">
   {`<Heading as="h2" variant="heading60">
   Heading Six
 </Heading>`}
+</LivePreview>
+
+### Heading with no bottom margin
+
+<LivePreview scope={{Heading, Card}} language="jsx">
+  {`<Card>
+  <Heading as="h2" marginBottom="space0" variant="heading10">
+    Heading with no margin
+  </Heading>
+</Card>`}
 </LivePreview>
 
 ## Composition Notes
@@ -199,6 +210,7 @@ import {Heading} from '@twilio-paste/heading';
 | Prop           | Type                  | Description                                                                        | Default          |
 | -------------- | --------------------- | ---------------------------------------------------------------------------------- | ---------------- |
 | as             | asTags                | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                         | null             |
+| marginBottom   | oneOf(['space0'])     | Currently we only allow `space0` to remove bottom margin                           | null             |
 | variant?       | headingVariants       | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'       | 'heading20'      |
 
 <Box marginTop="space90">


### PR DESCRIPTION
Based on a conversation in Slack, a use case was presented where removing the bottom margin on the `Heading` component would be useful.

This can be use when placing headings in contained areas or on top of other components with bounding boxes such as tables.

This PR introduces the `noMargin` prop, which removes margin from a rendered `Heading`