### PR TITLE
fix(docs): Change instances of "helper" to "help" on form components

### DIFF
--- a/packages/paste-website/src/pages/form-elements/input/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/input/index.mdx
@@ -93,7 +93,7 @@ You can set the input to more [specific types](#input-types) if needed.
     Include inline error text with the error icon on any field that errors to make it visually clear that the field
     changed.
   </ListItem>
-  <ListItem>If the input has assicated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on the input. This should match the <inlineCode>id</inlineCode> of the helper or error text.</ListItem>
+  <ListItem>If the input has assicated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on the input. This should match the <inlineCode>id</inlineCode> of the help or error text.</ListItem>
 </UnorderedList>
 
 ## Examples
@@ -112,7 +112,7 @@ The input component should include the base input, along with supporting element
     Make sure to connect the <inlineCode>FormLabel</inlineCode> to the <inlineCode>FormInput</inlineCode>. This is done with the <inlineCode>htmlFor</inlineCode> prop on the label, and the <inlineCode>id</inlineCode> prop on the input. Those two need to match.
   </CalloutText>
   <CalloutText>
-    If the input has any associated helper text, the input should also use the <inlineCode>aria-describedby</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the help text. This ensures screen readers know the helper text ties directly to the input.
+    If the input has any associated help text, the input should also use the <inlineCode>aria-describedby</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the help text. This ensures screen readers know the help text ties directly to the input.
   </CalloutText>
 </Callout>
 
@@ -653,7 +653,7 @@ All the valid HTML attributes (role, aria-*, type, and so on) including the foll
 | ---------     | --------------------| -------------------------------------- | ---------  |
 | children?     | `ReactNode`         |                                        | null       |
 | marginTop?    | 'space0', 'space20' |                                        | 'space20'  |
-| variant?      | 'error'             | Sets the helper text to an error state | 'space20'  |
+| variant?      | 'error'             | Sets the help text to an error state | 'space20'  |
 
 <Box marginTop="space90">
   <Changelog />

--- a/packages/paste-website/src/pages/form-elements/textarea/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/textarea/index.mdx
@@ -92,7 +92,7 @@ Use a textarea when you want to allow a user to enter text on multiple lines. A 
     Include inline error text with the error icon on any field that errors to make it visually clear that the field
     changed.
   </ListItem>
-  <ListItem>If the textarea has associated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on the textarea. This should match the <inlineCode>id</inlineCode> of the helper or error text.</ListItem>
+  <ListItem>If the textarea has associated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on the textarea. This should match the <inlineCode>id</inlineCode> of the help or error text.</ListItem>
 </UnorderedList>
 
 ## Examples
@@ -111,7 +111,7 @@ The textarea should include the base textarea, along with supporting elements to
     Make sure to connect the <inlineCode>FormLabel</inlineCode> to the <inlineCode>FormTextArea</inlineCode>. This is done with the <inlineCode>htmlFor</inlineCode> prop on the label, and the <inlineCode>id</inlineCode> prop on the textarea. Those two need to match.
   </CalloutText>
   <CalloutText>
-    If the textarea has any associated helper text, the textarea should also use the <inlineCode>aria-describedby</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the help text. This ensures screen readers know the helper text ties directly to the textarea.
+    If the textarea has any associated help text, the textarea should also use the <inlineCode>aria-describedby</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the help text. This ensures screen readers know the help text ties directly to the textarea.
   </CalloutText>
 </Callout>
 
@@ -593,7 +593,7 @@ All the valid HTML attributes (role, aria-*, type, and so on) including the foll
 | ---------     | --------------------| -------------------------------------- | ---------  |
 | children?     | `ReactNode`         |                                        | null       |
 | marginTop?    | 'space0', 'space20' |                                        | 'space20'  |
-| variant?      | 'error'             | Sets the helper text to an error state | 'space20'  |
+| variant?      | 'error'             | Sets the help text to an error state | 'space20'  |
 
 <Box marginTop="space90">
   <Changelog />


### PR DESCRIPTION
There are still a few places we're referring to help text as "helper" instead of "help"

- Input: https://paste-git-fixdocs-form-helper-text.twilio-dsys.now.sh/form-elements/input/
- Textarea: https://paste-git-fixdocs-form-helper-text.twilio-dsys.now.sh/form-elements/textarea/
