### PR TITLE
feat(alert docs): update color tokens in Anatomy

### DIFF
--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -285,7 +285,7 @@ In general, the persistence and behavior on scroll of an alert should match the 
 | border-color     | <ul><li>Error: color-border-error-light</li><li>Neutral: color-border-neutral-light</li><li>Warning: color-border-warning-light</li></ul>                                                             | No          |
 | border-radius    | border-radius-0                                                                                                                                                                                       | No          |
 | border-width     | Bottom border: border-width-20                                                                                                                                                                        | No          |
-| icon color       | <ul><li>Error: color-text-error-dark</li><li>Neutral: color-text-icon</li><li>Warning: color-text-warning-dark</li><li>Close: color-text-icon</li></ul>                                               | No          |
+| icon color       | <ul><li>Error: color-text-error</li><li>Neutral: color-text-icon</li><li>Warning: color-text-warning</li><li>Close: color-text-icon</li></ul>                                               | No          |
 | icon size        | <ul><li>Alert icon: size-icon-30</li><li>Close icon: size-icon-30</li></ul>                                                                                                                           | No          |
 | spacing          | <ul><li>Top padding: space-50</li><li>Bottom padding: space-40</li><li>left/right padding: space-70</li><li>Between icon and body: space-40</li><li>Between body and close button: space-40</li></ul> | No          |
 


### PR DESCRIPTION
Updated icon colors in Alert docs Anatomy section (based on icon update in previous PR):
- Error: color-text-error-dark --> color-text-error
- Warning: color-text-warning-dark --> color-text-warning