### PR TITLE
fix(form): change hover for disabled and readonly input and textarea

### DIFF
--- a/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`FormInput render it should render with disabled 1`] = `
 }
 
 .emotion-2:hover {
-  box-shadow: 0 0 0 1px #030b5d;
+  box-shadow: 0 0 0 1px #e4e7e9;
 }
 
 .emotion-2:focus-within {
@@ -528,7 +528,7 @@ exports[`FormInput render it should render with readOnly 1`] = `
 }
 
 .emotion-2:hover {
-  box-shadow: 0 0 0 1px #030b5d;
+  box-shadow: 0 0 0 1px #606b85;
 }
 
 .emotion-2:focus-within {

--- a/packages/paste-core/components/form/src/shared/FieldWrapper.tsx
+++ b/packages/paste-core/components/form/src/shared/FieldWrapper.tsx
@@ -12,7 +12,7 @@ interface FieldWrapperProps {
 }
 
 const FieldWrapper: React.FC<FieldWrapperProps> = ({disabled, hasError, readOnly, children, type}) => {
-  let boxShadow = 'shadowBorderInput';
+  let boxShadow = 'shadowBorderInput' as BoxShadow;
   let boxShadowHover = 'shadowBorderInputHover' as BoxShadow;
   if (disabled) {
     boxShadow = 'shadowBorderInputDisabled';
@@ -21,8 +21,9 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({disabled, hasError, readOnly
     boxShadowHover = 'shadowBorderInput';
   } else if (hasError) {
     boxShadow = 'shadowBorderInputError';
+    boxShadowHover = 'shadowBorderInputErrorHover';
   } else if (type === 'hidden') {
-    boxShadow = 'none';
+    boxShadow = null;
   }
 
   return (
@@ -30,12 +31,12 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({disabled, hasError, readOnly
       display="flex"
       width="100%"
       backgroundColor={readOnly || disabled ? 'colorBackground' : 'colorBackgroundBody'}
-      boxShadow={boxShadow as BoxShadow}
+      boxShadow={boxShadow}
       borderRadius="borderRadius20"
       transition="box-shadow 100ms ease-in"
       cursor={disabled ? 'not-allowed' : 'text'}
       _hover={{
-        boxShadow: hasError ? 'shadowBorderInputErrorHover' : boxShadowHover,
+        boxShadow: boxShadowHover,
       }}
       _focusWithin={{
         boxShadow: 'shadowFocus',

--- a/packages/paste-core/components/form/src/shared/FieldWrapper.tsx
+++ b/packages/paste-core/components/form/src/shared/FieldWrapper.tsx
@@ -13,8 +13,12 @@ interface FieldWrapperProps {
 
 const FieldWrapper: React.FC<FieldWrapperProps> = ({disabled, hasError, readOnly, children, type}) => {
   let boxShadow = 'shadowBorderInput';
+  let boxShadowHover = 'shadowBorderInputHover' as BoxShadow;
   if (disabled) {
     boxShadow = 'shadowBorderInputDisabled';
+    boxShadowHover = 'shadowBorderInputDisabled';
+  } else if (readOnly) {
+    boxShadowHover = 'shadowBorderInput';
   } else if (hasError) {
     boxShadow = 'shadowBorderInputError';
   } else if (type === 'hidden') {
@@ -31,7 +35,7 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({disabled, hasError, readOnly
       transition="box-shadow 100ms ease-in"
       cursor={disabled ? 'not-allowed' : 'text'}
       _hover={{
-        boxShadow: hasError ? 'shadowBorderInputErrorHover' : 'shadowBorderInputHover',
+        boxShadow: hasError ? 'shadowBorderInputErrorHover' : boxShadowHover,
       }}
       _focusWithin={{
         boxShadow: 'shadowFocus',


### PR DESCRIPTION
- [x] Fix disabled hover
- [x] Fix readOnly hover
- [x] Update snapshot

Fix is in `FieldWrapper` and fixes both `FormInput` and `FormTextArea`