### PR TITLE
feat: add animations to modal, globally respect 'prefers-reduced-motion'

### DIFF
--- a/.jest/setupFilesAfterEnv.js
+++ b/.jest/setupFilesAfterEnv.js
@@ -7,3 +7,8 @@ expect.extend(toHaveNoViolations);
 
 expect.addSnapshotSerializer(createSerializer(emotion));
 Enzyme.configure({adapter: new Adapter()});
+
+// Shim for useReducedMotion hooks
+global.window.matchMedia = jest.fn(() => {
+  return {matches: false, addListener: jest.fn(), removeListener: jest.fn()};
+});

--- a/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -14,17 +14,11 @@ exports[`Alert Variant error Should render an error alert 1`] = `
 }
 
 .emotion-6 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-6 *,
-.emotion-6 *::after,
-.emotion-6 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -133,17 +127,11 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
 }
 
 .emotion-11 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-11 *,
-.emotion-11 *::after,
-.emotion-11 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -389,17 +377,11 @@ exports[`Alert Variant neutral Should render a neutral alert 1`] = `
 }
 
 .emotion-6 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-6 *,
-.emotion-6 *::after,
-.emotion-6 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-5 {
@@ -508,17 +490,11 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
 }
 
 .emotion-11 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-11 *,
-.emotion-11 *::after,
-.emotion-11 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-10 {
@@ -754,17 +730,11 @@ exports[`Alert Variant warning Should render an warning alert 1`] = `
 }
 
 .emotion-6 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-6 *,
-.emotion-6 *::after,
-.emotion-6 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -873,17 +843,11 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
 }
 
 .emotion-11 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-11 *,
-.emotion-11 *::after,
-.emotion-11 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {

--- a/packages/paste-core/components/anchor/__tests__/__snapshots__/anchor.test.tsx.snap
+++ b/packages/paste-core/components/anchor/__tests__/__snapshots__/anchor.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Anchor it should render an anchor 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -50,17 +44,11 @@ exports[`Anchor it should render an anchor 1`] = `
 
 exports[`Anchor it should render an external anchor 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -100,17 +88,11 @@ exports[`Anchor it should render an external anchor 1`] = `
 
 exports[`Anchor it should render an external anchor with overwritten target and rel 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/button/__tests__/__snapshots__/button.test.tsx.snap
+++ b/packages/paste-core/components/button/__tests__/__snapshots__/button.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Button States Has a disabled state 1`] = `
 .emotion-24 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-24 *,
-.emotion-24 *::after,
-.emotion-24 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -311,17 +305,11 @@ exports[`Button States Has a loading state 1`] = `
 }
 
 .emotion-48 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-48 *,
-.emotion-48 *::after,
-.emotion-48 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-6 {
@@ -855,17 +843,11 @@ exports[`Button States Has a loading state 1`] = `
 
 exports[`Button Variants Has a destructive variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -972,17 +954,11 @@ exports[`Button Variants Has a destructive variant 1`] = `
 
 exports[`Button Variants Has a destructive_link variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1080,17 +1056,11 @@ exports[`Button Variants Has a destructive_link variant 1`] = `
 
 exports[`Button Variants Has a link variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1188,17 +1158,11 @@ exports[`Button Variants Has a link variant 1`] = `
 
 exports[`Button Variants Has a primary variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -1305,17 +1269,11 @@ exports[`Button Variants Has a primary variant 1`] = `
 
 exports[`Button Variants Has a reset variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1396,17 +1354,11 @@ exports[`Button Variants Has a reset variant 1`] = `
 
 exports[`Button Variants Has a secondary variant 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -3,19 +3,13 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {withKnobs, select, text, boolean} from '@storybook/addon-knobs';
 import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
+import {isRenderingOnServer} from '@twilio-paste/animation-library';
 import {Button} from '../src';
 import {ButtonVariants, ButtonSizes, ButtonTabIndexes} from '../src/types';
 
 const ButtonSizeOptions = ['', 'default', 'small', 'icon', 'reset'];
 const ButtonVariantOptions = ['primary', 'secondary', 'destructive', 'destructive_link', 'link', 'reset'];
 const ButtonTabIndexOptions = [0, -1];
-
-const IS_VRT_ENV = (() => {
-  if (!window || !window.location || !window.location.href) {
-    return true;
-  }
-  return Boolean(new URL(window.location.href).searchParams.get('eyes-storybook'));
-})();
 
 storiesOf('Components|Button', module)
   .addDecorator(withKnobs)
@@ -87,7 +81,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size={size}>
             Primary
           </Button>
-          <Button variant="primary" size={size} loading={!IS_VRT_ENV}>
+          <Button variant="primary" size={size} loading={!isRenderingOnServer}>
             Primary
           </Button>
           <Button variant="primary" size={size} disabled>
@@ -99,7 +93,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="small">
             Primary
           </Button>
-          <Button variant="primary" size="small" loading={!IS_VRT_ENV}>
+          <Button variant="primary" size="small" loading={!isRenderingOnServer}>
             Primary
           </Button>
           <Button variant="primary" size="small" disabled>
@@ -111,7 +105,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="primary" size="icon" loading={!IS_VRT_ENV}>
+          <Button variant="primary" size="icon" loading={!isRenderingOnServer}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="primary" size="icon" disabled>
@@ -123,7 +117,7 @@ storiesOf('Components|Button', module)
           <Button variant="primary" size="reset">
             Primary
           </Button>
-          <Button variant="primary" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="primary" size="reset" loading={!isRenderingOnServer}>
             Primary
           </Button>
           <Button variant="primary" size="reset" disabled>
@@ -135,7 +129,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size={size}>
             Secondary
           </Button>
-          <Button variant="secondary" size={size} loading={!IS_VRT_ENV}>
+          <Button variant="secondary" size={size} loading={!isRenderingOnServer}>
             Secondary
           </Button>
           <Button variant="secondary" size={size} disabled>
@@ -147,7 +141,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="small">
             Secondary
           </Button>
-          <Button variant="secondary" size="small" loading={!IS_VRT_ENV}>
+          <Button variant="secondary" size="small" loading={!isRenderingOnServer}>
             Secondary
           </Button>
           <Button variant="secondary" size="small" disabled>
@@ -159,7 +153,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="secondary" size="icon" loading={!IS_VRT_ENV}>
+          <Button variant="secondary" size="icon" loading={!isRenderingOnServer}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="secondary" size="icon" disabled>
@@ -171,7 +165,7 @@ storiesOf('Components|Button', module)
           <Button variant="secondary" size="reset">
             Secondary
           </Button>
-          <Button variant="secondary" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="secondary" size="reset" loading={!isRenderingOnServer}>
             Secondary
           </Button>
           <Button variant="secondary" size="reset" disabled>
@@ -183,7 +177,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size={size}>
             Destructive
           </Button>
-          <Button variant="destructive" size={size} loading={!IS_VRT_ENV}>
+          <Button variant="destructive" size={size} loading={!isRenderingOnServer}>
             Destructive
           </Button>
           <Button variant="destructive" size={size} disabled>
@@ -195,7 +189,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="small">
             Destructive
           </Button>
-          <Button variant="destructive" size="small" loading={!IS_VRT_ENV}>
+          <Button variant="destructive" size="small" loading={!isRenderingOnServer}>
             Destructive
           </Button>
           <Button variant="destructive" size="small" disabled>
@@ -207,7 +201,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="destructive" size="icon" loading={!IS_VRT_ENV}>
+          <Button variant="destructive" size="icon" loading={!isRenderingOnServer}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="destructive" size="icon" disabled>
@@ -219,7 +213,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive" size="reset">
             Destructive
           </Button>
-          <Button variant="destructive" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="destructive" size="reset" loading={!isRenderingOnServer}>
             Destructive
           </Button>
           <Button variant="destructive" size="reset" disabled>
@@ -231,7 +225,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size={size}>
             Link
           </Button>
-          <Button variant="link" size={size} loading={!IS_VRT_ENV}>
+          <Button variant="link" size={size} loading={!isRenderingOnServer}>
             Link
           </Button>
           <Button variant="link" size={size} disabled>
@@ -243,7 +237,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="small">
             Link
           </Button>
-          <Button variant="link" size="small" loading={!IS_VRT_ENV}>
+          <Button variant="link" size="small" loading={!isRenderingOnServer}>
             Link
           </Button>
           <Button variant="link" size="small" disabled>
@@ -255,7 +249,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="link" size="icon" loading={!IS_VRT_ENV}>
+          <Button variant="link" size="icon" loading={!isRenderingOnServer}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="link" size="icon" disabled>
@@ -267,7 +261,7 @@ storiesOf('Components|Button', module)
           <Button variant="link" size="reset">
             Link
           </Button>
-          <Button variant="link" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="link" size="reset" loading={!isRenderingOnServer}>
             Link
           </Button>
           <Button variant="link" size="reset" disabled>
@@ -279,7 +273,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size={size}>
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size={size} loading={!IS_VRT_ENV}>
+          <Button variant="destructive_link" size={size} loading={!isRenderingOnServer}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size={size} disabled>
@@ -291,7 +285,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="small">
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size="small" loading={!IS_VRT_ENV}>
+          <Button variant="destructive_link" size="small" loading={!isRenderingOnServer}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size="small" disabled>
@@ -303,7 +297,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="icon">
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
-          <Button variant="destructive_link" size="icon" loading={!IS_VRT_ENV}>
+          <Button variant="destructive_link" size="icon" loading={!isRenderingOnServer}>
             <PlusIcon decorative={false} title="Add to cart" />
           </Button>
           <Button variant="destructive_link" size="icon" disabled>
@@ -315,7 +309,7 @@ storiesOf('Components|Button', module)
           <Button variant="destructive_link" size="reset">
             Destructive Link
           </Button>
-          <Button variant="destructive_link" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="destructive_link" size="reset" loading={!isRenderingOnServer}>
             Destructive Link
           </Button>
           <Button variant="destructive_link" size="reset" disabled>
@@ -326,7 +320,7 @@ storiesOf('Components|Button', module)
           <Button variant="reset" size="reset">
             Reset
           </Button>
-          <Button variant="reset" size="reset" loading={!IS_VRT_ENV}>
+          <Button variant="reset" size="reset" loading={!isRenderingOnServer}>
             Reset
           </Button>
           <Button variant="reset" size="reset" disabled>

--- a/packages/paste-core/components/card/__test__/__snapshots__/card.test.tsx.snap
+++ b/packages/paste-core/components/card/__test__/__snapshots__/card.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Card it should filter out style props that are not allowed 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -36,17 +30,11 @@ exports[`Card it should filter out style props that are not allowed 1`] = `
 
 exports[`Card it should render children 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -72,17 +60,11 @@ exports[`Card it should render children 1`] = `
 
 exports[`Card it should render default values 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -106,17 +88,11 @@ exports[`Card it should render default values 1`] = `
 
 exports[`Card it should render default values unless overridden by the component 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formInput.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`FormInput render it should render 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -113,17 +107,11 @@ exports[`FormInput render it should render 1`] = `
 
 exports[`FormInput render it should render with disabled 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -225,17 +213,11 @@ exports[`FormInput render it should render with disabled 1`] = `
 
 exports[`FormInput render it should render with hasError 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -337,17 +319,11 @@ exports[`FormInput render it should render with hasError 1`] = `
 
 exports[`FormInput render it should render with prefix 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-3 {
@@ -475,17 +451,11 @@ exports[`FormInput render it should render with prefix 1`] = `
 
 exports[`FormInput render it should render with readOnly 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -588,17 +558,11 @@ exports[`FormInput render it should render with readOnly 1`] = `
 
 exports[`FormInput render it should render with suffix 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-3 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formTextarea.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`FormTextArea render it should render 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formhelptext.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formhelptext.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`FormHelpText render it should render 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -61,17 +55,11 @@ exports[`FormHelpText render it should render 1`] = `
 
 exports[`FormHelpText render it should render with an error icon 1`] = `
 .emotion-4 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-4 *,
-.emotion-4 *::after,
-.emotion-4 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-3 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`FormLabel render it should render 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -78,17 +72,11 @@ exports[`FormLabel render it should render 1`] = `
 
 exports[`FormLabel render it should render with required 1`] = `
 .emotion-6 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-6 *,
-.emotion-6 *::after,
-.emotion-6 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-5 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/siblingBox.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/siblingBox.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`SiblingBox render it should render 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/heading/__tests__/__snapshots__/heading.test.tsx.snap
+++ b/packages/paste-core/components/heading/__tests__/__snapshots__/heading.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Heading it should render an H1 at fontSize90 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -43,17 +37,11 @@ exports[`Heading it should render an H1 at fontSize90 1`] = `
 
 exports[`Heading it should render an H2 at fontSize70 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -84,17 +72,11 @@ exports[`Heading it should render an H2 at fontSize70 1`] = `
 
 exports[`Heading it should render an H3 at fontSize60 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -125,17 +107,11 @@ exports[`Heading it should render an H3 at fontSize60 1`] = `
 
 exports[`Heading it should render an H4 at fontSize40 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -166,17 +142,11 @@ exports[`Heading it should render an H4 at fontSize40 1`] = `
 
 exports[`Heading it should render an H5 at fontSize30 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -207,17 +177,11 @@ exports[`Heading it should render an H5 at fontSize30 1`] = `
 
 exports[`Heading it should render an H6 at fontSize20 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -248,17 +212,11 @@ exports[`Heading it should render an H6 at fontSize20 1`] = `
 
 exports[`Heading it should render an italic H2 at fontSize50 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -291,17 +249,11 @@ exports[`Heading it should render an italic H2 at fontSize50 1`] = `
 
 exports[`Heading it should render with no margin 1`] = `
 .emotion-6 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-6 *,
-.emotion-6 *::after,
-.emotion-6 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/list/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/list/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`ListItem should filter out styling props 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -42,17 +36,11 @@ exports[`ListItem should filter out styling props 1`] = `
 
 exports[`ListItem should render a plain list item 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -82,17 +70,11 @@ exports[`ListItem should render a plain list item 1`] = `
 
 exports[`Ordered List should allow marginTop and marginBottom styling props 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -123,17 +105,11 @@ exports[`Ordered List should allow marginTop and marginBottom styling props 1`] 
 
 exports[`Ordered List should filter out styling props 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -163,17 +139,11 @@ exports[`Ordered List should filter out styling props 1`] = `
 
 exports[`Ordered List should render a plain ordered list wrapper 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -203,17 +173,11 @@ exports[`Ordered List should render a plain ordered list wrapper 1`] = `
 
 exports[`Unordered List should filter out styling props 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -243,17 +207,11 @@ exports[`Unordered List should filter out styling props 1`] = `
 
 exports[`Unordered List should render a plain unordered list wrapper 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/components/modal/package.json
+++ b/packages/paste-core/components/modal/package.json
@@ -33,6 +33,7 @@
     "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/absolute": "^2.0.38",
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/box": "^2.4.6",
     "@twilio-paste/button": "^1.2.2",
     "@twilio-paste/design-tokens": "^5.2.0",
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@twilio-paste/absolute": "^2.0.38",
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/box": "^2.4.6",
     "@twilio-paste/button": "^1.2.2",
     "@twilio-paste/design-tokens": "^5.2.0",

--- a/packages/paste-core/components/modal/tsconfig.build.json
+++ b/packages/paste-core/components/modal/tsconfig.build.json
@@ -12,6 +12,9 @@
       "path": "../../layout/absolute"
     },
     {
+      "path": "../../../paste-libraries/animation"
+    },
+    {
       "path": "../../primitives/box"
     },
     {

--- a/packages/paste-core/components/separator/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/separator/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Separator it should set horizontal margins 1`] = `
 .emotion-1 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(18,28,45);
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -41,17 +35,11 @@ exports[`Separator it should set horizontal margins 1`] = `
 
 exports[`Separator it should set responsive horizontal margins 1`] = `
 .emotion-1 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(18,28,45);
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -94,17 +82,11 @@ exports[`Separator it should set responsive horizontal margins 1`] = `
 
 exports[`Separator it should set responsive vertical margins 1`] = `
 .emotion-1 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(18,28,45);
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -147,17 +129,11 @@ exports[`Separator it should set responsive vertical margins 1`] = `
 
 exports[`Separator it should set vertical margins 1`] = `
 .emotion-1 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(18,28,45);
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -60,6 +60,7 @@
     "@emotion/styled": "^10.0.10",
     "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/design-tokens": "^5.2.0",
     "@twilio-paste/dropdown-library": "^0.1.1",
     "@twilio-paste/icons": "^2.2.0",
@@ -74,6 +75,7 @@
     "styled-system": "^5.1.2"
   },
   "devDependencies": {
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/design-tokens": "^5.2.0",
     "@twilio-paste/dropdown-library": "^0.1.1",
     "@twilio-paste/icons": "^2.2.0",

--- a/packages/paste-core/core-bundle/tsconfig.build.json
+++ b/packages/paste-core/core-bundle/tsconfig.build.json
@@ -9,6 +9,9 @@
   ],
   "references": [
     {
+      "path": "../../paste-libraries/animation"
+    },
+    {
       "path": "../../paste-design-tokens"
     },
     {

--- a/packages/paste-core/layout/flex/__tests__/__snapshots__/flex.test.tsx.snap
+++ b/packages/paste-core/layout/flex/__tests__/__snapshots__/flex.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Flex Display it should render as any HTML element 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -46,17 +40,11 @@ exports[`Flex Display it should render as any HTML element 1`] = `
 
 exports[`Flex Display it should set a display: flex property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -101,17 +89,11 @@ exports[`Flex Display it should set a display: flex property 1`] = `
 
 exports[`Flex Options it should set a flex-basis property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -166,17 +148,11 @@ exports[`Flex Options it should set a flex-basis property 1`] = `
 
 exports[`Flex Options it should set a flex-grow property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -231,17 +207,11 @@ exports[`Flex Options it should set a flex-grow property 1`] = `
 
 exports[`Flex Options it should set a flex-shrink property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -296,17 +266,11 @@ exports[`Flex Options it should set a flex-shrink property 1`] = `
 
 exports[`Flex Options it should set a responsive flex-basis property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -377,17 +341,11 @@ exports[`Flex Options it should set a responsive flex-basis property 1`] = `
 
 exports[`Flex Options it should set a responsive flex-grow property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -460,17 +418,11 @@ exports[`Flex Options it should set a responsive flex-grow property 1`] = `
 
 exports[`Flex Options it should set a responsive flex-shrink property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -541,17 +493,11 @@ exports[`Flex Options it should set a responsive flex-shrink property 1`] = `
 
 exports[`Flex Row it should not set a flex-direction property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -614,17 +560,11 @@ exports[`Flex Row it should not set a flex-direction property 1`] = `
 
 exports[`Flex Row it should set a responsive flex-direction property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -723,17 +663,11 @@ exports[`Flex Row it should set a responsive flex-direction property 1`] = `
 
 exports[`Flex Wrap it should not set a flex-wrap property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -796,17 +730,11 @@ exports[`Flex Wrap it should not set a flex-wrap property 1`] = `
 
 exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -905,17 +833,11 @@ exports[`Flex Wrap it should set a responsive flex-wrap property 1`] = `
 
 exports[`Horizontal Alignment it should set a justify-content: flex-start property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -978,17 +900,11 @@ exports[`Horizontal Alignment it should set a justify-content: flex-start proper
 
 exports[`Horizontal Alignment it should set a responsive justify-content property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -1086,17 +1002,11 @@ exports[`Horizontal Alignment it should set a responsive justify-content propert
 
 exports[`Vertical Alignment it should set a align-items: flex-start property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {
@@ -1159,17 +1069,11 @@ exports[`Vertical Alignment it should set a align-items: flex-start property 1`]
 
 exports[`Vertical Alignment it should set a responvise align-items property 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-1 {

--- a/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -66,17 +60,11 @@ exports[`12 Column Options it should render a 5 span, 3 span column grid 1`] = `
 
 exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid 1`] = `
 .emotion-7 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-7 *,
-.emotion-7 *::after,
-.emotion-7 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-6 {
@@ -134,17 +122,11 @@ exports[`12 Column Options it should render a 5 span, 5 span, 2 span column grid
 
 exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -194,17 +176,11 @@ exports[`12 Column Options it should render a 6 span, 6 span column grid 1`] = `
 
 exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -258,17 +234,11 @@ exports[`12 Column Options it should render a 8 span, 4 span column grid 1`] = `
 
 exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -322,17 +292,11 @@ exports[`12 Column Options it should render a 9 span, 3 span column grid 1`] = `
 
 exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -386,17 +350,11 @@ exports[`12 Column Options it should render a 10 span, 2 span column grid 1`] = 
 
 exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -450,17 +408,11 @@ exports[`12 Column Options it should render a 11 span, 1 span column grid 1`] = 
 
 exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -514,17 +466,11 @@ exports[`12 Column Options it should render a 11 span, 2 span column grid 1`] = 
 
 exports[`12 Column Options it should render a grid with 1 column 1`] = `
 .emotion-3 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-3 *,
-.emotion-3 *::after,
-.emotion-3 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-2 {
@@ -570,17 +516,11 @@ exports[`12 Column Options it should render a grid with 1 column 1`] = `
 
 exports[`12 Column Options it should render a grid with 2 columns 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -630,17 +570,11 @@ exports[`12 Column Options it should render a grid with 2 columns 1`] = `
 
 exports[`12 Column Options it should render a grid with 3 columns 1`] = `
 .emotion-7 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-7 *,
-.emotion-7 *::after,
-.emotion-7 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-6 {
@@ -694,17 +628,11 @@ exports[`12 Column Options it should render a grid with 3 columns 1`] = `
 
 exports[`12 Column Options it should render a grid with 4 columns 1`] = `
 .emotion-9 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-9 *,
-.emotion-9 *::after,
-.emotion-9 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-8 {
@@ -762,17 +690,11 @@ exports[`12 Column Options it should render a grid with 4 columns 1`] = `
 
 exports[`12 Column Options it should render a grid with 6 columns 1`] = `
 .emotion-13 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-13 *,
-.emotion-13 *::after,
-.emotion-13 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-12 {
@@ -838,17 +760,11 @@ exports[`12 Column Options it should render a grid with 6 columns 1`] = `
 
 exports[`12 Column Options it should render a grid with 12 columns 1`] = `
 .emotion-25 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-25 *,
-.emotion-25 *::after,
-.emotion-25 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-24 {
@@ -938,17 +854,11 @@ exports[`12 Column Options it should render a grid with 12 columns 1`] = `
 
 exports[`Column Offset Prop it should render two columns, one with a offset 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1003,17 +913,11 @@ exports[`Column Offset Prop it should render two columns, one with a offset 1`] 
 
 exports[`Column Offset Prop it should render two columns, one with a responsive offset 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1088,17 +992,11 @@ exports[`Column Offset Prop it should render two columns, one with a responsive 
 
 exports[`Column Span Prop it should render two columns with different responsive column spans 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1188,17 +1086,11 @@ exports[`Column Span Prop it should render two columns with different responsive
 
 exports[`Column Span Prop it should render two columns, one spaning 8 columns, the other spanning 4 columns 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1252,17 +1144,11 @@ exports[`Column Span Prop it should render two columns, one spaning 8 columns, t
 
 exports[`Column render it should render 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1283,17 +1169,11 @@ exports[`Column render it should render 1`] = `
 
 exports[`Column render it should render as any HTML element 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1314,17 +1194,11 @@ exports[`Column render it should render as any HTML element 1`] = `
 
 exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1376,17 +1250,11 @@ exports[`Grid Gutter Prop it should render two columns with gutters 1`] = `
 
 exports[`Grid Gutter Prop it should render two columns with responsive gutters 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1466,17 +1334,11 @@ exports[`Grid Gutter Prop it should render two columns with responsive gutters 1
 
 exports[`Grid Vertical Prop it should render two columns stacked only on mobile and tablet 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1559,17 +1421,11 @@ exports[`Grid Vertical Prop it should render two columns stacked only on mobile 
 
 exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
 .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1624,17 +1480,11 @@ exports[`Grid Vertical Prop it should render two stacked columns 1`] = `
 
 exports[`Grid render it should render 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1673,17 +1523,11 @@ exports[`Grid render it should render 1`] = `
 
 exports[`Grid render it should render as any HTML element 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/layout/media-object/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/layout/media-object/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`MediaBody should render 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -36,17 +30,11 @@ exports[`MediaBody should render 1`] = `
 
 exports[`MediaBody should render as any HTML element 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -70,17 +58,11 @@ exports[`MediaBody should render as any HTML element 1`] = `
 
 exports[`MediaFigure should render 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -109,17 +91,11 @@ exports[`MediaFigure should render 1`] = `
 
 exports[`MediaFigure should render as any HTML element 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -148,17 +124,11 @@ exports[`MediaFigure should render as any HTML element 1`] = `
 
 exports[`MediaFigure should render with spacing on the left for end alignment 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -187,17 +157,11 @@ exports[`MediaFigure should render with spacing on the left for end alignment 1`
 
 exports[`MediaFigure should render with spacing on the right for default alignment 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -226,17 +190,11 @@ exports[`MediaFigure should render with spacing on the right for default alignme
 
 exports[`MediaObject should render 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -265,17 +223,11 @@ exports[`MediaObject should render 1`] = `
 
 exports[`MediaObject should render as another HTML element 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -304,17 +256,11 @@ exports[`MediaObject should render as another HTML element 1`] = `
 
 exports[`MediaObject should render bottom margin 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -344,17 +290,11 @@ exports[`MediaObject should render bottom margin 1`] = `
 
 exports[`MediaObject should render top margin 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -384,17 +324,11 @@ exports[`MediaObject should render top margin 1`] = `
 
 exports[`MediaObject should render with center aligned children 1`] = `
 .emotion-1 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-1 *,
-.emotion-1 *::after,
-.emotion-1 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/layout/stack/__tests__/__snapshots__/stack.test.tsx.snap
+++ b/packages/paste-core/layout/stack/__tests__/__snapshots__/stack.test.tsx.snap
@@ -3,17 +3,11 @@
 exports[`Stack should render a horizontal stack 1`] = `
 <DocumentFragment>
   .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -83,17 +77,11 @@ exports[`Stack should render a horizontal stack 1`] = `
 exports[`Stack should render a responsive stack 1`] = `
 <DocumentFragment>
   .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -193,17 +181,11 @@ exports[`Stack should render a responsive stack 1`] = `
 exports[`Stack should render a vertical stack 1`] = `
 <DocumentFragment>
   .emotion-5 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-5 *,
-.emotion-5 *::after,
-.emotion-5 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-4 {

--- a/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
+++ b/packages/paste-core/primitives/box/__tests__/__snapshots__/box.test.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Backgrounds it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -39,17 +33,11 @@ exports[`Backgrounds it should render responsive values 1`] = `
 
 exports[`Backgrounds it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -70,17 +58,11 @@ exports[`Backgrounds it should render single values 1`] = `
 
 exports[`Borders it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -119,17 +101,11 @@ exports[`Borders it should render responsive values 1`] = `
 
 exports[`Borders it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -153,17 +129,11 @@ exports[`Borders it should render single values 1`] = `
 
 exports[`Shadows it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -190,17 +160,11 @@ exports[`Shadows it should render responsive values 1`] = `
 
 exports[`Shadows it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -221,17 +185,11 @@ exports[`Shadows it should render single values 1`] = `
 
 exports[`Sizes it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -280,17 +238,11 @@ exports[`Sizes it should render responsive values 1`] = `
 
 exports[`Sizes it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -318,17 +270,11 @@ exports[`Sizes it should render single values 1`] = `
 
 exports[`Spaces (A) it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -355,17 +301,11 @@ exports[`Spaces (A) it should render responsive values 1`] = `
 
 exports[`Spaces (A) it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -386,17 +326,11 @@ exports[`Spaces (A) it should render single values 1`] = `
 
 exports[`Spaces (B) it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -420,17 +354,11 @@ exports[`Spaces (B) it should render single values 1`] = `
 
 exports[`Spaces (B)it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -463,17 +391,11 @@ exports[`Spaces (B)it should render responsive values 1`] = `
 
 exports[`ZIndex Pseudo-class props it should generate pseudo-class CSS 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -611,17 +533,11 @@ exports[`ZIndex Pseudo-class props it should generate pseudo-class CSS 1`] = `
 
 exports[`ZIndex it should render responsive values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -648,17 +564,11 @@ exports[`ZIndex it should render responsive values 1`] = `
 
 exports[`ZIndex it should render single values 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-core/primitives/text/__tests__/__snapshots__/text.spec.tsx.snap
+++ b/packages/paste-core/primitives/text/__tests__/__snapshots__/text.spec.tsx.snap
@@ -2,17 +2,11 @@
 
 exports[`Pseudo-class props it should generate pseudo-class CSS 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -142,17 +136,11 @@ exports[`Pseudo-class props it should generate pseudo-class CSS 1`] = `
 
 exports[`as it should render as a provided HTML element 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -178,17 +166,11 @@ exports[`as it should render as a provided HTML element 1`] = `
 
 exports[`color should set a color property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -214,17 +196,11 @@ exports[`color should set a color property 1`] = `
 
 exports[`color should set a responsive color property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -261,17 +237,11 @@ exports[`color should set a responsive color property 1`] = `
 
 exports[`display should set a display property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -299,17 +269,11 @@ exports[`display should set a display property 1`] = `
 
 exports[`display should set a responsive display property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -348,17 +312,11 @@ exports[`display should set a responsive display property 1`] = `
 
 exports[`fontFamily should set a font family property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -386,17 +344,11 @@ exports[`fontFamily should set a font family property 1`] = `
 
 exports[`fontFamily should set a responsive font family property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -435,17 +387,11 @@ exports[`fontFamily should set a responsive font family property 1`] = `
 
 exports[`fontSize should set a font size property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -471,17 +417,11 @@ exports[`fontSize should set a font size property 1`] = `
 
 exports[`fontSize should set a responsive font size property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -518,17 +458,11 @@ exports[`fontSize should set a responsive font size property 1`] = `
 
 exports[`fontStyle should set a font style property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -556,17 +490,11 @@ exports[`fontStyle should set a font style property 1`] = `
 
 exports[`fontStyle should set a responsive font style property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -605,17 +533,11 @@ exports[`fontStyle should set a responsive font style property 1`] = `
 
 exports[`fontWeight should set a font weight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -643,17 +565,11 @@ exports[`fontWeight should set a font weight property 1`] = `
 
 exports[`fontWeight should set a responsive font weight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -692,17 +608,11 @@ exports[`fontWeight should set a responsive font weight property 1`] = `
 
 exports[`letterSpacing should set a letter spacing property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -733,17 +643,11 @@ exports[`letterSpacing should set a letter spacing property 1`] = `
 
 exports[`letterSpacing should set a responsive letter spacing property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -788,17 +692,11 @@ exports[`letterSpacing should set a responsive letter spacing property 1`] = `
 
 exports[`lineHeight should set a line height property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -824,17 +722,11 @@ exports[`lineHeight should set a line height property 1`] = `
 
 exports[`lineHeight should set a responsive line height property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -866,17 +758,11 @@ exports[`lineHeight should set a responsive line height property 1`] = `
 
 exports[`margin should set a margin property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -903,17 +789,11 @@ exports[`margin should set a margin property 1`] = `
 
 exports[`margin should set a responsive margin property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -946,17 +826,11 @@ exports[`margin should set a responsive margin property 1`] = `
 
 exports[`marginBottom should set a marginBottom property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -983,17 +857,11 @@ exports[`marginBottom should set a marginBottom property 1`] = `
 
 exports[`marginBottom should set a responsive marginBottom property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1026,17 +894,11 @@ exports[`marginBottom should set a responsive marginBottom property 1`] = `
 
 exports[`marginLeft should set a marginLeft property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1063,17 +925,11 @@ exports[`marginLeft should set a marginLeft property 1`] = `
 
 exports[`marginLeft should set a responsive marginLeft property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1106,17 +962,11 @@ exports[`marginLeft should set a responsive marginLeft property 1`] = `
 
 exports[`marginRight should set a marginRight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1143,17 +993,11 @@ exports[`marginRight should set a marginRight property 1`] = `
 
 exports[`marginRight should set a responsive marginRight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1186,17 +1030,11 @@ exports[`marginRight should set a responsive marginRight property 1`] = `
 
 exports[`marginTop should set a marginTop property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1223,17 +1061,11 @@ exports[`marginTop should set a marginTop property 1`] = `
 
 exports[`marginTop should set a responsive marginTop property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1266,17 +1098,11 @@ exports[`marginTop should set a responsive marginTop property 1`] = `
 
 exports[`padding should set a padding property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1303,17 +1129,11 @@ exports[`padding should set a padding property 1`] = `
 
 exports[`padding should set a responsive padding property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1346,17 +1166,11 @@ exports[`padding should set a responsive padding property 1`] = `
 
 exports[`paddingBottom should set a paddingBottom property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1383,17 +1197,11 @@ exports[`paddingBottom should set a paddingBottom property 1`] = `
 
 exports[`paddingBottom should set a responsive paddingBottom property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1426,17 +1234,11 @@ exports[`paddingBottom should set a responsive paddingBottom property 1`] = `
 
 exports[`paddingLeft should set a paddingLeft property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1463,17 +1265,11 @@ exports[`paddingLeft should set a paddingLeft property 1`] = `
 
 exports[`paddingLeft should set a responsive paddingLeft property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1506,17 +1302,11 @@ exports[`paddingLeft should set a responsive paddingLeft property 1`] = `
 
 exports[`paddingRight should set a paddingRight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1543,17 +1333,11 @@ exports[`paddingRight should set a paddingRight property 1`] = `
 
 exports[`paddingRight should set a responsive paddingRight property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1586,17 +1370,11 @@ exports[`paddingRight should set a responsive paddingRight property 1`] = `
 
 exports[`paddingTop should set a paddingTop property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1623,17 +1401,11 @@ exports[`paddingTop should set a paddingTop property 1`] = `
 
 exports[`paddingTop should set a responsive paddingTop property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1666,17 +1438,11 @@ exports[`paddingTop should set a responsive paddingTop property 1`] = `
 
 exports[`textAlign should set a responsive textAlign property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1709,17 +1475,11 @@ exports[`textAlign should set a responsive textAlign property 1`] = `
 
 exports[`textAlign should set a textAlign property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1746,17 +1506,11 @@ exports[`textAlign should set a textAlign property 1`] = `
 
 exports[`textDecoration should set a responsive textDecoration property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {
@@ -1797,17 +1551,11 @@ exports[`textDecoration should set a responsive textDecoration property 1`] = `
 
 exports[`textDecoration should set a textDecoration property 1`] = `
 .emotion-2 {
-  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   color: rgb(40,42,43);
+  font-size: 0.875rem;
+  font-family: 'Whitney SSm A','Whitney SSm B','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.5rem;
   font-weight: 400;
-}
-
-.emotion-2 *,
-.emotion-2 *::after,
-.emotion-2 *::before {
-  box-sizing: border-box;
 }
 
 .emotion-0 {

--- a/packages/paste-libraries/animation/package.json
+++ b/packages/paste-libraries/animation/package.json
@@ -27,7 +27,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "react-spring": "8.0.27"
+    "@react-spring/web": "9.0.0-rc.3",
+    "@react-spring/shared": "9.0.0-rc.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/paste-libraries/animation/src/index.tsx
+++ b/packages/paste-libraries/animation/src/index.tsx
@@ -1,1 +1,34 @@
-export * from 'react-spring';
+import {
+  animated,
+  AnimatedProps,
+  useSpring,
+  UseSpringProps,
+  useTransition,
+  UseTransitionProps,
+  useTrail,
+  UseTrailProps,
+  useSprings,
+  UseSpringsProps,
+  useChain,
+  interpolate,
+} from '@react-spring/web';
+import {Globals} from '@react-spring/shared';
+import {useReducedMotion, isRenderingOnServer} from './useReducedMotion';
+
+export {
+  Globals,
+  animated,
+  AnimatedProps,
+  useSpring,
+  UseSpringProps,
+  useTransition,
+  UseTransitionProps,
+  useTrail,
+  UseTrailProps,
+  useSprings,
+  UseSpringsProps,
+  useChain,
+  interpolate,
+  useReducedMotion,
+  isRenderingOnServer,
+};

--- a/packages/paste-libraries/animation/src/useReducedMotion.tsx
+++ b/packages/paste-libraries/animation/src/useReducedMotion.tsx
@@ -1,0 +1,51 @@
+// Credits:
+// https://github.com/infiniteluke/react-reduce-motion
+// https://joshwcomeau.com/react/prefers-reduced-motion/#the-hook
+import * as React from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+// Due to a bug in how terser is compiling these functions,
+// we're getting into situations where SSR is checking for window.matchMedia.
+// Wrapping the second return in an else fixes how terser compiles the code.
+/* eslint-disable no-else-return */
+export const isRenderingOnServer = (() => {
+  if (typeof window == 'undefined' || !window.location || !window.location.href) {
+    return true;
+  } else {
+    // Disable animations during VRT
+    return Boolean(new URL(window.location.href).searchParams.get('eyes-storybook'));
+  }
+})();
+
+const getMediaQueryList = (): {matches: boolean; addListener: Function; removeListener: Function} => {
+  if (isRenderingOnServer) {
+    return {
+      matches: true, // When SSR, true === disable animations
+      addListener: () => {},
+      removeListener: () => {},
+    };
+  } else {
+    return window.matchMedia(REDUCED_MOTION_QUERY);
+  }
+};
+/* eslint-enable no-else-return */
+
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(getMediaQueryList().matches);
+
+  React.useEffect((): (() => void) => {
+    const mediaQueryList = getMediaQueryList();
+
+    const handleChange = (): void => {
+      setPrefersReducedMotion(mediaQueryList.matches);
+    };
+
+    mediaQueryList.addListener(handleChange);
+    return () => {
+      mediaQueryList.removeListener(handleChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/packages/paste-theme/package.json
+++ b/packages/paste-theme/package.json
@@ -27,7 +27,9 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
+    "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/design-tokens": "^5.2.0",
     "@twilio-paste/types": "^3.0.7",
     "react": "^16.8.6",
@@ -35,6 +37,7 @@
     "styled-system": "^5.1.2"
   },
   "devDependencies": {
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/design-tokens": "^5.2.0",
     "@twilio-paste/types": "^3.0.7"
   }

--- a/packages/paste-theme/tsconfig.build.json
+++ b/packages/paste-theme/tsconfig.build.json
@@ -9,6 +9,9 @@
   ],
   "references": [
     {
+      "path": "../paste-libraries/animation"
+    },
+    {
       "path": "../paste-design-tokens"
     },
     {

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -24,6 +24,7 @@
     "@styled-system/css": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@twilio-paste/absolute": "^2.0.38",
+    "@twilio-paste/animation-library": "^0.1.1",
     "@twilio-paste/alert": "^0.1.45",
     "@twilio-paste/anchor": "^1.1.17",
     "@twilio-paste/aspect-ratio": "^1.0.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@alloc/types@^1.2.1":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@alloc/types/-/types-1.2.5.tgz#108e4c1d9c593723e9702efc21e59d50093e972d"
+  integrity sha512-/P8+QHJCG+xhXlFa9XH/Udy6Q8BFonQOJGzb2n6OVVlOa7VWoNGOJgkEGcJj7PkP4pMYFry9iIgprRLSAqN1Aw==
+
 "@applitools/dom-snapshot@3.4.5":
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-3.4.5.tgz#0669657dd5676d11fe5339db3a4f6315ba59834b"
@@ -3259,6 +3264,46 @@
   dependencies:
     tslib "^1.10.0"
     warning "^4.0.3"
+
+"@react-spring/animated@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.0.0-rc.3.tgz#e792cb76aacecfc78db2be6020ac11ce96503eb5"
+  integrity sha512-dAvgtKhkYpzzr+EkmZ4ZuJ5CujxCW0LaT109DvO/2MQNk3EWIxcgl+ik4tSulSbgau1GN8RlkRKyDp0wISdQ3Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/shared" "9.0.0-rc.3"
+    react-layout-effect "^1.0.1"
+
+"@react-spring/core@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.0.0-rc.3.tgz#c8e697573936c525bd0f6ca0c0869f75c86e8a83"
+  integrity sha512-3OzsVFxpfMJNkkQj8TwAH3NhUAX76AXu6WkslQF4EgBeEoG5eY3m+VvM9RsAsGWDuBKpscZ/wBpFt5Ih6KdGHA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+    react-layout-effect "^1.0.1"
+    use-memo-one "^1.1.0"
+
+"@react-spring/shared@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.0.0-rc.3.tgz#3f4c9d90accc20fef51a283a7806d78390b84161"
+  integrity sha512-dd50TxwwMWd+dSB0InjndUN9w17cbnMCPy+0sag6zRxxKIo7eOyWSliOtLKxvufgmdC8Prm4M3GT5dmB1yxKEQ==
+  dependencies:
+    "@alloc/types" "^1.2.1"
+    "@babel/runtime" "^7.3.1"
+    fluids "^0.1.6"
+    tslib "^1.11.1"
+
+"@react-spring/web@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.0.0-rc.3.tgz#da977382f91d9af4c400e4aa7dc37d3db07b87e0"
+  integrity sha512-rEvipblmihiz8+Eo01zDp5dqWn6XfYk8q2rlN9c18YIOL4o6nuY/VplDoocUMHYfH4liurpO4o1QudKOO1nAiQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
 
 "@rollup/plugin-commonjs@^11.0.2":
   version "11.1.0"
@@ -11335,6 +11380,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+fluids@^0.1.6:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/fluids/-/fluids-0.1.8.tgz#0a708b4f917f96ed9453dc21ab167d4bae9877c3"
+  integrity sha512-tl3nUHkZeqCJs6FnlN4hTLmOzwDNXWqRbTIXGOkUT6HUAAuWsd28CyxwLOy9KAIbJNY2Bgn2C2gZVRiEhdCtBg==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"
@@ -20335,6 +20385,11 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-layout-effect@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-layout-effect/-/react-layout-effect-1.0.5.tgz#0dc4e24452aee5de66c93c166f0ec512dfb1be80"
+  integrity sha512-zdRXHuch+OBHU6bvjTelOGUCM+UDr/iCY+c0wXLEAc+G4/FlcJruD/hUOzlKH5XgO90Y/BUJPNhI/g9kl+VAsA==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -20464,14 +20519,6 @@ react-sizeme@^2.5.2, react-sizeme@^2.6.7:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
-
-react-spring@8.0.27:
-  version "8.0.27"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
-  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    prop-types "^15.5.8"
 
 react-style-singleton@^2.1.0:
   version "2.1.0"
@@ -23776,6 +23823,11 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
+tslib@^1.11.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tsutils@^3.17.1, tsutils@^3.7.0:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -24445,6 +24497,11 @@ use-callback-ref@^1.2.1, use-callback-ref@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.3.tgz#9f939dfb5740807bbf9dd79cdd4e99d27e827756"
   integrity sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA==
+
+use-memo-one@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use-sidecar@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
In the process of adding animations to our Modal component, I also wanted to make sure we handled the prefers-reduced-motion media query.  

This PR:
- [x] Unfortunately, react-spring v8 didn't have a mechanism to globally modify/disable animations so I bumped that library to v9 RC3.  
- [x] Add the animation-library dependency to other Paste packages.
- [x] Makes animations globally (CSS and JS using our lib) respect the [prefers-reduced-motion](https://css-tricks.com/introduction-reduced-motion-media-query/) system setting.
- [x] Adds an open/close animation to the Modal component
- [x] Disables JS animations by default on Applitools (for VRT)
- [x] Adds a minHeight to the Modal component to prevent the footer buttons from overflowing
- [x] Adds an exported React Hook "useReducedMotion" to the animation-library, to determine whether the user has that flag toggled on or off
- [x] Updates the ThemeProvider to use our more recent style of writing CSS, moves the `box-sizing` styles into the global styles block (so it doesn't dupe), and globally disables CSS animations for any user of ThemeProvider if prefers-reduced-motion is on.

---

Sidenote: a neat animation visualizer https://react-spring-visualizer.com/