### PR TITLE
fix(website): setup responsive friendly structure

### DIFF
--- a/packages/paste-style-props/src/proptypes/layout.ts
+++ b/packages/paste-style-props/src/proptypes/layout.ts
@@ -2,10 +2,10 @@ import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
 
 // Tokens
-const WidthOptions = ['100%', 'auto', ...Object.keys(DefaultTheme.widths)];
+const WidthOptions = ['100%', '100vw', 'auto', ...Object.keys(DefaultTheme.widths)];
 const MinWidthOptions = Object.keys(DefaultTheme.minWidths);
 const MaxWidthOptions = Object.keys(DefaultTheme.maxWidths);
-const HeightOptions = ['100%', 'auto', ...Object.keys(DefaultTheme.heights)];
+const HeightOptions = ['100%', '100vh', 'auto', ...Object.keys(DefaultTheme.heights)];
 const MinHeightOptions = Object.keys(DefaultTheme.minHeights);
 const MaxHeightOptions = Object.keys(DefaultTheme.maxHeights);
 const IconSizeOptions = Object.keys(DefaultTheme.iconSizes);

--- a/packages/paste-style-props/src/types/layout.ts
+++ b/packages/paste-style-props/src/types/layout.ts
@@ -4,10 +4,10 @@ import {ThemeShape} from '@twilio-paste/theme';
 import {ResponsiveValue, TLengthStyledSystem} from 'styled-system';
 
 // Tokens
-export type WidthOptions = keyof ThemeShape['widths'] | '100%' | 'auto';
+export type WidthOptions = keyof ThemeShape['widths'] | '100%' | '100vw' | 'auto';
 export type MinWidthOptions = keyof ThemeShape['minWidths'];
 export type MaxWidthOptions = keyof ThemeShape['maxWidths'];
-export type HeightOptions = keyof ThemeShape['heights'] | '100%' | 'auto';
+export type HeightOptions = keyof ThemeShape['heights'] | '100%' | '100vh' | 'auto';
 export type MinHeightOptions = keyof ThemeShape['minHeights'];
 export type MaxHeightOptions = keyof ThemeShape['maxHeights'];
 export type IconSizeOptions = keyof ThemeShape['iconSizes'];

--- a/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
@@ -11,7 +11,6 @@ import {SiteMain, SiteMainInner} from './SiteMain';
 import {SiteFooter} from './SiteFooter';
 import {ScrollAnchorIntoView} from './ScrollAnchorIntoView';
 import {useActiveSiteTheme} from '../../context/ActiveSiteThemeContext';
