### PR TITLE
fix(box): removing min-width

### DIFF
--- a/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Alert Variant error Should render an error alert 1`] = `
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,14 +11,6 @@ exports[`Alert Variant error Should render an error alert 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-6 {
@@ -38,7 +29,6 @@ exports[`Alert Variant error Should render an error alert 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,9 +39,16 @@ exports[`Alert Variant error Should render an error alert 1`] = `
   margin-right: 0.75rem;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-5 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #ffe9e7;
   border-color: #de5858;
   border-bottom-width: 2px;
@@ -79,11 +76,11 @@ exports[`Alert Variant error Should render an error alert 1`] = `
     className="emotion-5"
     role="alert"
   >
-    <span
+    <div
       className="emotion-4"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -111,13 +108,13 @@ exports[`Alert Variant error Should render an error alert 1`] = `
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an error alert
-      </span>
-    </span>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -125,7 +122,6 @@ exports[`Alert Variant error Should render an error alert 1`] = `
 exports[`Alert Variant error Should render an error alert with dismiss button 1`] = `
 .emotion-9 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,14 +130,6 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-11 {
@@ -160,7 +148,6 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -181,9 +168,16 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
   color: #666a6d;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-8 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -269,7 +263,6 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
 
 .emotion-10 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #ffe9e7;
   border-color: #de5858;
   border-bottom-width: 2px;
@@ -297,11 +290,11 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
     className="emotion-10"
     role="alert"
   >
-    <span
+    <div
       className="emotion-9"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -329,12 +322,12 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an error alert
-      </span>
+      </div>
       <span
         className="emotion-8"
         display="flex"
@@ -377,7 +370,7 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
           </span>
         </button>
       </span>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -385,7 +378,6 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
 exports[`Alert Variant neutral Should render a neutral alert 1`] = `
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -394,14 +386,6 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-6 {
@@ -420,7 +404,6 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
 
 .emotion-5 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f5f8ff;
   border-color: #c8cccf;
   border-bottom-width: 2px;
@@ -433,7 +416,6 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -454,6 +436,14 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
   color: #666a6d;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 <div
   className="emotion-6"
 >
@@ -461,11 +451,11 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
     className="emotion-5"
     role="status"
   >
-    <span
+    <div
       className="emotion-4"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -493,13 +483,13 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an alert
-      </span>
-    </span>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -507,7 +497,6 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
 exports[`Alert Variant neutral Should render a neutral alert with dismiss button 1`] = `
 .emotion-9 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -516,14 +505,6 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-11 {
@@ -542,7 +523,6 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
 
 .emotion-10 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f5f8ff;
   border-color: #c8cccf;
   border-bottom-width: 2px;
@@ -555,7 +535,6 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -576,9 +555,16 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
   color: #666a6d;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-8 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -669,11 +655,11 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
     className="emotion-10"
     role="status"
   >
-    <span
+    <div
       className="emotion-9"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -701,12 +687,12 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an alert
-      </span>
+      </div>
       <span
         className="emotion-8"
         display="flex"
@@ -749,7 +735,7 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
           </span>
         </button>
       </span>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -757,7 +743,6 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
 exports[`Alert Variant warning Should render an warning alert 1`] = `
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -766,14 +751,6 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-6 {
@@ -792,7 +769,6 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -803,9 +779,16 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
   margin-right: 0.75rem;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-5 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #ffecd8;
   border-color: #f28510;
   border-bottom-width: 2px;
@@ -833,11 +816,11 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
     className="emotion-5"
     role="alert"
   >
-    <span
+    <div
       className="emotion-4"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -865,13 +848,13 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an warning alert
-      </span>
-    </span>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -879,7 +862,6 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
 exports[`Alert Variant warning Should render an warning alert with dismiss button 1`] = `
 .emotion-9 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -888,14 +870,6 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.emotion-3 {
-  box-sizing: border-box;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .emotion-11 {
@@ -914,7 +888,6 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -935,9 +908,16 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
   color: #666a6d;
 }
 
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-8 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1023,7 +1003,6 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
 
 .emotion-10 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #ffecd8;
   border-color: #f28510;
   border-bottom-width: 2px;
@@ -1051,11 +1030,11 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
     className="emotion-10"
     role="alert"
   >
-    <span
+    <div
       className="emotion-9"
       display="flex"
     >
-      <span
+      <div
         className="emotion-2"
         display="flex"
       >
@@ -1083,12 +1062,12 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
             />
           </svg>
         </span>
-      </span>
-      <span
+      </div>
+      <div
         className="emotion-3"
       >
         This is an warning alert
-      </span>
+      </div>
       <span
         className="emotion-8"
         display="flex"
@@ -1131,7 +1110,7 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
           </span>
         </button>
       </span>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/packages/paste-core/components/alert/src/index.tsx
+++ b/packages/paste-core/components/alert/src/index.tsx
@@ -70,9 +70,11 @@ const Alert: React.FC<AlertProps> = ({children, onDismiss, variant, role, ...pro
       paddingBottom="space30"
       role={role != null ? role : AlertRoles[variant.toUpperCase()]}
     >
-      <MediaObject>
-        <MediaFigure spacing="space40">{renderAlertIcon(variant)}</MediaFigure>
-        <MediaBody>{children}</MediaBody>
+      <MediaObject as="div">
+        <MediaFigure as="div" spacing="space40">
+          {renderAlertIcon(variant)}
+        </MediaFigure>
+        <MediaBody as="div">{children}</MediaBody>
         {onDismiss && typeof onDismiss === 'function' && (
           <MediaFigure align="end" spacing="space70">
             <Button onClick={onDismiss} variant="link" size="reset">

--- a/packages/paste-core/components/alert/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert/stories/index.stories.tsx
@@ -3,6 +3,8 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs, boolean, select} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
 import {Text} from '@twilio-paste/text';
+import {Box} from '@twilio-paste/box';
+import {Truncate} from '@twilio-paste/truncate';
 import {Alert, AlertVariants} from '../src';
 
 storiesOf('Components|Alert', module)
@@ -33,17 +35,22 @@ storiesOf('Components|Alert', module)
             commodo cursus magna.
           </Text>
         </Alert>
-        <Alert variant="neutral" onDismiss={action('dismiss')}>
-          <Text as="div">
-            Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Praesent
-            commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat
-            porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla
-            vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem
-            malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec
-            ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
-          </Text>
-        </Alert>
+        <Box width="size50">
+          <Alert variant="neutral" onDismiss={action('dismiss')}>
+            <Text as="div">
+              Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod.
+              Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus,
+              nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor
+              fringilla. Nulla vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla.
+              Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl
+              consectetur et. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec
+              elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
+            </Text>
+            <Text as="p">
+              <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            </Text>
+          </Alert>
+        </Box>
       </>
     );
   })
@@ -64,17 +71,22 @@ storiesOf('Components|Alert', module)
             commodo cursus magna.
           </Text>
         </Alert>
-        <Alert variant="error">
-          <Text as="div">
-            Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Praesent
-            commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat
-            porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla
-            vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem
-            malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec
-            ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
-          </Text>
-        </Alert>
+        <Box width="size50">
+          <Alert variant="error">
+            <Text as="div">
+              Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod.
+              Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus,
+              nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor
+              fringilla. Nulla vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla.
+              Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl
+              consectetur et. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec
+              elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
+            </Text>
+            <Text as="p">
+              <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            </Text>
+          </Alert>
+        </Box>
       </>
     );
   })
@@ -95,17 +107,22 @@ storiesOf('Components|Alert', module)
             commodo cursus magna.
           </Text>
         </Alert>
-        <Alert variant="warning" onDismiss={action('dismiss')}>
-          <Text as="div">
-            Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Praesent
-            commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat
-            porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla
-            vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem
-            malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec
-            ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
-          </Text>
-        </Alert>
+        <Box width="size50">
+          <Alert variant="warning" onDismiss={action('dismiss')}>
+            <Text as="div">
+              Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod.
+              Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus,
+              nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor
+              fringilla. Nulla vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla.
+              Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl
+              consectetur et. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec
+              elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
+            </Text>
+            <Text as="p">
+              <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            </Text>
+          </Alert>
+        </Box>
       </>
     );
   });

--- a/packages/paste-core/components/button/__tests__/__snapshots__/button.test.tsx.snap
+++ b/packages/paste-core/components/button/__tests__/__snapshots__/button.test.tsx.snap
@@ -385,7 +385,6 @@ exports[`Button States Has a loading state 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   left: 0;
   right: 0;
   top: 0;

--- a/packages/paste-core/components/card/__test__/__snapshots__/card.test.tsx.snap
+++ b/packages/paste-core/components/card/__test__/__snapshots__/card.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Card it should filter out style props that are not allowed 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-width: 2px;
   border-color: #e4e7e9;
   border-style: solid;
@@ -52,7 +51,6 @@ exports[`Card it should render children 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-width: 2px;
   border-color: #e4e7e9;
   border-style: solid;
@@ -89,7 +87,6 @@ exports[`Card it should render default values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-width: 2px;
   border-color: #e4e7e9;
   border-style: solid;
@@ -124,7 +121,6 @@ exports[`Card it should render default values unless overridden by the component
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-width: 2px;
   border-color: #e4e7e9;
   border-style: solid;

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`FormInput render it should render 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +167,6 @@ exports[`FormInput render it should render with disabled 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -274,7 +272,6 @@ exports[`FormInput render it should render with hasError 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -334,7 +331,6 @@ exports[`FormInput render it should render with prefix 1`] = `
 
 .emotion-3 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -404,7 +400,6 @@ exports[`FormInput render it should render with prefix 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -513,7 +508,6 @@ exports[`FormInput render it should render with readOnly 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -574,7 +568,6 @@ exports[`FormInput render it should render with suffix 1`] = `
 
 .emotion-3 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -644,7 +637,6 @@ exports[`FormInput render it should render with suffix 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`FormTextArea render it should render 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formhelptext.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formhelptext.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`FormHelpText render it should render 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -31,6 +30,7 @@ exports[`FormHelpText render it should render 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin-top: 0.25rem;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -75,7 +75,6 @@ exports[`FormHelpText render it should render with an error icon 1`] = `
 
 .emotion-3 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -89,6 +88,7 @@ exports[`FormHelpText render it should render with an error icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin-top: 0.25rem;
+  min-width: 0;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`FormLabel render it should render 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -31,6 +30,7 @@ exports[`FormLabel render it should render 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin-bottom: 0.125rem;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -80,7 +80,6 @@ exports[`FormLabel render it should render with required 1`] = `
 
 .emotion-3 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -94,6 +93,7 @@ exports[`FormLabel render it should render with required 1`] = `
   display: -ms-flexbox;
   display: flex;
   margin-bottom: 0.125rem;
+  min-width: 0;
 }
 
 .emotion-2 {

--- a/packages/paste-core/layout/flex/__tests__/__snapshots__/flex.test.tsx.snap
+++ b/packages/paste-core/layout/flex/__tests__/__snapshots__/flex.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Flex Display it should render as any HTML element 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -30,6 +29,7 @@ exports[`Flex Display it should render as any HTML element 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 <div
@@ -61,7 +61,6 @@ exports[`Flex Display it should set a display: flex property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -74,11 +73,11 @@ exports[`Flex Display it should set a display: flex property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -117,7 +116,6 @@ exports[`Flex Options it should set a flex-basis property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -126,7 +124,6 @@ exports[`Flex Options it should set a flex-basis property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -149,6 +146,7 @@ exports[`Flex Options it should set a flex-basis property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 <div
@@ -183,7 +181,6 @@ exports[`Flex Options it should set a flex-grow property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -192,7 +189,6 @@ exports[`Flex Options it should set a flex-grow property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -215,6 +211,7 @@ exports[`Flex Options it should set a flex-grow property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 <div
@@ -249,7 +246,6 @@ exports[`Flex Options it should set a flex-shrink property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -258,7 +254,6 @@ exports[`Flex Options it should set a flex-shrink property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -281,6 +276,7 @@ exports[`Flex Options it should set a flex-shrink property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 <div
@@ -315,7 +311,6 @@ exports[`Flex Options it should set a responsive flex-basis property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -324,7 +319,6 @@ exports[`Flex Options it should set a responsive flex-basis property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -347,6 +341,7 @@ exports[`Flex Options it should set a responsive flex-basis property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -397,7 +392,6 @@ exports[`Flex Options it should set a responsive flex-grow property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -406,7 +400,6 @@ exports[`Flex Options it should set a responsive flex-grow property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -429,6 +422,7 @@ exports[`Flex Options it should set a responsive flex-grow property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -481,7 +475,6 @@ exports[`Flex Options it should set a responsive flex-shrink property 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   padding: 0.5rem;
   background-color: #233659;
   width: 100%;
@@ -490,7 +483,6 @@ exports[`Flex Options it should set a responsive flex-shrink property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -513,6 +505,7 @@ exports[`Flex Options it should set a responsive flex-shrink property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -563,7 +556,6 @@ exports[`Flex Row it should not set a flex-direction property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -576,11 +568,11 @@ exports[`Flex Row it should not set a flex-direction property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -588,7 +580,6 @@ exports[`Flex Row it should not set a flex-direction property 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -638,7 +629,6 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -651,11 +641,11 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -663,7 +653,6 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -671,7 +660,6 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -687,6 +675,7 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -749,7 +738,6 @@ exports[`Flex Wrap it should not set a flex-wrap property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -762,11 +750,11 @@ exports[`Flex Wrap it should not set a flex-wrap property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -774,7 +762,6 @@ exports[`Flex Wrap it should not set a flex-wrap property 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -824,7 +811,6 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -837,11 +823,11 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -849,7 +835,6 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -857,7 +842,6 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -873,6 +857,7 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -935,7 +920,6 @@ exports[`Horizontal Alignment it should set a justify-content: flex-start proper
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -948,11 +932,11 @@ exports[`Horizontal Alignment it should set a justify-content: flex-start proper
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -960,7 +944,6 @@ exports[`Horizontal Alignment it should set a justify-content: flex-start proper
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1010,7 +993,6 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1023,11 +1005,11 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1035,7 +1017,6 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1043,7 +1024,6 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1056,6 +1036,7 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -1120,7 +1101,6 @@ exports[`Vertical Alignment it should set a align-items: flex-start property 1`]
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1133,11 +1113,11 @@ exports[`Vertical Alignment it should set a align-items: flex-start property 1`]
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1145,7 +1125,6 @@ exports[`Vertical Alignment it should set a align-items: flex-start property 1`]
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1195,7 +1174,6 @@ exports[`Vertical Alignment it should set a responvise align-items property 1`] 
 
 .emotion-1 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1208,11 +1186,11 @@ exports[`Vertical Alignment it should set a responvise align-items property 1`] 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #233659;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1220,7 +1198,6 @@ exports[`Vertical Alignment it should set a responvise align-items property 1`] 
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #f22f46;
   min-width: 12rem;
   min-height: 5.5rem;
@@ -1228,7 +1205,6 @@ exports[`Vertical Alignment it should set a responvise align-items property 1`] 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1241,6 +1217,7 @@ exports[`Vertical Alignment it should set a responvise align-items property 1`] 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {

--- a/packages/paste-core/layout/flex/src/index.tsx
+++ b/packages/paste-core/layout/flex/src/index.tsx
@@ -44,7 +44,7 @@ const Flex: React.FC<FlexProps> = ({
   paddingBottom,
   paddingLeft,
   maxWidth,
-  minWidth,
+  minWidth = 'size0',
   shrink,
   vertical,
   vAlignContent,

--- a/packages/paste-core/layout/flex/stories/index.stories.tsx
+++ b/packages/paste-core/layout/flex/stories/index.stories.tsx
@@ -4,6 +4,7 @@ import {withKnobs, select, boolean, number, text} from '@storybook/addon-knobs';
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
 import {Paragraph} from '@twilio-paste/paragraph';
+import {Truncate} from '@twilio-paste/truncate';
 import {Flex} from '../src';
 import {Display, VerticalAlign, HorizontalAlign} from '../src/types';
 
@@ -343,6 +344,21 @@ storiesOf('Layout|Flex', module)
           </Flex>
           <Flex>
             <Box backgroundColor="colorBackgroundPrimary" minWidth="size20" minHeight="size10" />
+          </Flex>
+        </Flex>
+      </Box>
+    );
+  })
+  .add('Contained width', () => {
+    return (
+      <Box padding="space30" borderStyle="solid" size="size70">
+        <Paragraph>Text should not cause the flex boxes to break out of their containers when too long.</Paragraph>
+        <Flex>
+          <Flex>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          </Flex>
+          <Flex>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
           </Flex>
         </Flex>
       </Box>

--- a/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -32,6 +31,7 @@ exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -78,7 +78,6 @@ exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid
 
 .emotion-6 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -93,6 +92,7 @@ exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-4 {
@@ -143,7 +143,6 @@ exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -158,6 +157,7 @@ exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -200,7 +200,6 @@ exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -215,6 +214,7 @@ exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -261,7 +261,6 @@ exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -276,6 +275,7 @@ exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -322,7 +322,6 @@ exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -337,6 +336,7 @@ exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -383,7 +383,6 @@ exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -398,6 +397,7 @@ exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -444,7 +444,6 @@ exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -459,6 +458,7 @@ exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -505,7 +505,6 @@ exports[`12 Column Options it should render a grid with 1 column 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -520,6 +519,7 @@ exports[`12 Column Options it should render a grid with 1 column 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -558,7 +558,6 @@ exports[`12 Column Options it should render a grid with 2 columns 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -573,6 +572,7 @@ exports[`12 Column Options it should render a grid with 2 columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -615,7 +615,6 @@ exports[`12 Column Options it should render a grid with 3 columns 1`] = `
 
 .emotion-6 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -630,6 +629,7 @@ exports[`12 Column Options it should render a grid with 3 columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -676,7 +676,6 @@ exports[`12 Column Options it should render a grid with 4 columns 1`] = `
 
 .emotion-8 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -691,6 +690,7 @@ exports[`12 Column Options it should render a grid with 4 columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -741,7 +741,6 @@ exports[`12 Column Options it should render a grid with 6 columns 1`] = `
 
 .emotion-12 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -756,6 +755,7 @@ exports[`12 Column Options it should render a grid with 6 columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -814,7 +814,6 @@ exports[`12 Column Options it should render a grid with 12 columns 1`] = `
 
 .emotion-24 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -829,6 +828,7 @@ exports[`12 Column Options it should render a grid with 12 columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -911,7 +911,6 @@ exports[`Column Offset Prop it should render two columns, one with a offset 1`] 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -926,6 +925,7 @@ exports[`Column Offset Prop it should render two columns, one with a offset 1`] 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -973,7 +973,6 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -988,6 +987,7 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-2 {
@@ -1055,7 +1055,6 @@ exports[`Column Span Prop it should render two columns with different responsive
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1070,6 +1069,7 @@ exports[`Column Span Prop it should render two columns with different responsive
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -1152,7 +1152,6 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1167,6 +1166,7 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -1275,7 +1275,6 @@ exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1290,6 +1289,7 @@ exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
   display: flex;
   margin-right: -0.25rem;
   margin-left: -0.25rem;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -1334,7 +1334,6 @@ exports[`Grid Gutter Prop it should render two columns with responsive gutters 1
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1349,6 +1348,7 @@ exports[`Grid Gutter Prop it should render two columns with responsive gutters 1
   display: flex;
   margin-right: -0.125rem;
   margin-left: -0.125rem;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -1421,7 +1421,6 @@ exports[`Grid Vertical Prop it should render two columns stacked only on mobile 
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1439,6 +1438,7 @@ exports[`Grid Vertical Prop it should render two columns stacked only on mobile 
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 @media screen and (min-width:25rem) {
@@ -1511,7 +1511,6 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1529,6 +1528,7 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 .emotion-0 {
@@ -1573,7 +1573,6 @@ exports[`Grid render it should render 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1588,6 +1587,7 @@ exports[`Grid render it should render 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 <div
@@ -1619,7 +1619,6 @@ exports[`Grid render it should render as any HTML element 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1634,6 +1633,7 @@ exports[`Grid render it should render as any HTML element 1`] = `
   display: flex;
   margin-right: auto;
   margin-left: auto;
+  min-width: 0;
 }
 
 <div

--- a/packages/paste-core/layout/grid/stories/index.stories.tsx
+++ b/packages/paste-core/layout/grid/stories/index.stories.tsx
@@ -7,6 +7,7 @@ import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {Text} from '@twilio-paste/text';
+import {Truncate} from '@twilio-paste/truncate';
 import {Grid, Column} from '../src';
 
 const spaceOptions = Object.keys(DefaultTheme.space);
@@ -590,5 +591,30 @@ storiesOf('Layout|Grid', module)
           </Card>
         </Column>
       </Grid>
+    );
+  })
+  .add('Grid - Containing long content', () => {
+    return (
+      <Box width="size50">
+        <Text as="p" marginBottom="space100">
+          Proving that long content shouldn&rsquo;t break out from it&rsquo;s flex container width
+        </Text>
+        <Grid gutter="space70">
+          <Column span={8}>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          </Column>
+          <Column span={4}>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          </Column>
+        </Grid>
+        <Grid gutter="space70">
+          <Column>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          </Column>
+          <Column>
+            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          </Column>
+        </Grid>
+      </Box>
     );
   });

--- a/packages/paste-core/layout/media-object/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/layout/media-object/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,10 +17,10 @@ exports[`MediaBody should render 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  min-width: 0;
 }
 
 <div
@@ -51,10 +51,10 @@ exports[`MediaBody should render as any HTML element 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  min-width: 0;
 }
 
 <div
@@ -85,7 +85,6 @@ exports[`MediaFigure should render 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -125,7 +124,6 @@ exports[`MediaFigure should render as any HTML element 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -165,7 +163,6 @@ exports[`MediaFigure should render with spacing on the left for end alignment 1`
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,7 +202,6 @@ exports[`MediaFigure should render with spacing on the right for default alignme
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -245,7 +241,6 @@ exports[`MediaObject should render 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -285,7 +280,6 @@ exports[`MediaObject should render as another HTML element 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -325,7 +319,6 @@ exports[`MediaObject should render bottom margin 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -366,7 +359,6 @@ exports[`MediaObject should render top margin 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -407,7 +399,6 @@ exports[`MediaObject should render with center aligned children 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/paste-core/layout/media-object/src/index.tsx
+++ b/packages/paste-core/layout/media-object/src/index.tsx
@@ -69,7 +69,7 @@ export type MediaBodyProps = Pick<BoxProps, 'as'>;
 
 const MediaBody: React.FC<MediaBodyProps> = ({as = 'span', children}) => {
   return (
-    <Box as={as} flex={1}>
+    <Box as={as} flex={1} minWidth="size0">
       {children}
     </Box>
   );

--- a/packages/paste-core/layout/media-object/stories/index.stories.tsx
+++ b/packages/paste-core/layout/media-object/stories/index.stories.tsx
@@ -3,6 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs, select, text} from '@storybook/addon-knobs';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
+import {Truncate} from '@twilio-paste/truncate';
 import {DefaultTheme, ThemeShape} from '@twilio-paste/theme';
 import {MediaObject, MediaFigure, MediaBody} from '../src';
 
@@ -61,5 +62,25 @@ storiesOf('Layout|Media Object', module)
           <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
         </MediaFigure>
       </MediaObject>
+    );
+  })
+  .add('Constrained width', () => {
+    return (
+      <Box width="size60">
+        <MediaObject as="div" verticalAlign="center">
+          <MediaFigure as="div" spacing="space100">
+            <Box backgroundColor="colorBackgroundSuccess" size="size20" />
+          </MediaFigure>
+          <MediaBody as="div">
+            <Text as="p">Some media Object body text</Text>
+            <Text as="p">
+              <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            </Text>
+          </MediaBody>
+          <MediaFigure as="div" align="end" spacing="space70">
+            <Box backgroundColor="colorBackgroundSuccess" height="size10" minWidth="size10" />
+          </MediaFigure>
+        </MediaObject>
+      </Box>
     );
   });

--- a/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
+++ b/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Backgrounds it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #b3d3e9;
 }
 
@@ -55,7 +54,6 @@ exports[`Backgrounds it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   background-color: #027ac5;
 }
 
@@ -87,7 +85,6 @@ exports[`Borders it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-style: dashed;
   border-color: #003e82;
   border-width: 1px;
@@ -137,7 +134,6 @@ exports[`Borders it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   border-style: solid;
   border-color: #003e82;
   border-width: 1px;
@@ -172,7 +168,6 @@ exports[`Shadows it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   box-shadow: 0 2px 4px 0 rgba(40,42,43,0.3);
 }
 
@@ -210,7 +205,6 @@ exports[`Shadows it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   box-shadow: 0 2px 4px 0 rgba(40,42,43,0.3);
 }
 
@@ -242,7 +236,6 @@ exports[`Sizes it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   width: 5.5rem;
   min-width: 0;
   max-width: 12rem;
@@ -302,7 +295,6 @@ exports[`Sizes it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   width: 5.5rem;
   min-width: 0;
   max-width: 12rem;
@@ -341,7 +333,6 @@ exports[`Spaces (A) it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   margin: 0.25rem;
 }
 
@@ -379,7 +370,6 @@ exports[`Spaces (A) it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   margin: 0.25rem;
 }
 
@@ -411,7 +401,6 @@ exports[`Spaces (B) it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   margin-top: 0.25rem;
   margin-right: 0.25rem;
   margin-bottom: 0.5rem;
@@ -446,7 +435,6 @@ exports[`Spaces (B)it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   margin-top: 0.25rem;
   margin-right: 0.25rem;
   margin-bottom: 0.5rem;
@@ -490,7 +478,6 @@ exports[`ZIndex Pseudo-class props it should generate pseudo-class CSS 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
 }
 
 .emotion-0:hover {
@@ -636,7 +623,6 @@ exports[`ZIndex it should render responsive values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   z-index: 10;
 }
 
@@ -674,7 +660,6 @@ exports[`ZIndex it should render single values 1`] = `
 
 .emotion-0 {
   box-sizing: border-box;
-  min-width: 0;
   z-index: 10;
 }
 

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -151,7 +151,6 @@ const getPseudoStyles = (props: BoxProps): {} => {
 export const Box = styled.div(
   {
     boxSizing: 'border-box',
-    minWidth: 0,
   },
   compose(
     space,


### PR DESCRIPTION
Box having a default `min-width:0` property was causing undesirable effects when flex children were collapsing their containers.

Removing it as a default and only setting it when needed it a safer, more intentional fix.

TODO:
- [x] verify Flex needs it?