### PR TITLE
fix(checkbox docs): typo in live example

### DIFF
--- a/packages/paste-website/src/component-examples/CheckboxExamples.ts
+++ b/packages/paste-website/src/component-examples/CheckboxExamples.ts
@@ -33,7 +33,7 @@ const AdPartners = () => {
         value="facebook"
         helpText={
           <Text as="span" color="currentColor">
-            Questions? <Anchor href="http://paste.twilio.com">Click here to learn mor</Anchor>.
+            Questions? <Anchor href="http://paste.twilio.com">Click here to learn more</Anchor>.
           </Text>
         }
       >
@@ -44,7 +44,7 @@ const AdPartners = () => {
         value="instagram"
         helpText={
           <Text as="span" color="currentColor">
-            Questions? <Anchor href="http://paste.twilio.com">Click here to learn mor</Anchor>.
+            Questions? <Anchor href="http://paste.twilio.com">Click here to learn more</Anchor>.
           </Text>
         }
       >

--- a/packages/paste-website/src/component-examples/RadioGroupExamples.ts
+++ b/packages/paste-website/src/component-examples/RadioGroupExamples.ts
@@ -95,14 +95,14 @@ const NetworkRadioGroup = () => {
         value="existing"
         name="network"
       >
-        Select existing netowrk access profile
+        Select existing network access profile
       </Radio>
       <Radio
         id="new"
         value="new"
         name="network"
       >
-        Create new netowrk access profile
+        Create new network access profile
       </Radio>
     </RadioGroup>
   );


### PR DESCRIPTION
- Checkbox docs: "mor" --> "more"
- Radio docs: "netowrk" --> "network"