-import {PASTE_THEME_WARNING_BANNER_OFFSET, PASTE_THEME_WARNING_BANNER_OFFSET_BLM} from '../../constants';
 
 interface StyledSiteBodyProps {
   activeTheme: string;
@@ -19,17 +18,8 @@ interface StyledSiteBodyProps {
 
 /* Wraps the entire doc site page */
 const StyledSiteBody = styled.div<StyledSiteBodyProps>`
-  position: absolute; /* Absolute so we can only scroll the inner area */
-  top: ${props =>
-    props.activeTheme === 'default' ? PASTE_THEME_WARNING_BANNER_OFFSET_BLM : PASTE_THEME_WARNING_BANNER_OFFSET};
-  right: 0;
-  bottom: 0;
-  left: 0;
   display: flex;
-  min-height: 100vh;
   min-width: 240px;
-  height: 100vh;
-  overflow: hidden;
 
   @supports (display: grid) {
     display: grid;
@@ -49,6 +39,9 @@ const BLMAlert: React.FC = () => {
       role="status"
       display="flex"
       justifyContent="center"
+      position="sticky"
+      top="0"
+      zIndex="zIndex20"
     >
       <Text as="span" fontWeight="fontWeightBold" color="colorTextBrandInverse" marginRight="space30">
         Black Lives Matter.
@@ -88,12 +81,14 @@ export const SiteBody: React.FC = ({children}) => {
       )}
       <StyledSiteBody activeTheme={activeTheme}>
         <Sidebar />
-        <SiteHeader />
-        <SiteMain id="site-main">
-          <ScrollAnchorIntoView />
-          <SiteMainInner>{children}</SiteMainInner>
-          <SiteFooter />
-        </SiteMain>
+        <Box height="100vh" overflow="auto">
+          <SiteHeader />
+          <SiteMain id="site-main">
+            <ScrollAnchorIntoView />
+            <SiteMainInner>{children}</SiteMainInner>
+            <SiteFooter />
+          </SiteMain>
+        </Box>
       </StyledSiteBody>
     </>
   );

--- a/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
-import {Flex} from '@twilio-paste/flex';
 import {Box} from '@twilio-paste/box';
 import {Stack} from '@twilio-paste/stack';
 import {Anchor} from '@twilio-paste/anchor';
 import {useTheme} from '@twilio-paste/theme';
-import {Absolute} from '@twilio-paste/absolute';
 import {ThemeSwitcher} from '../ThemeSwitcher';
 import {Search} from '../search';
 import {ContactUsMenu} from '../ContactUsMenu';
 import GithubIcon from '../icons/GithubIcon';
-import {SIDEBAR_WIDTH, HEADER_HEIGHT} from './constants';
 import {version} from '../../../../../package.json';
 
 export const SiteHeader: React.FC<{}> = () => {
   const theme = useTheme();
   return (
-    <Absolute
-      preset="top_fill"
+    <Box
       as="aside"
       backgroundColor="colorBackgroundBody"
       borderColor="colorBorderLight"
@@ -26,31 +22,39 @@ export const SiteHeader: React.FC<{}> = () => {
       paddingRight="space80"
       paddingTop="space50"
       paddingBottom="space50"
-      marginBottom="space140"
-      css={{
-        left: SIDEBAR_WIDTH,
-        height: HEADER_HEIGHT,
-      }}
+      position="sticky"
+      top="0"
+      zIndex="zIndex10"
     >
-      <Flex hAlignContent="between" vAlignContent="center">
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems={['flex-start', 'flex-start', 'flex-start', 'center']}
+        flexDirection={['column', 'column', 'column', 'row']}
+      >
         <ThemeSwitcher />
-        <Stack orientation="horizontal" spacing="space60">
-          <Box minWidth="size40">
-            <Search />
-          </Box>
-          <ContactUsMenu />
-          <Stack orientation="horizontal" spacing="space30">
-            <span>v{version}</span>
-            <Anchor href="https://www.github.com/twilio-labs/paste">
-              <GithubIcon
-                css={{height: theme.heights.sizeIcon30, width: theme.heights.sizeIcon30}}
-                title="View this project on github"
-                color={theme.textColors.colorTextWeak}
-              />
-            </Anchor>
+        <Box marginTop={['space40', 'space40', 'space40', 'space0']}>
+          <Stack orientation="horizontal" spacing="space60">
+            <Box
+              minWidth={['size20', 'size20', 'size20', 'size40']}
+              marginBottom={['space40', 'space40', 'space40', 'space0']}
+            >
+              <Search />
+            </Box>
+            <ContactUsMenu />
+            <Stack orientation="horizontal" spacing="space30">
+              <span>v{version}</span>
+              <Anchor href="https://www.github.com/twilio-labs/paste">
+                <GithubIcon
+                  css={{height: theme.heights.sizeIcon30, width: theme.heights.sizeIcon30}}
+                  title="View this project on github"
+                  color={theme.textColors.colorTextWeak}
+                />
+              </Anchor>
+            </Stack>
           </Stack>
-        </Stack>
-      </Flex>
-    </Absolute>
+        </Box>
+      </Box>
+    </Box>
   );
 };

--- a/packages/paste-website/src/components/site-wrapper/SiteMain.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteMain.tsx
@@ -1,11 +1,9 @@
 import styled from '@emotion/styled';
 import {themeGet} from '@styled-system/theme-get';
-import {HEADER_HEIGHT} from './constants';
 
 export const SiteMain = styled.main`
   position: relative;
   overflow: auto;
-  margin-top: ${HEADER_HEIGHT};
   padding-top: ${themeGet('space.space100')};
 `;
 

--- a/packages/paste-website/src/components/site-wrapper/SiteThemeProvider.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteThemeProvider.tsx
@@ -4,7 +4,17 @@ import {useActiveSiteTheme} from '../../context/ActiveSiteThemeContext';
 
 const SiteThemeProvider: React.FC = ({children}) => {
   const {theme} = useActiveSiteTheme();
-  return <Theme.Provider theme={theme}>{children}</Theme.Provider>;
+  return (
+    <Theme.Provider
+      theme={theme}
+      css={{
+        height: '100vh',
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </Theme.Provider>
+  );
 };
 
 export {SiteThemeProvider};

--- a/packages/paste-website/src/components/site-wrapper/constants.ts
+++ b/packages/paste-website/src/components/site-wrapper/constants.ts
@@ -1,2 +1,1 @@
 export const SIDEBAR_WIDTH = '240px';
-export const HEADER_HEIGHT = '76px';

--- a/packages/paste-website/src/constants.ts
+++ b/packages/paste-website/src/constants.ts
@@ -3,9 +3,6 @@ export const TWILIO_BLUE = '#0D122B';
 
 export const PASTE_PACKAGE_PREFIX = '@twilio-paste/';
 
-export const PASTE_THEME_WARNING_BANNER_OFFSET = '44px';
-export const PASTE_THEME_WARNING_BANNER_OFFSET_BLM = '90px';
-
 export const SidebarCategoryRoutes = {
   COMPONENTS: '/components',
   PRIMITIVES: '/primitives',


### PR DESCRIPTION
- [x] Setup more responsive site wrapper so top bar is more responsive friendly. (Not perfect, but better).
- [x] Add `100vh` and `100vw` to style props and proptypes for height and width

Screen capture showing responsive top bar: https://share.getcloudapp.com/E0uz5pNy