### PR TITLE
feat(website): new modal dialog primitive docs

### DIFF
--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -34,6 +34,7 @@
     "@twilio-paste/icons": "^1.7.0",
     "@twilio-paste/list": "^0.1.10",
     "@twilio-paste/media-object": "^1.2.1",
+    "@twilio-paste/modal-dialog-primitive": "0.1.0",
     "@twilio-paste/paragraph": "^1.0.15",
     "@twilio-paste/screen-reader-only": "^1.1.2",
     "@twilio-paste/style-props": "^0.1.7",

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/ModalDemo.tsx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/ModalDemo.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import {Text} from '@twilio-paste/text';
+import {Button} from '@twilio-paste/button';
+import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '@twilio-paste/modal-dialog-primitive';
+
+const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  background: 'rgba(0, 0, 0, 0.7)',
+});
+
+const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
+  width: '100%',
+  maxWidth: '560px',
+  maxHeight: 'calc(100% - 60px)',
+  background: '#f4f5f6',
+  borderRadius: '5px',
+  padding: '20px',
+});
+
+interface BasicModalDialogProps {
+  isOpen: boolean;
+  handleClose: () => void;
+}
+
+const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}) => {
+  const inputRef = React.useRef(null);
+
+  return (
+    <StyledModalDialogOverlay isOpen={isOpen} onDismiss={handleClose} allowPinchZoom initialFocusRef={inputRef}>
+      <StyledModalDialogContent>
+        <input type="text" value="first" />
+        <br />
+        <input ref={inputRef} type="text" value="second (initial focused)" />
+        <Text as="p" color="colorText">
+          Roll your own dialog!
+        </Text>
+      </StyledModalDialogContent>
+    </StyledModalDialogOverlay>
+  );
+};
+
+export const ModalActivator: React.FC = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleOpen = (): void => setIsOpen(true);
+  const handleClose = (): void => setIsOpen(false);
+
+  return (
+    <div>
+      <Button variant="primary" onClick={handleOpen}>
+        Open Sample Modal
+      </Button>
+      <BasicModalDialog isOpen={isOpen} handleClose={handleClose} />
+    </div>
+  );
+};

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/ModalDemo.tsx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/ModalDemo.tsx
@@ -47,7 +47,7 @@ const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}
   );
 };
 
-export const ModalActivator: React.FC = () => {
+const ModalActivator: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const handleOpen = (): void => setIsOpen(true);
   const handleClose = (): void => setIsOpen(false);
@@ -61,3 +61,5 @@ export const ModalActivator: React.FC = () => {
     </div>
   );
 };
