### PR TITLE
fix: remove "close icon" sizing note on Alert docs

### DIFF
--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -178,13 +178,6 @@ There's a good chance you need to use an error alert if both these conditions ar
 
 ### Dismissible
 
-<Callout variant="warning">
-  <CalloutTitle>A note about Icon Sizing</CalloutTitle>
-  <CalloutText>
-  Heads up! We're making some changes to Icon sizing which will reduce the size of the close action that dismisses alerts. You may still proceed to use this component, as the Icon update will not be a breaking change.
-  </CalloutText>
-</Callout>
-
 Add a close button to the alert if it doesn't communicate a persistent status of the system or the account. If you make an alert dismissible, provide another way for the user to retrieve the alert information.
 
 Don't add a close button to the alert if all these conditions are true:


### PR DESCRIPTION
We fixed it.

Removed this callout from the Alert docs page:

> A note about Icon Sizing
> Heads up! We're making some changes to Icon sizing which will reduce the size of the close action that dismisses alerts. You may still proceed to use this component, as the Icon update will not be a breaking change.

https://paste-git-fix-alert-icon-sizing.twilio-dsys.now.sh/components/alert#dismissible