### PR TITLE
fix(website): change codeblock background to white for visibility

### DIFF
--- a/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
@@ -36,7 +36,11 @@ const LivePreview: React.FC<CodeblockProps> = ({
           paddingRight="space50"
           paddingTop="space80"
           paddingBottom="space80"
-          backgroundColor="colorBackground"
+          borderColor="colorBorderLight"
+          borderStyle="solid"
+          borderWidth="borderWidth20"
+          borderBottomWidth="borderWidth0"
+          backgroundColor="colorBackgroundBody"
           borderTopLeftRadius="borderRadius20"
           borderTopRightRadius="borderRadius20"
         >


### PR DESCRIPTION
Change the code block example background from grey to white to make the components easier to see.

## Before
![image](https://user-images.githubusercontent.com/368249/80060999-d76ee380-84e4-11ea-8ef5-dd324e8436f5.png)

## After
![image](https://user-images.githubusercontent.com/368249/80060960-bc03d880-84e4-11ea-8566-19e642af9901.png)
