### PR TITLE
feat(checkbox docs): typo in "when to use" heading

### DIFF
--- a/packages/paste-website/src/pages/form-elements/checkbox/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/checkbox/index.mdx
@@ -240,7 +240,7 @@ Error text should:
 - Use the passive voice for input errors to avoid placing blame on the user. For example, "A Friendly Name is required."
 - Use the active voice for system errors. For example, "Our systems are currently down. Please contact our support team.".
 
-## When to use an Checkbox and Checkbox Group
+## When to use a Checkbox and Checkbox Group
 
 Use a checkbox when users are required to make a binary choice. Use a checkbox group when more than one checkbox is related to one another.
 


### PR DESCRIPTION
"When to use an Checkbox and Checkbox Group" --> "When to use a Checkbox and Checkbox Group"