### PR TITLE
chore: add prop building to release task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
         run: yarn bootstrap
       - name: Build packages
         run: yarn build
+      - name: Build package props
+        run: yarn build:props
       - name: Publish packages
         run: yarn release:stable:ci
         env:


### PR DESCRIPTION
Package prop building is now a separate task but we publish the output with the package.

We should run this before publishing our packages still.

