### PR TITLE
feat(form): add autoresizing to the textarea component

### DIFF
--- a/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`FormTextArea render it should render 1`] = `
     width="100%"
   >
     <textarea
+      async={true}
       className="emotion-0 emotion-1"
       id="textarea"
       onChange={[Function]}

--- a/packages/paste-core/components/form/package.json
+++ b/packages/paste-core/components/form/package.json
@@ -58,5 +58,8 @@
     "rollup-plugin-typescript2": "^0.21.2",
     "typedoc": "^0.16.9",
     "typescript": "3.7.5"
+  },
+  "dependencies": {
+    "react-autosize-textarea": "^7.0.0"
   }
 }

--- a/packages/paste-core/components/form/package.json
+++ b/packages/paste-core/components/form/package.json
@@ -60,6 +60,6 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "react-autosize-textarea": "^7.0.0"
+    "react-autosize-textarea": "7.0.0"
   }
 }

--- a/packages/paste-core/components/form/src/FormTextArea.tsx
+++ b/packages/paste-core/components/form/src/FormTextArea.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import css from '@styled-system/css';
+import TextareaAutosize from 'react-autosize-textarea';
 import {FieldWrapper} from './shared/FieldWrapper';
 import {Prefix} from './shared/Prefix';
 import {Suffix} from './shared/Suffix';
@@ -24,7 +25,7 @@ export interface FormTextAreaProps extends React.TextareaHTMLAttributes<HTMLText
 }
 
 /* eslint-disable emotion/syntax-preference */
-const TextAreaElement = styled.textarea(
+const TextAreaElement = styled(TextareaAutosize)(() =>
   css({
     appearance: 'none',
     border: 'none',
@@ -68,6 +69,7 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
           aria-invalid={hasError}
           aria-readonly={readOnly}
           {...props}
+          async
           ref={ref}
           id={id}
           name={name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18815,7 +18815,7 @@ react-addons-create-fragment@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-autosize-textarea@^7.0.0:
+react-autosize-textarea@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz#4f633e4238de7ba73c1da8fdc307353c50f1c5ab"
   integrity sha512-rGQLpGUaELvzy3NKzp0kkcppaUtZTptsyR0PGuLotaJDjwRbT0DpD000yCzETpXseJQ/eMsyVGDDHXjXP93u8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5541,6 +5541,11 @@ autoprefixer@^9.7.2, autoprefixer@^9.7.4:
     postcss "^7.0.26"
     postcss-value-parser "^4.0.2"
 
+autosize@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -7470,6 +7475,11 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
+
+computed-style@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
+  integrity sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -14886,6 +14896,13 @@ limiter@^1.0.5:
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
   integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
 
+line-height@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
+  integrity sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=
+  dependencies:
+    computed-style "~0.1.3"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -18496,7 +18513,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -18797,6 +18814,15 @@ react-addons-create-fragment@^15.6.2:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
+
+react-autosize-textarea@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz#4f633e4238de7ba73c1da8fdc307353c50f1c5ab"
+  integrity sha512-rGQLpGUaELvzy3NKzp0kkcppaUtZTptsyR0PGuLotaJDjwRbT0DpD000yCzETpXseJQ/eMsyVGDDHXjXP93u8w==
+  dependencies:
+    autosize "^4.0.2"
+    line-height "^0.3.1"
+    prop-types "^15.5.6"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
Adding resizing to the textarea component via react-autosize-textarea.

I have not added any tests here as enzyme doesn't seem to detect that styles applied by the library in the style prop. We have to rely on the fact that we're just directly using the library directly and that should have it's own tests. It's annoying, I'm getting annoyed with enzyme.