### PR TITLE
fix(form): enable safely spreading props to form controls

### DIFF
--- a/packages/paste-core/components/form/__tests__/formInput.test.tsx
+++ b/packages/paste-core/components/form/__tests__/formInput.test.tsx
@@ -337,3 +337,21 @@ describe('FormInput event handlers', () => {
     expect(onBlurMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('FormInput block props', () => {
+  const initialProps = {
+    id: 'input',
+    type: 'text' as FormInputTypes,
+    value: 'value',
+    onChange: NOOP,
+    style: {background: 'red'},
+    height: '200px',
+  };
+
+  const container = shallow(<FormInput {...initialProps} />);
+
+  it('should not pass width and classname props', () => {
+    expect(container.find('InputElement').prop('width')).toEqual(undefined);
+    expect(container.find('InputElement').prop('className')).toEqual(undefined);
+  });
+});

--- a/packages/paste-core/components/form/__tests__/formInput.test.tsx
+++ b/packages/paste-core/components/form/__tests__/formInput.test.tsx
@@ -344,8 +344,8 @@ describe('FormInput block props', () => {
     type: 'text' as FormInputTypes,
     value: 'value',
     onChange: NOOP,
-    style: {background: 'red'},
-    height: '200px',
+    className: 'foo',
+    width: '300px',
   };
 
   const container = shallow(<FormInput {...initialProps} />);

--- a/packages/paste-core/components/form/__tests__/formTextarea.test.tsx
+++ b/packages/paste-core/components/form/__tests__/formTextarea.test.tsx
@@ -211,3 +211,20 @@ describe('FormTextArea event handlers', () => {
     expect(onBlurMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('FormTextArea block props', () => {
+  const initialProps = {
+    id: 'textarea',
+    placeholder: 'placeholder',
+    onChange: NOOP,
+    style: {background: 'red'},
+    height: '200px',
+  };
+
+  const container = shallow(<FormTextArea {...initialProps} />);
+
+  it('should not pass height or style props', () => {
+    expect(container.find('TextAreaElement').prop('height')).toEqual(undefined);
+    expect(container.find('TextAreaElement').prop('style')).toEqual(undefined);
+  });
+});

--- a/packages/paste-core/components/form/src/FormInput.tsx
+++ b/packages/paste-core/components/form/src/FormInput.tsx
@@ -6,7 +6,7 @@ import {FieldWrapper} from './shared/FieldWrapper';
 import {Prefix} from './shared/Prefix';
 import {Suffix} from './shared/Suffix';
 import {FormInputTypes} from './shared/types';
-import {safelyFormControlSpreadProps} from './shared/Utils';
+import {safelySpreadFormControlProps} from './shared/Utils';
 
 export interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
@@ -88,7 +88,7 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
         <InputElement
           aria-invalid={hasError}
           aria-readonly={readOnly}
-          {...safelyFormControlSpreadProps(props)}
+          {...safelySpreadFormControlProps(props)}
           {...typeProps}
           ref={ref}
           id={id}

--- a/packages/paste-core/components/form/src/FormInput.tsx
+++ b/packages/paste-core/components/form/src/FormInput.tsx
@@ -6,6 +6,7 @@ import {FieldWrapper} from './shared/FieldWrapper';
 import {Prefix} from './shared/Prefix';
 import {Suffix} from './shared/Suffix';
 import {FormInputTypes} from './shared/types';
+import {safelyFormControlSpreadProps} from './shared/Utils';
 
 export interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
@@ -87,7 +88,7 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
         <InputElement
           aria-invalid={hasError}
           aria-readonly={readOnly}
-          {...props}
+          {...safelyFormControlSpreadProps(props)}
           {...typeProps}
           ref={ref}
           id={id}

--- a/packages/paste-core/components/form/src/FormTextArea.tsx
+++ b/packages/paste-core/components/form/src/FormTextArea.tsx
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 import {FieldWrapper} from './shared/FieldWrapper';
 import {Prefix} from './shared/Prefix';
 import {Suffix} from './shared/Suffix';
-import {safelyFormControlSpreadProps} from './shared/Utils';
+import {safelySpreadFormControlProps} from './shared/Utils';
 
 export interface FormTextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   id: string;
@@ -69,7 +69,7 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
         <TextAreaElement
           aria-invalid={hasError}
           aria-readonly={readOnly}
-          {...safelyFormControlSpreadProps(props)}
+          {...safelySpreadFormControlProps(props)}
           async
           ref={ref}
           id={id}

--- a/packages/paste-core/components/form/src/FormTextArea.tsx
+++ b/packages/paste-core/components/form/src/FormTextArea.tsx
@@ -6,6 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 import {FieldWrapper} from './shared/FieldWrapper';
 import {Prefix} from './shared/Prefix';
 import {Suffix} from './shared/Suffix';
+import {safelyFormControlSpreadProps} from './shared/Utils';
 
 export interface FormTextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   id: string;
@@ -68,7 +69,7 @@ const FormTextArea = React.forwardRef<HTMLTextAreaElement, FormTextAreaProps>(
         <TextAreaElement
           aria-invalid={hasError}
           aria-readonly={readOnly}
-          {...props}
+          {...safelyFormControlSpreadProps(props)}
           async
           ref={ref}
           id={id}

--- a/packages/paste-core/components/form/src/shared/Utils.tsx
+++ b/packages/paste-core/components/form/src/shared/Utils.tsx
@@ -1,6 +1,6 @@
 const PROPS_TO_BLOCK = ['className', 'style', 'size', 'height', 'width'];
 
-export const safelyFormControlSpreadProps = (props: {}): {} => {
+export const safelySpreadFormControlProps = (props: {}): {} => {
   // https://www.measurethat.net/Benchmarks/Show/6642/0/for-in-vs-reduce-vs-pick#latest_results_block
   const newList = Object.keys(props).reduce((newObj, key) => {
     if (!PROPS_TO_BLOCK.includes(key)) {

--- a/packages/paste-core/components/form/src/shared/Utils.tsx
+++ b/packages/paste-core/components/form/src/shared/Utils.tsx
@@ -1,0 +1,13 @@
+const PROPS_TO_BLOCK = ['className', 'style', 'size', 'height', 'width'];
+
+export const safelyFormControlSpreadProps = (props: {}): {} => {
+  // https://www.measurethat.net/Benchmarks/Show/6642/0/for-in-vs-reduce-vs-pick#latest_results_block
+  const newList = Object.keys(props).reduce((newObj, key) => {
+    if (!PROPS_TO_BLOCK.includes(key)) {
+      // eslint-disable-next-line no-param-reassign
+      newObj[key] = props[key];
+    }
+    return newObj;
+  }, {});
+  return newList;
+};


### PR DESCRIPTION
We spread props to the input and textarea. We might block you from doing so in typescript, but I can ignore those and if I'm not using typescript I don't get a warning.

In all cases where we spread props we must manually pluck those banned props from the consumer provided props.

I'm also not convinced about the use of `never` as the props still appear in the auto completion suggestions, only for typescript to then tell you, you can't use it. It's a little confusing.

![image](https://user-images.githubusercontent.com/368249/78179920-dc290600-7416-11ea-9949-7ad9465f264c.png)
