### PR TITLE
fix(website): add overflow-y to do/dont Box

### DIFF
--- a/packages/paste-website/src/components/DoDont.tsx
+++ b/packages/paste-website/src/components/DoDont.tsx
@@ -57,6 +57,7 @@ const Item: React.FC<DoProps> = ({center = false, ...props}) => {
         borderLeftWidth="borderWidth10"
         borderColor="colorBorderLight"
         display={props.children == null ? 'none' : 'block'}
+        overflowY="auto"
       >
         <AspectRatio ratio="4:3">{preview}</AspectRatio>
       </Box>


### PR DESCRIPTION
- [x] Added `overflow-y` to add scroll capabilities to the do/dont `Box` containers. Now longer do/dont example content is visible via scroll.