### PR TITLE
chore: correctly get the full git history for chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch: 0
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
was incorrectly fetching gith history for the action to do comparisons