### PR TITLE
fix(button): allow html button attributes

### DIFF
--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -290,7 +290,7 @@ describe('Button Errors', () => {
           Go to Paste
         </Button>
       )
-    ).toThrowError();
+    ).toThrow();
   });
 
   it('Throws an error when an "a" tag is passed but a href is not', () => {
@@ -300,7 +300,7 @@ describe('Button Errors', () => {
           Go to Paste
         </Button>
       )
-    ).toThrowError();
+    ).toThrow();
   });
 
   it('Throws an error when the user should use an Anchor component instead', () => {
@@ -310,7 +310,7 @@ describe('Button Errors', () => {
           Go to Paste
         </Button>
       )
-    ).toThrowError();
+    ).toThrow();
   });
 
   it('Throws an error when size=reset is not applied to variant=reset', () => {
@@ -320,7 +320,7 @@ describe('Button Errors', () => {
           Submit
         </Button>
       )
-    ).toThrowError();
+    ).toThrow();
   });
 
   it('Throws an error when using fullWidth with an icon sizing', () => {
@@ -330,15 +330,15 @@ describe('Button Errors', () => {
           X
         </Button>
       )
-    ).toThrowError();
+    ).toThrow();
   });
 
   it('Throws an error when not passing children', () => {
-    expect(() => shallow(<Button variant="primary" />)).toThrowError();
+    expect(() => shallow(<Button variant="primary" />)).toThrow();
   });
 
   it('Throws an error when passing an invalid tabIndex', () => {
-    expect(() => shallow(<Button variant="primary" tabIndex="-2" />)).toThrowError();
+    expect(() => shallow(<Button variant="primary" tabIndex="-2" />)).toThrow();
   });
 });
 
@@ -377,6 +377,17 @@ describe('Button aria attributes', () => {
       </Button>
     );
     expect(wrapper.exists('button[aria-busy="true"]')).toEqual(true);
+  });
+});
+
+describe('Button data attributes', () => {
+  it('Has an data-foo attribute', () => {
+    const wrapper: ReactWrapper = mount(
+      <Button variant="secondary" data-foo="test">
+        button
+      </Button>
+    );
+    expect(wrapper.exists('button[data-foo="test"]')).toEqual(true);
   });
 });
 

--- a/packages/paste-core/components/button/src/types.ts
+++ b/packages/paste-core/components/button/src/types.ts
@@ -4,39 +4,16 @@ export type ButtonVariants = 'primary' | 'secondary' | 'destructive' | 'destruct
 export type ButtonStates = 'disabled' | 'loading' | 'default';
 export type ButtonTabIndexes = 0 | -1;
 
