### PR TITLE
fix(docs): homepage typo

### DIFF
--- a/packages/paste-website/src/pages/index.tsx
+++ b/packages/paste-website/src/pages/index.tsx
@@ -62,7 +62,7 @@ const IndexPage: React.FC<{}> = (): React.ReactElement => {
               <SiteLink to="/content">Content</SiteLink>
             </Heading>
             <Paragraph>
-              Read our content guidelines to write authentic ands inclusive content for Twilio&rsquo;s products.
+              Read our content guidelines to write authentic and inclusive content for Twilio&rsquo;s products.
             </Paragraph>
           </Card>
           <Card padding="space80">


### PR DESCRIPTION
I can't spell

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
