### PR TITLE
docs(web): add callout to modal in modal primitive

### DIFF
--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -63,7 +63,7 @@ and accessibility issues in our products.
 <Callout>
   <CalloutTitle as="h4">Looking for Paste's styled Modal?</CalloutTitle>
   <CalloutText>
-    Only use this primitive if you have a bespoke modal design. For most Twilio interfaces, we recommend using the <Anchor href="https://paste.twilio.design/components/modal">Paste Modal component</Anchor>.
+    Only use this primitive if you have a bespoke modal design. For most Twilio interfaces, we recommend using the <Anchor href="/components/modal">Paste Modal component</Anchor>.
   </CalloutText>
 </Callout>
 

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -9,7 +9,7 @@ import Changelog from '@twilio-paste/modal-dialog-primitive/CHANGELOG.md';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
 import {SidebarCategoryRoutes} from '../../../constants';
-import {Callout, CalloutText} from '../../../components/callout';
+import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import ModalDemo from './ModalDemo.tsx';
 

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -60,6 +60,13 @@ we suggest falling back to this component to roll your own solution. We encourag
 using this code as a basis for all modal dialogs in order to avoid code fragmentation
 and accessibility issues in our products.
 
+<Callout>
+  <CalloutTitle as="h4">Looking for Paste's styled Modal?</CalloutTitle>
+  <CalloutText>
+    Only use this primitive if you have a bespoke modal design. For most Twilio interfaces, we recommend using the <Anchor href="https://paste.twilio.design/components/modal">Paste Modal component</Anchor>.
+  </CalloutText>
+</Callout>
+
 ## Usage Guide
 
 This package is a wrapper around [`@reach/dialog`](https://reacttraining.com/reach-ui/dialog). If


### PR DESCRIPTION
Added a callout to modal docs, given that there may be confusion between choosing primitive or component

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