-export interface ButtonProps {
-  id?: never;
-  className?: never;
-  type?: ButtonTypes;
-  href?: string;
-  autoFocus?: boolean;
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   as?: string;
-  tabIndex?: ButtonTabIndexes;
-
-  variant: ButtonVariants;
-  size?: ButtonSizes;
-  fullWidth?: boolean;
-
   children: React.ReactNode;
-
-  disabled?: boolean;
+  fullWidth?: boolean;
+  href?: string;
   loading?: boolean;
-
-  // For accordions
-  'aria-expanded'?: 'true' | 'false';
-  // For modal and menus
-  'aria-haspopup'?: 'true' | 'dialog' | 'menu';
-  'aria-controls'?: string;
-  // For testing
-  'data-test'?: string;
-
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
-  onMouseDown?(event: React.MouseEvent<HTMLElement>): void;
-  onMouseUp?(event: React.MouseEvent<HTMLElement>): void;
-  onMouseEnter?(event: React.MouseEvent<HTMLElement>): void;
-  onMouseLeave?(event: React.MouseEvent<HTMLElement>): void;
-  onFocus?(event: React.FocusEvent<HTMLElement>): void;
-  onBlur?(event: React.FocusEvent<HTMLElement>): void;
+  size?: ButtonSizes;
+  tabIndex?: ButtonTabIndexes;
+  type?: ButtonTypes;
+  variant: ButtonVariants;
 }
 
 export interface ButtonWrapperProps extends ButtonProps {

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -26,7 +26,6 @@ storiesOf('Components|Button', module)
         variant={select('variant', ButtonVariantOptions, 'primary') as ButtonVariants}
         size={select('size', ButtonSizeOptions, 'default') as ButtonSizes}
         fullWidth={boolean('fullWidth', false)}
-        autoFocus={boolean('autoFocus', false)}
         disabled={boolean('disabled', false)}
         loading={boolean('loading', false)}
         as={text('as', 'button')}
@@ -47,7 +46,6 @@ storiesOf('Components|Button', module)
         variant={select('variant', ButtonVariantOptions, 'primary') as ButtonVariants}
         size={select('size', ButtonSizeOptions, 'default') as ButtonSizes}
         fullWidth={boolean('fullWidth', false)}
-        autoFocus={boolean('autoFocus', false)}
         disabled={boolean('disabled', false)}
         loading={boolean('loading', false)}
         as={text('as', 'button')}
@@ -68,7 +66,6 @@ storiesOf('Components|Button', module)
       <Button
         variant={select('variant', ButtonVariantOptions, 'primary') as ButtonVariants}
         size={select('size', ButtonSizeOptions, 'icon') as ButtonSizes}
-        autoFocus={boolean('autoFocus', false)}
         disabled={boolean('disabled', false)}
         loading={boolean('loading', false)}
         as={text('as', 'button')}

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -499,27 +499,25 @@ import {Button} from '@twilio-paste/button';
 
 #### Props
 
-| Prop           | Type                                     | Description                                                                         | Default   |
-| -------------- | ---------------------------------------- | ----------------------------------------------------------------------------------- | --------- |
-| type?          | string                                   | If the button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default). | 'button'  |
-| as?            | string                                   | The HTML tag to replace the default `<button>` tag.                                 | 'button'  |
-| href?          | string                                   | A URL to route to. Must use `as="a"` for this prop to work.                         | null      |
-| variant?       | ButtonVariants                           | 'primary', 'secondary', 'destructive', 'destructive_link', 'link', 'reset'          | 'primary' |
-| size?          | ButtonSizes                              | 'default', 'small', 'icon', 'reset'                                                 | 'default' |
-| fullWidth      | boolean                                  | Sets the button width to 100% of the parent container.                              | false     |
-| disabled?      | boolean                                  | Prevent actions from firing on this button                                          | false     |
-| loading?       | boolean                                  | Prevent actions and show a loading spinner                                          | false     |
-| onClick?       | `(event: React.MouseEvent<HTMLElement>)` |                                                                                     | null      |
-| onMouseDown?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                                     | null      |
-| onMouseUp?     | `(event: React.MouseEvent<HTMLElement>)` |                                                                                     | null      |
-| onMouseEnter?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                     | null      |
-| onMouseLeave?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                     | null      |
-| onFocus?       | `(event: React.FocusEvent<HTMLElement>)` |                                                                                     | null      |
-| onBlur?        | `(event: React.FocusEvent<HTMLElement>)` |                                                                                     | null      |
-| aria-expanded? | boolean                                  | A11y: For accordions                                                                | null      |
-| aria-haspopup? | {'true', 'dialog', 'menu'}               | A11y: For modals and menus                                                          | null      |
-| aria-controls? | string                                   | A11y: For modals and menus                                                          | null      |
-| data-test?     | string                                   | To detect the element to run tests against.                                         | null      |
+All the valid HTML attributes for `button` are supported including the following props:
+
+| Prop           | Type                                     | Description                                                                                                        | Default   |
+| -------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
+| as?            | `string`                                   | The HTML tag to replace the default `<button>` tag.                                                              | 'button'  |
+| disabled?      | `boolean`                                  | Prevent actions from firing on this button                                                                       | false     |
+| fullWidth      | `boolean`                                  | Sets the button width to 100% of the parent container.                                                           | false     |
+| href?          | `string`                                   | A URL to route to. Must use `as="a"` for this prop to work.                                                      | null      |
+| loading?       | `boolean`                                  | Prevent actions and show a loading spinner                                                                       | false     |
+| size?          | `ButtonSizes`                              | 'default', 'small', 'icon', 'reset'                                                                              | 'default' |
+| type?          | `ButtonTypes`                              | 'button', 'submit', 'reset'. If the button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default). | 'button'  |
+| variant?       | `ButtonVariants`                           | 'primary', 'secondary', 'destructive', 'destructive_link', 'link', 'reset'                                       | 'primary' |
+| onClick?       | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onMouseDown?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onMouseUp?     | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onMouseEnter?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onMouseLeave?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onFocus?       | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                    | null      |
+| onBlur?        | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                    | null      |
 
 <Box marginTop="space90">
   <Changelog />


### PR DESCRIPTION
Fixes https://github.com/twilio-labs/paste/issues/368

- [x] Allowed all HTML button attributes
- [x] Added `data-foo` test
- [x] Added safely spread utility
- [x] Updated website button props table