### PR TITLE
fix(heading): set variant as required, remove default variant

### DIFF
--- a/packages/paste-core/components/heading/src/index.tsx
+++ b/packages/paste-core/components/heading/src/index.tsx
@@ -10,7 +10,7 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   className?: never;
   id?: string;
   marginBottom?: 'space0';
-  variant?: HeadingVariants;
+  variant: HeadingVariants;
 }
 
 function getHeadingProps(headingVariant?: HeadingVariants, marginBottom?: 'space0'): {} {
@@ -81,15 +81,18 @@ const Heading: React.FC<HeadingProps> = ({as, children, id, marginBottom, varian
 };
 Heading.displayName = 'Heading';
 
-Heading.defaultProps = {
-  variant: 'heading20',
-};
-
 if (process.env.NODE_ENV === 'development') {
   Heading.propTypes = {
     as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'] as asTags[]).isRequired,
     marginBottom: PropTypes.oneOf(['space0']),
-    variant: PropTypes.oneOf(['heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60']),
+    variant: PropTypes.oneOf([
+      'heading10',
+      'heading20',
+      'heading30',
+      'heading40',
+      'heading50',
+      'heading60',
+    ] as HeadingVariants[]).isRequired,
   };
 }
 

--- a/packages/paste-website/src/pages/components/card/index.mdx
+++ b/packages/paste-website/src/pages/components/card/index.mdx
@@ -116,7 +116,7 @@ An example of a Card with default padding.
 
 <LivePreview scope={{Card, Paragraph, Heading}} language="jsx">
   {`<Card>
-  <Heading as="h2">This is a card</Heading>
+  <Heading as="h2" variant="heading20">This is a card</Heading>
   <Paragraph>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
     labore et dolore magna aliqua.
@@ -134,7 +134,7 @@ adjusted to suit the needs of your implementation.
 
 <LivePreview scope={{Card, Paragraph, Heading, Button}} language="jsx">
   {`<Card padding="space120">
-  <Heading as="h2">This is a card with a primary action</Heading>
+  <Heading as="h2" variant="heading20">This is a card with a primary action</Heading>
   <Paragraph>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam dui tellus, tristique in tincidunt cursus, efficitur
     at felis. Phasellus imperdiet, lorem et commodo egestas, arcu.
@@ -153,7 +153,7 @@ Card using Box or Flex.
   {`<Card padding="space200">
   <Text as="div" textAlign="center">
     <PlusIcon size='sizeIcon40' decorative title="There just wasn't a details icon to use"/>
-    <Heading as="h2">Let's verify your integration</Heading>
+    <Heading as="h2" variant="heading20">Let's verify your integration</Heading>
     <Paragraph>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
       magna aliqua.
@@ -162,19 +162,6 @@ Card using Box or Flex.
   </Text>
 </Card>;`}
 </LivePreview>
-{/*
-We didn't have an icon or grid/layout components so we'll save this example for later.
-#### Card with Custom Layout
-
-<LivePreview scope={{Card, Paragraph, Heading, Button}} language="jsx">
-  {`<Card>
-  <Heading as="h2">Heading Two</Heading>
-  <Paragraph>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam dui tellus, tristique in tincidunt cursus, efficitur
-    at felis. Phasellus imperdiet, lorem et commodo egestas, arcu.
-  </Paragraph>
-</Card>`}
-</LivePreview> */}
 
 ## Composing a Card
 ### When to use a Card

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -207,11 +207,12 @@ import {Heading} from '@twilio-paste/heading';
 
 #### Props
 
-| Prop           | Type                  | Description                                                                        | Default          |
-| -------------- | --------------------- | ---------------------------------------------------------------------------------- | ---------------- |
-| as             | asTags                | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                         | null             |
-| marginBottom   | oneOf(['space0'])     | Currently we only allow `space0` to remove bottom margin                           | null             |
-| variant?       | headingVariants       | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'       | 'heading20'      |
+| Prop           | Type                  | Description                                                                          | Default          |
+| -------------- | --------------------- | ------------------------------------------------------------------------------------ | ---------------- |
+| as             | `asTags`                | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                         | null             |
+| id?            | `string`                |                                                                                    | null             |
+| marginBottom?  | `oneOf(['space0'])`     | Currently we only allow `space0` to remove bottom margin                           | null             |
+| variant        | `headingVariants`       | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'       | null             |
 
 <Box marginTop="space90">
   <Changelog />

--- a/packages/paste-website/src/pages/layout/grid/index.mdx
+++ b/packages/paste-website/src/pages/layout/grid/index.mdx
@@ -266,7 +266,7 @@ Let's look at a common use case where we need to layout a page with a sidebar an
   <Grid gutter="space30">
     <Column span={3}>
       <Box backgroundColor="colorBackground" padding="space70" borderRadius="borderRadius20">
-        <Heading variant="heading40">Dashboard</Heading>
+        <Heading as="h4" variant="heading40">Dashboard</Heading>
         <Box marginBottom="space20">
           <Anchor href="#">Billing</Anchor>
         </Box>


### PR DESCRIPTION
- [x] Breaking Change(heading): Set `variant` as required for `Heading`
- [x] Removed default `variant` prop
- [x] Updated `Heading` prop table on website
- [x] Added missing variants when used on website