### PR TITLE
chore: remove the prop build from the main build command

### DIFF
--- a/now-build.sh
+++ b/now-build.sh
@@ -2,4 +2,5 @@
 
 yarn
 yarn build
+yarn build:props
 yarn build:website

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:icons": "yarn workspace @twilio-paste/icons build",
     "build:storybook": "build-storybook -c .storybook -o ./docs",
     "build:website": "yarn workspace @twilio-paste/website build",
+    "build:props": "lerna run build:props --ignore @twilio-paste/website --concurrency 2",
     "pre-push": "concurrently \"yarn:lint\" \"yarn:test\" \"yarn:prettier\" \"yarn:type-check\"",
     "release": "yarn lerna publish -m 'chore(release): publish' --conventional-commits --canary --preid beta",
     "release:stable": "yarn lerna publish -m 'chore(release): publish' --conventional-commits",
@@ -43,7 +44,6 @@
     "package-size-action-build": "yarn bootstrap && yarn build",
     "prettier": "prettier --list-different '{.storybook,packages}/**/*.{ts,tsx}'",
     "prettier-clean": "prettier --write '{.storybook,packages}/**/*.{ts,tsx}'",
-    "props-gen": "lerna run props-gen",
     "lint": "yarn pre-test && eslint --ext .tsx,.ts ./packages/**",
     "type-check": "lerna run type-check"
   },

--- a/packages/paste-core/components/alert/package.json
+++ b/packages/paste-core/components/alert/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -cw --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/anchor/package.json
+++ b/packages/paste-core/components/anchor/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -cw --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/button/package.json
+++ b/packages/paste-core/components/button/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/card/package.json
+++ b/packages/paste-core/components/card/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/form/package.json
+++ b/packages/paste-core/components/form/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/heading/package.json
+++ b/packages/paste-core/components/heading/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/list/package.json
+++ b/packages/paste-core/components/list/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -cw --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/paragraph/package.json
+++ b/packages/paste-core/components/paragraph/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -cw --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/components/spinner/package.json
+++ b/packages/paste-core/components/spinner/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/primitives/box/package.json
+++ b/packages/paste-core/primitives/box/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/primitives/modal-dialog/package.json
+++ b/packages/paste-core/primitives/modal-dialog/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -cw --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/paste-core/primitives/text/package.json
+++ b/packages/paste-core/primitives/text/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/absolute/package.json
+++ b/packages/paste-core/utilities/absolute/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/aspect-ratio/package.json
+++ b/packages/paste-core/utilities/aspect-ratio/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/flex/package.json
+++ b/packages/paste-core/utilities/flex/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/grid/package.json
+++ b/packages/paste-core/utilities/grid/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/media-object/package.json
+++ b/packages/paste-core/utilities/media-object/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/screen-reader-only/package.json
+++ b/packages/paste-core/utilities/screen-reader-only/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-core/utilities/truncate/package.json
+++ b/packages/paste-core/utilities/truncate/package.json
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/paste-icons/package.json
+++ b/packages/paste-icons/package.json
@@ -14,13 +14,13 @@
   ],
   "scripts": {
     "convert": "node ./tools/cli.js convert",
-    "build": "yarn clean && yarn compile && yarn props-gen",
-    "build:dev": "yarn build",
+    "build": "yarn clean && yarn compile",
+    "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./esm && rm -rf ./cjs && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit",
     "list-icons": "node ./tools/cli.js list-icons",
     "convert-new": "node ./tools/cli.js convert-new"

--- a/packages/paste-style-props/package.json
+++ b/packages/paste-style-props/package.json
@@ -16,13 +16,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn props-gen",
+    "build": "yarn clean && yarn compile",
     "build:dev": "yarn clean && yarn compile:dev",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
     "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
-    "props-gen": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
I moved the props-gen build from the main `yarn build` command because it makes my builds take ages to complete.  Instead, it's now isolated in its own `yarn build:props` command which I added to the now config.