### PR TITLE
feat(components): promote text components, spinner and primitive to prod

### DIFF
--- a/packages/paste-core/components/heading/package.json
+++ b/packages/paste-core/components/heading/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/heading",
   "version": "1.2.2",
   "category": "typography",
-  "status": "beta",
+  "status": "production",
   "description": "Twilio's Heading component",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/components/list/package.json
+++ b/packages/paste-core/components/list/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/list",
   "version": "0.1.24",
   "category": "typography",
-  "status": "beta",
+  "status": "production",
   "description": "The list component is used to render text as a list of items.",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/components/paragraph/package.json
+++ b/packages/paste-core/components/paragraph/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/paragraph",
   "version": "1.0.29",
   "category": "typography",
-  "status": "beta",
+  "status": "production",
   "description": "The paragraph component is used to render blocks of text, with a preset amount of space beneath it to distinguish from adjacent content.",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/components/spinner/package.json
+++ b/packages/paste-core/components/spinner/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/spinner",
   "version": "1.1.30",
   "category": "feedback",
-  "status": "beta",
+  "status": "production",
   "description": "Twilio's Spinner component",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/primitives/box/package.json
+++ b/packages/paste-core/primitives/box/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/box",
   "version": "2.2.10",
   "category": "layout",
-  "status": "beta",
+  "status": "production",
   "description": "A primitive component that can be used to create all block level styles in Paste",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/primitives/text/package.json
+++ b/packages/paste-core/primitives/text/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/text",
   "version": "2.0.3",
   "category": "typography",
-  "status": "beta",
+  "status": "production",
   "description": "A primitive component that can be used to create all text styles in Paste",
   "author": "Twilio Inc.",
   "license": "MIT",


### PR DESCRIPTION
Update the following components to `production` status since teams are using them:

- List
- Heading
- Paragraph
- Text Primitive
- Box Primitive
- Spinner

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
