### PR TITLE
fix(style-props): correct width options in the style props proptypes

### DIFF
--- a/packages/paste-style-props/src/proptypes/layout.ts
+++ b/packages/paste-style-props/src/proptypes/layout.ts
@@ -2,8 +2,7 @@ import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
 
 // Tokens
-const Widths = [DefaultTheme.widths, '100%'];
-const WidthOptions = Object.keys(Widths);
+const WidthOptions = ['100%', ...Object.keys(DefaultTheme.widths)];
 const MinWidthOptions = Object.keys(DefaultTheme.minWidths);
 const MaxWidthOptions = Object.keys(DefaultTheme.maxWidths);
 const HeightOptions = Object.keys(DefaultTheme.heights);


### PR DESCRIPTION
The width options given to the style props proptypes for sizing are wrong due to a minor syntax error.

Object.keys on an array will return the indices.