### PR TITLE
feat(box): allow passing tokens via pseudo-class props

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/react-test-renderer": "^16.8.2",
     "@types/storybook__addon-info": "^5.2.1",
     "@types/styled-system": "^5.1.2",
+    "@types/styled-system__css": "^5.0.5",
     "@types/webpack": "^4.4.34",
     "@types/webpack-env": "^1.13.9",
     "@typescript-eslint/eslint-plugin": "^1.11.0",

--- a/packages/paste-core/components/alert/package.json
+++ b/packages/paste-core/components/alert/package.json
@@ -30,6 +30,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.14",
+    "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/absolute": "^2.0.17",
     "@twilio-paste/box": "^2.1.12",

--- a/packages/paste-core/components/button/package.json
+++ b/packages/paste-core/components/button/package.json
@@ -30,6 +30,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/absolute": "^2.0.17",
     "@twilio-paste/box": "^2.1.12",

--- a/packages/paste-core/components/card/package.json
+++ b/packages/paste-core/components/card/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/box": "^2.1.12",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/style-props": "^0.1.10",

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -49,6 +49,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/icons": "^2.0.1",

--- a/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
+++ b/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
@@ -473,6 +473,152 @@ exports[`Spaces (B)it should render responsive values 1`] = `
 </div>
 `;
 
