### PR TITLE
feat(Paragraph docs): change Anatomy to show margin-bottom is modifiable

### DIFF
--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -196,7 +196,7 @@ Paragraphs should be used for most text blocks. Paragraphs provide defaults for 
 | font-size     | font-size-30       | No          |
 | line-height   | line-height-30     | No          |
 | font-weight   | font-weight-normal | No          |
-| margin-bottom | space-70           | No          |
+| margin-bottom | space-70           | Yes         |
 | color         | color-text         | No          |
 
 ---


### PR DESCRIPTION
Updated Anatomy section in Paragraph docs to show margin-bottom is modifiable