### PR TITLE
fix(website): adding resolution for vulnerable sub-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,9 @@
     "typescript": "3.7.5",
     "webpack": "^4.35.3"
   },
+  "resolutions": {
+    "**/websocket-extensions": "^0.1.4"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "precise-commits",

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -87,5 +87,8 @@
     "react-scrollspy": "^3.4.0",
     "react-uid": "^2.2.0",
     "styled-system": "^5.1.2"
+  },
+  "resolutions": {
+    "**/websocket-extensions": "^0.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25524,10 +25524,10 @@ websocket-driver@>=0.5.1:
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
-websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+websocket-extensions@>=0.1.1, websocket-extensions@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Using [yarn resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this) to update a vulnerable sub-dependency detected by dependabot (https://github.com/twilio-labs/paste/pull/483)