### PR TITLE
fix(paragraph docs): margin-bottom typo in Anatomy

### DIFF
--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -182,7 +182,7 @@ Paragraphs should be used for most text blocks. Paragraphs provide defaults for 
 | font-size     | font-size-30       | No          |
 | line-height   | line-height-30     | No          |
 | font-weight   | font-weight-normal | No          |
-| margin-bottom | space-60           | No          |
+| margin-bottom | space-70           | No          |
 | color         | color-text         | No          |
 
 ---


### PR DESCRIPTION
margin-bottom in paragraph uses space-70, not space-60