+
+export default ModalActivator;

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -1,0 +1,314 @@
+---
+title: Modal Dialog - Primitives
+description: An accessible modal dialog window
+---
+
+import {graphql} from 'gatsby';
+import {ModalDialogPrimitiveContent, ModalDialogPrimitiveOverlay} from '@twilio-paste/modal-dialog-primitive';
+import Changelog from '@twilio-paste/modal-dialog-primitive/CHANGELOG.md';
+import {Anchor} from '@twilio-paste/anchor';
+import {Box} from '@twilio-paste/box';
+import {SidebarCategoryRoutes} from '../../../constants';
+import {Callout, CalloutText} from '../../../components/callout';
+import {DoDont, Do, Dont} from '../../../components/DoDont';
+
+export const pageQuery = graphql`
+  {
+    allPastePrimitive(filter: {name: {eq: "@twilio-paste/modal-dialog-primitive"}}) {
+      edges {
+        node {
+          name
+          description
+          status
+          version
+        }
+      }
+    }
+    mdx(fields: {slug: {eq: "/modal-dialog-primitive/"}}) {
+      headings {
+        depth
+        value
+      }
+    }
+  }
+`;
+
+<ComponentHeader
+  name="Modal Dialog Primitive"
+  categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
+  githubUrl="https://github.com/twilio-labs/paste/tree/master/packages/paste-core/primitives/modal-dialog"
+  storybookUrl="https://twilio-labs.github.io/paste/?path=/story/primitives-modaldialog--custom-overlay-and-content"
+  data={props.data.allPastePrimitive.edges}
+/>
+
+---
+
+<contentwrapper>
+<TableOfContents headings={props.data.mdx.headings} />
+<content>
+
+## Guidelines
+
+### About the Modal Dialog Primitive
+
+The modal dialog primitive is an unstyled and barebones version of a [Modal dialog](https://www.w3.org/TR/wai-aria-practices/#dialog_modal).
+It handles the implementation details around accessibility and provides a robust API to
+build upon. For example, our Modal component (Link TBD) will be built on top of this primitive.
+If you find that our designed Modal component can’t work for your particular use case,
+we suggest falling back to this component to roll your own solution. We encourage
+using this code as a basis for all modal dialogs in order to avoid code fragmentation
+and accessibility issues in our products.
+
+## Usage Guide
+
+This package is a wrapper around [`@reach/dialog`](https://reacttraining.com/reach-ui/dialog). If
+you’re wondering why we wrapped that package into our own, we reasoned that it would be best
+for our consumers’ developer experience. With reasons such as:
+
+- We can control which APIs we expose and how to expose them. For example, in this package we rename
+  and export only some of the source package's exports.
+- If we want to migrate the underlying nuts and bolts in the future, Twilio products that
+  depend on this primitive would need to replace all occurrences of `import … from ‘@reach/dialog’`
+  to `import … from ‘@some-new/package’`. By wrapping it in `@twilio-paste/modal-dialog-primitive`,
+  this refactor can be avoided. The only change would be a version bump in the package.json file.
+- We can more strictly enforce semver and backwards compatibility than some of our dependencies.
+- We can control when to provide an update and which versions we whitelist, to help reduce
+  potential bugs our consumers may face.
+
+
+#### Installation
+
+This package is available individually or as part of `@twilio-paste/core`.
+
+```
+yarn add @twilio-paste/modal-dialog-primitive
+```
+
+#### Usage Example
+
+You can see this exact code [running in our storybook page](https://twilio-labs.github.io/paste/?path=/story/primitives-modaldialog--custom-overlay-and-content).
+
+```
+import * as React from 'react';
+import styled from '@emotion/styled';
+import {Text} from '@twilio-paste/text';
+import {Button} from '@twilio-paste/button';
+import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '../src';
+
+const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  background: 'rgba(0, 0, 0, 0.7)',
+});
+
+const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
+  width: '100%',
+  maxWidth: '560px',
+  maxHeight: 'calc(100% - 60px)',
+  background: '#f4f5f6',
+  borderRadius: '5px',
+  padding: '20px',
+});
+
+interface BasicModalDialogProps {
+  isOpen: boolean;
+  handleClose: () => void;
+}
+
+const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}) => {
+  const inputRef = React.useRef();
+
+  return (
+    <StyledModalDialogOverlay
+      isOpen={isOpen}
+      onDismiss={handleClose}
+      allowPinchZoom={true}
+      initialFocusRef={inputRef}
+    >
+      <StyledModalDialogContent>
+        <input type="text" value="first" />
+        <br />
+        <input ref={inputRef} type="text" value="second (initial focused)" />
+        <Text as="p" color="colorText">
+          Roll your own dialog!
+        </Text>
+      </StyledModalDialogContent>
+    </StyledModalDialogOverlay>
+  );
+};
+
+const ModalActivator: React.FC = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleOpen = (): void => setIsOpen(true);
+  const handleClose = (): void => setIsOpen(false);
+
+  return (
+    <div>
+      <Button variant="primary" onClick={handleOpen}>
+        Open Modal
+      </Button>
+      <BasicModalDialog isOpen={isOpen} handleClose={handleClose} />
+    </div>
+  );
+};
+```
+
+### API
+
+<Callout>
+  <CalloutText>
+    Much of the following is copied directly from <Anchor href="https://reacttraining.com/reach-ui/dialog/">reach-ui's docs</Anchor>. 
+    Because we may update at a different cadence, we're duplicating the docs here to prevent inconsistent
+    behaviors.</CalloutText>
+</Callout>
+
+#### ModalDialogPrimitiveOverlay Props
+
+All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
+
+| Prop             | Type            | Default |
+| ---------------- | --------------- | ------- |
+| isOpen           | bool            | false   |
+| allowPinchZoom?  | bool            | false   |
+| onDismiss?       | (event) => void | noop    |
+| initialFocusRef? | ref             | null    |
+| children         | node            | null    |
+
+##### `isOpen` prop
+
+Controls whether the dialog is open or not.
+
+```
+<ModalDialogPrimitiveOverlay isOpen={true}>
+  <p>I will be open</p>
+</ModalDialogPrimitiveOverlay>
+
+<ModalDialogPrimitiveOverlay isOpen={false}>
+  <p>I will be closed</p>
+</ModalDialogPrimitiveOverlay>
+```
+
+##### `allowPinchZoom` prop
+
+Controls whether the dialog should allow zoom/pinch gestures on iOS devices.
+
+##### `onDismiss` prop
+
+This function is called whenever the user hits "Escape" or clicks outside the dialog.
+It's important to close the dialog when onDismiss is fired, as seen in all the demos on this page.
+
+The only time you _shouldn't_ close the dialog onDismiss is when the dialog requires a
+choice and none of them are "cancel". For example, perhaps two records need to be merged
+and the user needs to pick the surviving record. Neither choice is less destructive than
+the other, in these cases you may want to alert the user they need to a make a choice
+onDismiss instead of closing the dialog.
+
+```
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
+    <div>
+      <button onClick={open}>Show Dialog</button>
+      <ModalDialogPrimitiveOverlay isOpen={showDialog} onDismiss={close}>
+        <ModalDialogPrimitiveContent>
+          <Text as="p">
+            It is your job to close this with state when the user clicks outside
+            or presses escape.
+          </Text>
+          <button onClick={close}>Okay</button>
+        </ModalDialogPrimitiveContent>
+      </ModalDialogPrimitiveOverlay>
+    </div>
+  );
+}
+```
+
+```
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const [showWarning, setShowWarning] = React.useState(false);
+  const open = () => {
+    setShowDialog(true);
+    setShowWarning(false);
+  };
+  const close = () => setShowDialog(false);
+  const dismiss = () => setShowWarning(true);
+
+  return (
+    <div>
+      <button onClick={open}>Show Dialog</button>
+      <ModalDialogPrimitiveOverlay isOpen={showDialog} onDismiss={close}>
+        <ModalDialogPrimitiveContent>
+          {showWarning && (
+            <p style={{ color: "red" }}>You must make a choice, sorry :(</p>
+          )}
+          <p>Which router should survive the merge?</p>
+          <button onClick={close}>React Router</button>{" "}
+          <button onClick={close}>@reach/router</button>
+        </ModalDialogPrimitiveContent>
+      </ModalDialogPrimitiveOverlay>
+    </div>
+  );
+}
+```
+
+##### `initialFocusRef` prop
+
+By default the first focusable element will receive focus when the dialog opens but you
+can provide a ref to focus instead.
+
+```
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const buttonRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (    
+    <div>      
+      <button onClick={open}>Show Dialog</button>      
+      {showDialog && (        
+        <ModalDialogPrimitiveOverlay initialFocusRef={buttonRef} onDismiss={close}>          
+          <ModalDialogPrimitiveContent>            
+            <p>Pass the button ref to DialogOverlay and the button.</p>            
+            <button onClick={close}>Not me</button> 
+            <button
+              ref={buttonRef}      
+              onClick={close}
+            >              
+              Got me!
+            </button>
+          </ModalDialogPrimitiveContent>        
+        </ModalDialogPrimitiveOverlay>      
+      )}    
+    </div>
+  );
+}
+```
+
+#### ModalDialogPrimitiveContent Props
+
+All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
+
+| Prop             | Type            | Default |
+| ---------------- | --------------- | ------- |
+| children         | node            | null    |
+
+
+<Box marginTop="space130">
+  <Changelog />
+</Box>
+
+</content>
+
+</contentwrapper>
+```

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -11,6 +11,7 @@ import {Box} from '@twilio-paste/box';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {Callout, CalloutText} from '../../../components/callout';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {ModalActivator} from './ModalDemo.tsx';
 
 export const pageQuery = graphql`
   {
@@ -86,14 +87,18 @@ yarn add @twilio-paste/modal-dialog-primitive
 
 #### Usage Example
 
-You can see this exact code [running in our storybook page](https://twilio-labs.github.io/paste/?path=/story/primitives-modaldialog--custom-overlay-and-content).
+<Box
+  paddingBottom="space80"
+>
+  <ModalActivator />
+</Box>
 
 ```
 import * as React from 'react';
 import styled from '@emotion/styled';
 import {Text} from '@twilio-paste/text';
 import {Button} from '@twilio-paste/button';
-import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '../src';
+import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '@twilio-paste/modal-dialog-primitive';
 
 const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
   position: 'fixed',
@@ -125,7 +130,7 @@ const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}
   const inputRef = React.useRef();
 
   return (
-    <StyledModalDialogOverlay
+    <StyledModalDialogOverlay 
       isOpen={isOpen}
       onDismiss={handleClose}
       allowPinchZoom={true}
@@ -143,7 +148,7 @@ const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}
   );
 };
 
-const ModalActivator: React.FC = () => {
+export const ModalActivator: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const handleOpen = (): void => setIsOpen(true);
   const handleClose = (): void => setIsOpen(false);
@@ -151,7 +156,7 @@ const ModalActivator: React.FC = () => {
   return (
     <div>
       <Button variant="primary" onClick={handleOpen}>
-        Open Modal
+        Open Sample Modal
       </Button>
       <BasicModalDialog isOpen={isOpen} handleClose={handleClose} />
     </div>

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -11,7 +11,7 @@ import {Box} from '@twilio-paste/box';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {Callout, CalloutText} from '../../../components/callout';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
-import {ModalActivator} from './ModalDemo.tsx';
+import ModalDemo from './ModalDemo.tsx';
 
 export const pageQuery = graphql`
   {
@@ -90,7 +90,7 @@ yarn add @twilio-paste/modal-dialog-primitive
 <Box
   paddingBottom="space80"
 >
-  <ModalActivator />
+  <ModalDemo />
 </Box>
 
 ```


### PR DESCRIPTION
Adds documentation to our doc site for the new modal dialog primitive component.

Things to note:
- I played around with the page structure a bit.  For example, `API` doesn't wrap everything in `Usage Guide` like it does elsewhere. 
Before:
![image](https://user-images.githubusercontent.com/1592327/75188055-1402a680-5711-11ea-8745-5e398dff432f.png)
After: 
![image](https://user-images.githubusercontent.com/1592327/75188121-30064800-5711-11ea-941a-76880663477e.png)

- I added two sections for props, one for each exported component.  
- Guidelines is fairly simple because this is a primitive, the bulk of the docs fall under the Usage guidelines.
- I give credit to `reach-ui` a few times so this doesn't read like blatant theft 😟 
- The `LivePreview` component doesn't work with Modals.  No biggie, I link to Storybook.