### PR TITLE
fix(website): fix regression in sidebar nav

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.styles.ts
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.styles.ts
@@ -17,7 +17,7 @@ interface SiteNavNestListProps {
   isOpen?: boolean;
 }
 
-export const SiteNavNestList = styled('ul')<SiteNavNestListProps>`
+export const SiteNavNestList = styled(SiteNavList)<SiteNavNestListProps>`
   display: ${props => (props.isOpen ? 'block' : 'none')};
   text-transform: capitalize;
   background-color: ${themeGet('colors.colorGray30')};


### PR DESCRIPTION
I made a small change in trying to fix something our typing issues with upgrading emotion, but forgot to remove it.

This undos that change and fixes a regression.

![](https://p13.f2.n0.cdn.getcloudapp.com/items/12u1zjQK/Image%202020-03-17%20at%2010.46.34.png?v=0e6e17626c2b0c1e82353cb377ac112d)