### PR TITLE
feat(Modal docs): add guideline about using h4 in Modal Body

### DIFF
--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -191,7 +191,7 @@ Include a Header, Body, and Footer in your modal.
 
 Modal Header text should be concise (2-4 words), start with a verb, and clearly describe the information or action the modal presents.
 
-Modal Body should be focused to 1 main section of content that's described by Modal Header text. If you do need to create multiple sections of content with Headings in Modal Body, use [Heading with the `heading40` variant](/components/heading#heading-as-h-2-with-heading-40-variant).
+Modal Body should have 1 main section of content that's described by the text in the Modal Header. If you do need to create multiple sections of content with Headings in Modal Body, use a [Heading with the `heading40` variant](/components/heading#heading-as-h-2-with-heading-40-variant).
 
 Modal Footers should include 1–2 actions aligned to the right side of the modal. Place the primary action farthest on the right to indicate to users they're progressing through their task.
 

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -187,9 +187,13 @@ To set a different initial focus target, set the `initialFocusRef` prop on the `
 
 ## Composition Notes
 
-Include a Header, Body, and Footer in your modal. Heading text should be concise (2-4 words), start with a verb, and clearly describe the information or action the modal presents.
+Include a Header, Body, and Footer in your modal.
 
-Footers should include 1–2 actions aligned to the right side of the modal. Place the primary action farthest on the right to indicate to users they're progressing through their task.
+Modal Header text should be concise (2-4 words), start with a verb, and clearly describe the information or action the modal presents.
+
+The Body of a Modal should be focused to 1 main section of content that's described by the Modal Header text. If you do need to create multiple sections of content with Headings in Modal Body, use [Heading with the `heading40` variant](/components/heading#heading-as-h-2-with-heading-40-variant).
+
+Modal Footers should include 1–2 actions aligned to the right side of the modal. Place the primary action farthest on the right to indicate to users they're progressing through their task.
 
 ### Footer actions alignment
 
@@ -312,7 +316,7 @@ If you need to show an important warning to prevent or correct critical errors, 
 
 | Property            | Default token/child | Modifiable? |
 | ------------------- | ------------------- | ----------- |
-| Heading             | H3                  | No          |
+| Heading             | h3                  | No          |
 | close-icon-color    | color-text-weak     | No          |
 | close-icon-size     | size-icon-60        | No          |
 | padding             | space-50            | No          |

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -191,7 +191,7 @@ Include a Header, Body, and Footer in your modal.
 
 Modal Header text should be concise (2-4 words), start with a verb, and clearly describe the information or action the modal presents.
 
-The Body of a Modal should be focused to 1 main section of content that's described by the Modal Header text. If you do need to create multiple sections of content with Headings in Modal Body, use [Heading with the `heading40` variant](/components/heading#heading-as-h-2-with-heading-40-variant).
+Modal Body should be focused to 1 main section of content that's described by Modal Header text. If you do need to create multiple sections of content with Headings in Modal Body, use [Heading with the `heading40` variant](/components/heading#heading-as-h-2-with-heading-40-variant).
 
 Modal Footers should include 1–2 actions aligned to the right side of the modal. Place the primary action farthest on the right to indicate to users they're progressing through their task.
 


### PR DESCRIPTION
Add guideline to Composition Notes about using h4 in Modal Body

https://paste-git-featmodal-docs-use-h4-in-body.twilio-dsys.now.sh/components/modal/#composition-notes