+exports[`ZIndex Pseudo-class props it should generate pseudo-class CSS 1`] = `
+.emotion-2 {
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #282a2b;
+  font-weight: 400;
+}
+
+.emotion-2 *,
+.emotion-2 *::after,
+.emotion-2 *::before {
+  box-sizing: border-box;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+.emotion-0:hover {
+  padding: 0.125rem;
+}
+
+.emotion-0:active,
+.emotion-0[data-active=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0:focus {
+  padding: 0.125rem;
+}
+
+.emotion-0:visited {
+  padding: 0.125rem;
+}
+
+.emotion-0:nth-of-type(even) {
+  padding: 0.125rem;
+}
+
+.emotion-0:nth-of-type(odd) {
+  padding: 0.125rem;
+}
+
+.emotion-0:disabled,
+.emotion-0:disabled:focus,
+.emotion-0:disabled:hover,
+.emotion-0[aria-disabled=true],
+.emotion-0[aria-disabled=true]:focus,
+.emotion-0[aria-disabled=true]:hover {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-checked=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-checked=mixed] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-selected=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-invalid=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-pressed=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-readonly=true],
+.emotion-0[readonly] {
+  padding: 0.125rem;
+}
+
+.emotion-0:first-of-type {
+  padding: 0.125rem;
+}
+
+.emotion-0:last-of-type {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-expanded=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0[aria-grabbed=true] {
+  padding: 0.125rem;
+}
+
+.emotion-0:not(:first-of-type) {
+  padding: 0.125rem;
+}
+
+.emotion-0:not(:last-of-type) {
+  padding: 0.125rem;
+}
+
+[role=group]:hover .emotion-0 {
+  padding: 0.125rem;
+}
+
+.emotion-0:before {
+  padding: 0.125rem;
+}
+
+.emotion-0:after {
+  padding: 0.125rem;
+}
+
+.emotion-0:focus-within {
+  padding: 0.125rem;
+}
+
+.emotion-0::-webkit-input-placeholder {
+  padding: 0.125rem;
+}
+
+.emotion-0::-moz-placeholder {
+  padding: 0.125rem;
+}
+
+.emotion-0:-ms-input-placeholder {
+  padding: 0.125rem;
+}
+
+.emotion-0::placeholder {
+  padding: 0.125rem;
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    PseudoBox
+  </div>
+</div>
+`;
+
 exports[`ZIndex it should render responsive values 1`] = `
 .emotion-2 {
   font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;

--- a/packages/paste-core/primitives/box/__tests__/box.test.tsx
+++ b/packages/paste-core/primitives/box/__tests__/box.test.tsx
@@ -201,4 +201,44 @@ describe('ZIndex', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  describe('Pseudo-class props', () => {
+    it('it should generate pseudo-class CSS', (): void => {
+      const tree = renderer
+        .create(
+          <Theme.Provider theme="console">
+            <Box
+              _hover={{padding: 'space10'}}
+              _active={{padding: 'space10'}}
+              _focus={{padding: 'space10'}}
+              _visited={{padding: 'space10'}}
+              _even={{padding: 'space10'}}
+              _odd={{padding: 'space10'}}
+              _disabled={{padding: 'space10'}}
+              _checked={{padding: 'space10'}}
+              _mixed={{padding: 'space10'}}
+              _selected={{padding: 'space10'}}
+              _invalid={{padding: 'space10'}}
+              _pressed={{padding: 'space10'}}
+              _readOnly={{padding: 'space10'}}
+              _first={{padding: 'space10'}}
+              _last={{padding: 'space10'}}
+              _expanded={{padding: 'space10'}}
+              _grabbed={{padding: 'space10'}}
+              _notFirst={{padding: 'space10'}}
+              _notLast={{padding: 'space10'}}
+              _groupHover={{padding: 'space10'}}
+              _before={{padding: 'space10'}}
+              _after={{padding: 'space10'}}
+              _focusWithin={{padding: 'space10'}}
+              _placeholder={{padding: 'space10'}}
+            >
+              PseudoBox
+            </Box>
+          </Theme.Provider>
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/paste-core/primitives/box/package.json
+++ b/packages/paste-core/primitives/box/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/style-props": "^0.1.10",
     "@twilio-paste/theme-tokens": "^3.1.0",

--- a/packages/paste-core/primitives/box/src/PseudoPropStyles.ts
+++ b/packages/paste-core/primitives/box/src/PseudoPropStyles.ts
@@ -1,0 +1,31 @@
+/**
+ * The selectors are based on [WAI-ARIA state properties](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties) and common CSS Selectors
+ * Based on the excellent work done in https://github.com/chakra-ui/chakra-ui
+ */
+export const PseudoPropStyles: {[key: string]: string} = {
+  _hover: '&:hover',
+  _active: '&:active, &[data-active=true]',
+  _focus: '&:focus',
+  _visited: '&:visited',
+  _even: '&:nth-of-type(even)',
+  _odd: '&:nth-of-type(odd)',
+  _disabled:
+    '&:disabled, &:disabled:focus, &:disabled:hover, &[aria-disabled=true], &[aria-disabled=true]:focus, &[aria-disabled=true]:hover',
+  _checked: '&[aria-checked=true]',
+  _mixed: '&[aria-checked=mixed]',
+  _selected: '&[aria-selected=true]',
+  _invalid: '&[aria-invalid=true]',
+  _pressed: '&[aria-pressed=true]',
+  _readOnly: '&[aria-readonly=true], &[readonly]',
+  _first: '&:first-of-type',
+  _last: '&:last-of-type',
+  _expanded: '&[aria-expanded=true]',
+  _grabbed: '&[aria-grabbed=true]',
+  _notFirst: '&:not(:first-of-type)',
+  _notLast: '&:not(:last-of-type)',
+  _groupHover: '[role=group]:hover &',
+  _before: '&:before',
+  _after: '&:after',
+  _focusWithin: '&:focus-within',
+  _placeholder: '&::placeholder',
+};

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import {compose, layout, space, background, border, boxShadow, position, flexbox, system} from 'styled-system';
+import css from '@styled-system/css';
 import {
   LayoutProps,
   SpaceProps,
@@ -9,8 +10,32 @@ import {
   PositionProps,
   FlexboxProps,
 } from '@twilio-paste/style-props';
+import {
+  CursorProperty,
+  AppearanceProperty,
+  AnimationProperty,
+  TransformProperty,
+  TransformOriginProperty,
+  VisibilityProperty,
+  WhiteSpaceProperty,
+  UserSelectProperty,
+  PointerEventsProperty,
+  BoxSizingProperty,
+  ResizeProperty,
+  TransitionProperty,
+  ListStyleTypeProperty,
+  ListStylePositionProperty,
+  ListStyleImageProperty,
+  ObjectFitProperty,
+  ObjectPositionProperty,
+  BackgroundAttachmentProperty,
+  OutlineProperty,
+  FloatProperty,
+  WillChangeProperty,
+} from 'csstype';
+import {PseudoPropStyles} from './PseudoPropStyles';
 
-export interface BoxProps
+interface BaseBoxProps
   extends React.HTMLAttributes<any>,
     LayoutProps,
     SpaceProps,
@@ -20,23 +45,109 @@ export interface BoxProps
     PositionProps,
     FlexboxProps {
   as?: keyof JSX.IntrinsicElements;
+  content?: string;
+  cursor?: CursorProperty;
+  appearance?: AppearanceProperty;
+  animation?: AnimationProperty;
+  transform?: TransformProperty;
+  transformOrigin?: TransformOriginProperty<string>;
+  visibility?: VisibilityProperty;
+  whiteSpace?: WhiteSpaceProperty;
+  userSelect?: UserSelectProperty;
+  pointerEvents?: PointerEventsProperty;
+  boxSizing?: BoxSizingProperty;
+  resize?: ResizeProperty;
+  transition?: TransitionProperty;
+  listStyleType?: ListStyleTypeProperty;
+  listStylePosition?: ListStylePositionProperty;
+  listStyleImage?: ListStyleImageProperty;
+  objectFit?: ObjectFitProperty;
+  objectPosition?: ObjectPositionProperty<string>;
+  backgroundAttachment?: BackgroundAttachmentProperty;
+  outline?: OutlineProperty<string>;
+  float?: FloatProperty;
+  willChange?: WillChangeProperty;
 }
 
-const backgroundColor = system({
+interface PseudoStylesProps {
+  _after?: BaseBoxProps;
+  _before?: BaseBoxProps;
+  _focus?: BaseBoxProps;
+  _hover?: BaseBoxProps;
+  _active?: BaseBoxProps;
+  _pressed?: BaseBoxProps;
+  _selected?: BaseBoxProps;
+  _focusWithin?: BaseBoxProps;
+  _invalid?: BaseBoxProps;
+  _disabled?: BaseBoxProps;
+  _grabbed?: BaseBoxProps;
+  _expanded?: BaseBoxProps;
+  _checked?: BaseBoxProps;
+  _mixed?: BaseBoxProps;
+  _odd?: BaseBoxProps;
+  _even?: BaseBoxProps;
+  _visited?: BaseBoxProps;
+  _readOnly?: BaseBoxProps;
+  _first?: BaseBoxProps;
+  _last?: BaseBoxProps;
+  _groupHover?: BaseBoxProps;
+  _notFirst?: BaseBoxProps;
+  _notLast?: BaseBoxProps;
+  _placeholder?: BaseBoxProps;
+}
+
+export interface BoxProps extends BaseBoxProps, PseudoStylesProps {}
+
+const extraConfig = system({
   backgroundColor: {
     property: 'backgroundColor',
     scale: 'backgroundColors',
   },
-});
-
-const borderColor = system({
   borderColor: {
     property: 'borderColor',
     scale: 'borderColors',
   },
+  animation: true,
+  appearance: true,
+  transform: true,
+  transformOrigin: true,
+  visibility: true,
+  whiteSpace: true,
+  userSelect: true,
+  pointerEvents: true,
+  boxSizing: true,
+  cursor: true,
+  resize: true,
+  transition: true,
+  listStyleType: true,
+  listStylePosition: true,
+  listStyleImage: true,
+  objectFit: true,
+  objectPosition: true,
+  backgroundAttachment: {
+    property: 'backgroundAttachment',
+  },
+  outline: true,
+  float: true,
+  willChange: true,
 });
 
-const Box = styled.div(
+const getPseudoStyles = (props: BoxProps): {} => {
+  const pseudoProps = Object.keys(props).filter(propName => propName.startsWith('_'));
+
+  if (pseudoProps.length === 0) {
+    return {};
+  }
+
+  const pseudoStyles = {};
+  pseudoProps.forEach(pseudoProp => {
+    pseudoStyles[PseudoPropStyles[pseudoProp]] = props[pseudoProp];
+  });
+
+  return css(pseudoStyles);
+};
+
+export const Box = styled.div(
   {
     boxSizing: 'border-box',
     minWidth: 0,
@@ -46,14 +157,13 @@ const Box = styled.div(
     layout,
     flexbox,
     background,
-    backgroundColor,
     border,
-    borderColor,
     boxShadow,
-    position
-  )
+    position,
+    extraConfig
+  ),
+  getPseudoStyles
 ) as React.FC<BoxProps>;
-
 Box.displayName = 'Box';
-export {Box};
+
 export * from './SafelySpreadProps';

--- a/packages/paste-core/primitives/box/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/box/stories/index.stories.tsx
@@ -138,4 +138,21 @@ storiesOf('Primitives|Box', module)
         </Text>
       </Box>
     );
+  })
+  .add('Pseudo-classes with props', () => {
+    return (
+      <Box
+        backgroundColor="colorBackgroundPrimaryLight"
+        height="size20"
+        position="relative"
+        _hover={{padding: 'space20', backgroundColor: 'colorBackgroundPrimaryLighter'}}
+        _first={{margin: 'space10'}}
+        _before={{content: `"Before text"`, position: 'absolute', bottom: 0, left: 0}}
+        _after={{content: `"After text"`, position: 'absolute', bottom: 0, right: 0}}
+      >
+        <Text as="p" textColor="colorText">
+          Hover this box
+        </Text>
+      </Box>
+    );
   });

--- a/packages/paste-core/utilities/absolute/package.json
+++ b/packages/paste-core/utilities/absolute/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/box": "^2.1.12",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/style-props": "^0.1.10",

--- a/packages/paste-core/utilities/aspect-ratio/package.json
+++ b/packages/paste-core/utilities/aspect-ratio/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/absolute": "^2.0.17",
     "@twilio-paste/box": "^2.1.12",
     "@twilio-paste/design-tokens": "^4.2.0",

--- a/packages/paste-core/utilities/grid/package.json
+++ b/packages/paste-core/utilities/grid/package.json
@@ -30,6 +30,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/box": "^2.1.12",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/flex": "^0.3.4",

--- a/packages/paste-core/utilities/media-object/package.json
+++ b/packages/paste-core/utilities/media-object/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@twilio-paste/box": "^2.1.12",
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/style-props": "^0.1.10",

--- a/packages/paste-theme-tokens/src/console/index.ts
+++ b/packages/paste-theme-tokens/src/console/index.ts
@@ -19,12 +19,18 @@ const breakpoints = [sizings.size40, sizings.size100, sizings.size120];
 
 export const ConsoleTheme = {
   shadows: boxShadows,
-  backgroundColors,
-  borderColors,
   borderWidths,
   radii,
   breakpoints,
-  colors,
+  colors: {
+    ...backgroundColors,
+    ...borderColors,
+    ...textColors,
+    ...colors,
+  },
+  textColors,
+  borderColors,
+  backgroundColors,
   fonts,
   fontSizes,
   fontWeights,
@@ -50,6 +56,5 @@ export const ConsoleTheme = {
     sizeIcon110: sizings.sizeIcon110,
   },
   space: spacings,
-  textColors,
   zIndices,
 };

--- a/packages/paste-theme-tokens/src/default/index.ts
+++ b/packages/paste-theme-tokens/src/default/index.ts
@@ -19,12 +19,18 @@ const breakpoints = [sizings.size40, sizings.size100, sizings.size120];
 
 export const DefaultTheme = {
   shadows: boxShadows,
-  backgroundColors,
-  borderColors,
   borderWidths,
   radii,
   breakpoints,
-  colors,
+  colors: {
+    ...backgroundColors,
+    ...borderColors,
+    ...textColors,
+    ...colors,
+  },
+  textColors,
+  borderColors,
+  backgroundColors,
   fonts,
   fontSizes,
   fontWeights,
@@ -50,6 +56,5 @@ export const DefaultTheme = {
     sizeIcon110: sizings.sizeIcon110,
   },
   space: spacings,
-  textColors,
   zIndices,
 };

--- a/packages/paste-theme-tokens/src/sendgrid/index.ts
+++ b/packages/paste-theme-tokens/src/sendgrid/index.ts
@@ -19,12 +19,18 @@ const breakpoints = [sizings.size40, sizings.size100, sizings.size120];
 
 export const SendGridTheme = {
   shadows: boxShadows,
-  backgroundColors,
-  borderColors,
   borderWidths,
   radii,
   breakpoints,
-  colors,
+  colors: {
+    ...backgroundColors,
+    ...borderColors,
+    ...textColors,
+    ...colors,
+  },
+  textColors,
+  borderColors,
+  backgroundColors,
   fonts,
   fontSizes,
   fontWeights,
@@ -50,6 +56,5 @@ export const SendGridTheme = {
     sizeIcon110: sizings.sizeIcon110,
   },
   space: spacings,
-  textColors,
   zIndices,
 };

--- a/packages/paste-types/package.json
+++ b/packages/paste-types/package.json
@@ -24,13 +24,11 @@
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@types/styled-system": "^5.1.3"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@twilio-paste/design-tokens": "^4.2.0",
     "@twilio-paste/theme-tokens": "^3.1.0",
-    "styled-system": "^5.1.2"
+    "react": "^16.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/mdx": "^1.0.23",
     "@mdx-js/react": "^1.0.23",
     "@mdx-js/tag": "^0.20.3",
+    "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/absolute": "^2.0.17",
     "@twilio-paste/alert": "^0.1.20",

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -83,6 +83,8 @@ resulting accessibility implications.
 
 ### Examples
 
+#### Tokens as props
+
 <LivePreview scope={{Box}} language="jsx">
   {`<Box
   as="article"
