### PR TITLE
fix(modal docs): swap alias names in Anatomy with token

### DIFF
--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -283,21 +283,19 @@ If you need to show an important warning to prevent or correct critical errors, 
 | border-color     | $color-background-body               | No          |
 | border-radius    | $border-radius-20                    | No          |
 | drop-shadow      | $shadow-card                         | No          |
-| modal-width      | sm [default]: $size-60, lg: $size-80 | No          |
-| overlay-color    | palette-gray-100 (at 50% opacity)    | No          |
+| modal-width      | default: $size-60, wide: $size-80    | No          |
+| overlay-color    | $color-background-overlay            | No          |
 
 ### ModalHeader
 
-| Property                 | Default token       | Modifiable?  |
+| Property                 | Default token/child | Modifiable?  |
 | ------------------------ | --------------------| ------------ |
-| header-title-size        | $font-size-60       | No           |
-| header-title-weight      | $font-weight-medium | No           |
-| header-title-line-height | $line-height-40     | No           |
-| close-icon-color         | $color-gray-50      | No           |
-| close-icon-size          | $size-icon-24       | No           |
+| Heading                  | H3                  | No           |
+| close-icon-color         | $color-text-weak    | No           |
+| close-icon-size          | $size-icon-60       | No           |
 | padding                  | $space-50           | No           |
 | bottom-border-width      | $border-width-10    | No           |
-| bottom-border-color      | $color-gray-50      | No           |
+| bottom-border-color      | $color-border-light | No           |
 
 ### ModalBody
 
@@ -307,11 +305,11 @@ If you need to show an important warning to prevent or correct critical errors, 
 
 ### ModalFooter
 
-| Property         | Default token    | Modifiable?  |
-| ---------------- | -----------------| ------------ |
-| padding          | $space-50        | No           |
-| top-border-width | $border-width-10 | No           |
-| top-border-color | $color-gray-50   | No           |
+| Property         | Default token        | Modifiable?  |
+| ---------------- | -------------------- | ------------ |
+| padding          | $space-50            | No           |
+| top-border-width | $border-width-10     | No           |
+| top-border-color | $color-border-light  | No           |
 
 ---
 


### PR DESCRIPTION
In the Modal docs Anatomy section:

- Swapped alias names for tokens
- Swapped heading anatomy with Heading component used

https://paste-git-fixmodal-docs-swap-aliases-in-anatomy.twilio-dsys.now.sh/components/modal#anatomy