@@ -104,6 +106,21 @@ Parent box on the hill side
   >
     Nested box 2 may look the same
   </Box>
+</Box>`}
+</LivePreview>
+
+#### Tokens as pseudo-class props
+
+To view the full list of pseudo-class props, check the [props table](/primitives/box#props).
+
+<LivePreview scope={{Box}} language="jsx">
+  {`<Box
+  backgroundColor="colorBackgroundPrimaryLight"
+  padding="space60"
+  transition="all 200ms ease-in"
+  _hover={{padding: "space30", backgroundColor: "colorBackgroundPrimaryLightest", cursor: "pointer"}}
+>
+Hover over me!
 </Box>`}
 </LivePreview>
 
@@ -196,55 +213,111 @@ yarn add @twilio-paste/box
 ```jsx
 import {Box} from '@twilio-paste/box';
 
-<Box as="article" backgroundColor="colorBackgroundBody" padding="space60">
+<Box 
+  as="article" 
+  backgroundColor="colorBackgroundBody" 
+  padding="space60" 
+  _hover={{
+    backgroundColor: "colorBackgroundPrimary"
+    padding: "space70"
+  }}
+>
   Foo
-</Box>;
+</Box>
 ```
 
 #### Props
 
 All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
 
-| Prop                     | Type                                                    | Description       | Default |
-| ------------------------ | ------------------------------------------------------- | ----------------- | ------- |
-| as?                      | string                                                  | A custom HTML tag | 'div'   |
-| display?                 | `ResponsiveValue<CSS.DisplayProperty>`                  |                   |         |
-| overflow?                | `ResponsiveValue<CSS.OverflowProperty>`                 |                   |         |
-| backgroundColor?         | `ResponsiveValue<keyof ThemeShape['backgroundColors']>` |                   |         |
-| width?                   | `ResponsiveValue<keyof ThemeShape['widths'] | '100%'>`           |                   |         |
-| minWidth?                | `ResponsiveValue<keyof ThemeShape['minWidths']>`        |                   |         |
-| maxWidth?                | `ResponsiveValue<keyof ThemeShape['maxWidths']>`        |                   |         |
-| height?                  | `ResponsiveValue<keyof ThemeShape['heights']>`          |                   |         |
-| minHeight?               | `ResponsiveValue<keyof ThemeShape['minHeights']>`       |                   |         |
-| maxHeight?               | `ResponsiveValue<keyof ThemeShape['maxHeights']>`       |                   |         |
-| margin?                  | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| marginTop?               | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| marginRight?             | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| marginBottom?            | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| marginLeft?              | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| padding?                 | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| paddingTop?              | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| paddingRight?            | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| paddingBottom?           | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| paddingLeft?             | `ResponsiveValue<keyof ThemeShape['space']>`            |                   |         |
-| borderRadius?            | `ResponsiveValue<keyof ThemeShape['radii']>`            |                   |         |
-| borderTopLeftRadius?     | `ResponsiveValue<keyof ThemeShape['radii']>`            |                   |         |
-| borderTopRightRadius?    | `ResponsiveValue<keyof ThemeShape['radii']>`            |                   |         |
-| borderBottomRightRadius? | `ResponsiveValue<keyof ThemeShape['radii']>`            |                   |         |
-| borderBottomLeftRadius?  | `ResponsiveValue<keyof ThemeShape['radii']>`            |                   |         |
-| borderWidth?             | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |                   |         |
-| borderTopWidth?          | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |                   |         |
-| borderRightWidth?        | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |                   |         |
-| borderBottomWidth?       | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |                   |         |
-| borderLeftWidth?         | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |                   |         |
-| borderColor?             | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |                   |         |
-| borderTopColor?          | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |                   |         |
-| borderRightColor?        | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |                   |         |
-| borderBottomColor?       | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |                   |         |
-| borderLeftColor?         | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |                   |         |
-| borderStyle?             | `ResponsiveValue<CSS.BorderStyleProperty>`              |                   |         |
-| boxshadow?               | `ResponsiveValue<keyof ThemeShape['shadows']>`          |                   |         |
-| zIndex?                  | `ResponsiveValue<keyof ThemeShape['zIndices']>`         |                   |         |
+| Prop                     | Type                                                    | Default |
+| ------------------------ | ------------------------------------------------------- | ------- |
+| as?                      | string                                                  | 'div'   |
+| display?                 | `ResponsiveValue<CSS.DisplayProperty>`                  |         |
+| overflow?                | `ResponsiveValue<CSS.OverflowProperty>`                 |         |
+| backgroundColor?         | `ResponsiveValue<keyof ThemeShape['backgroundColors']>` |         |
+| width?                   | `ResponsiveValue<keyof ThemeShape['widths'] \| '100%'>` |         |
+| minWidth?                | `ResponsiveValue<keyof ThemeShape['minWidths']>`        |         |
+| maxWidth?                | `ResponsiveValue<keyof ThemeShape['maxWidths']>`        |         |
+| height?                  | `ResponsiveValue<keyof ThemeShape['heights']>`          |         |
+| minHeight?               | `ResponsiveValue<keyof ThemeShape['minHeights']>`       |         |
+| maxHeight?               | `ResponsiveValue<keyof ThemeShape['maxHeights']>`       |         |
+| margin?                  | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| marginTop?               | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| marginRight?             | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| marginBottom?            | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| marginLeft?              | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| padding?                 | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| paddingTop?              | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| paddingRight?            | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| paddingBottom?           | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| paddingLeft?             | `ResponsiveValue<keyof ThemeShape['space']>`            |         |
+| borderRadius?            | `ResponsiveValue<keyof ThemeShape['radii']>`            |         |
+| borderTopLeftRadius?     | `ResponsiveValue<keyof ThemeShape['radii']>`            |         |
+| borderTopRightRadius?    | `ResponsiveValue<keyof ThemeShape['radii']>`            |         |
+| borderBottomRightRadius? | `ResponsiveValue<keyof ThemeShape['radii']>`            |         |
+| borderBottomLeftRadius?  | `ResponsiveValue<keyof ThemeShape['radii']>`            |         |
+| borderWidth?             | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |         |
+| borderTopWidth?          | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |         |
+| borderRightWidth?        | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |         |
+| borderBottomWidth?       | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |         |
+| borderLeftWidth?         | `ResponsiveValue<keyof ThemeShape['borderWidths']>`     |         |
+| borderColor?             | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |         |
+| borderTopColor?          | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |         |
+| borderRightColor?        | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |         |
+| borderBottomColor?       | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |         |
+| borderLeftColor?         | `ResponsiveValue<keyof ThemeShape['borderColors']>`     |         |
+| borderStyle?             | `ResponsiveValue<CSS.BorderStyleProperty>`              |         |
+| boxshadow?               | `ResponsiveValue<keyof ThemeShape['shadows']>`          |         |
+| zIndex?                  | `ResponsiveValue<keyof ThemeShape['zIndices']>`         |         |
+| cursor?                  | CursorProperty                                          |         |
+| content?                 | string                                                  |         |
+| appearance?              | AppearanceProperty                                      |         |
+| animation?               | AnimationProperty                                       |         |
+| transform?               | TransformProperty                                       |         |
+| transformOrigin?         | TransformOriginProperty                                 |         |
+| visibility?              | VisibilityProperty                                      |         |
+| whiteSpace?              | WhiteSpaceProperty                                      |         |
+| userSelect?              | UserSelectProperty                                      |         |
+| pointerEvents?           | PointerEventsProperty                                   |         |
+| boxSizing?               | BoxSizingProperty                                       |         |
+| resize?                  | ResizeProperty                                          |         |
+| transition?              | TransitionProperty                                      |         |
+| listStyleType?           | ListStyleTypeProperty                                   |         |
+| listStylePosition?       | ListStylePositionProperty                               |         |
+| listStyleImage?          | ListStyleImageProperty                                  |         |
+| objectFit?               | ObjectFitProperty                                       |         |
+| objectPosition?          | ObjectPositionProperty                                  |         |
+| backgroundAttachment?    | BackgroundAttachmentProperty                            |         |
+| outline?                 | OutlineProperty                                         |         |
+| float?                   | FloatProperty                                           |         |
+| willChange?              | WillChangeProperty                                      |         |
+| _hover?                  | BoxProps                                                |         |
+| _active?                 | BoxProps                                                |         |
+| _focus?                  | BoxProps                                                |         |
+| _visited?                | BoxProps                                                |         |
+| _even?                   | BoxProps                                                |         |
+| _odd?                    | BoxProps                                                |         |
+| _disabled?               | BoxProps                                                |         |
+| _checked?                | BoxProps                                                |         |
+| _mixed?                  | BoxProps                                                |         |
+| _selected?               | BoxProps                                                |         |
+| _invalid?                | BoxProps                                                |         |
+| _pressed?                | BoxProps                                                |         |
+| _readOnly?               | BoxProps                                                |         |
+| _first?                  | BoxProps                                                |         |
+| _last?                   | BoxProps                                                |         |
+| _expanded?               | BoxProps                                                |         |
+| _grabbed?                | BoxProps                                                |         |
+| _notFirst?               | BoxProps                                                |         |
+| _notLast?                | BoxProps                                                |         |
+| _groupHover?             | BoxProps                                                |         |
+| _before?                 | BoxProps                                                |         |
+| _after?                  | BoxProps                                                |         |
+| _focusWithin?            | BoxProps                                                |         |
+| _placeholder?            | BoxProps                                                |         |
+
+
 
 <Box marginTop="space90">
   <Changelog />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,6 +4092,13 @@
   dependencies:
     csstype "^2.6.9"
 
+"@types/styled-system__css@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.5.tgz#f3c8036e551fbf603f1ad39cf317fd0e6ad1e431"
+  integrity sha512-JaKYusiRtP3osDx+PhTPP7Ki68mMKoImv/bhr7lK4UFAxeXvveARD5v5rUY0Oy0pfbNkky/nVgHlgGaPbG/JBQ==
+  dependencies:
+    csstype "^2.6.6"
+
 "@types/tapable@*":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"


### PR DESCRIPTION
Inspired from [Chakra-UI's PseudoBox](https://chakra-ui.com/pseudobox).

This component makes Box much more versatile by allowing consumers to use the token props on CSS pseudo-selectors.  