### PR TITLE
chore(website): resolve graphql-playground-middleware-express v 1.7.18

### DIFF
--- a/RESOLUTIONS.md
+++ b/RESOLUTIONS.md
@@ -1,0 +1,26 @@
+# Package Resolution Reasoning
+
+This document serves as notes for why certain packages needed a resolution line in our package.json files.
+[Why would you want to use selective version resolution?](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this)
+
+## "websocket-extensions": "^0.1.4"
+
+Reason: [vulnerability](https://github.com/twilio-labs/paste/pull/483)
+
+```
+- Hoisted from "_project_#websocket-driver#websocket-extensions"
+- Hoisted from "_project_#@twilio-paste#website#gatsby#webpack-dev-server#sockjs#websocket-driver#websocket-extensions"
+- Hoisted from "_project_#@twilio-paste#website#gatsby#webpack-dev-server#sockjs#faye-websocket#websocket-driver#websocket-extensions"
+```
+
+Fix blocked on [this PR](https://github.com/faye/websocket-driver-node/pull/37). Maintainer recommends using yarn resolution instead. Even after a fix would be applied, we would need to wait for Gatsby to upgrade this package as well.
+
+## "graphql-playground-middleware-express": "^1.7.18"
+
+Reason: [vulnerability](https://github.com/twilio-labs/paste/pull/494)
+
+```
+- Hoisted from "_project_#@twilio-paste#website#gatsby#graphql-playground-middleware-express"
+```
+
+At this time, the latest Gatsby version does not have the correct version of this package.

--- a/package.json
+++ b/package.json
@@ -186,7 +186,8 @@
     "webpack": "^4.35.3"
   },
   "resolutions": {
-    "**/websocket-extensions": "^0.1.4"
+    "**/websocket-extensions": "^0.1.4",
+    "**/graphql-playground-middleware-express": "^1.7.18"
   },
   "husky": {
     "hooks": {

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -89,6 +89,7 @@
     "styled-system": "^5.1.2"
   },
   "resolutions": {
-    "**/websocket-extensions": "^0.1.4"
+    "**/websocket-extensions": "^0.1.4",
+    "**/graphql-playground-middleware-express": "^1.7.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8186,7 +8186,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.11.0, commander@^2.18.0, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.18.0, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0, commander@^2.20.3, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -8963,6 +8963,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -13107,17 +13112,19 @@ graphql-import@^0.7.1:
     lodash "^4.17.4"
     resolve-from "^4.0.0"
 
-graphql-playground-html@^1.6.19:
-  version "1.6.19"
-  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.19.tgz#3883ecf5e8c18b3c0f08145b5417b9c01a1f0bef"
-  integrity sha512-cLAqoOlxHbGj/LBpr4l2BE9qXf3g8ShjQqU2daVueITI/3wIkcDQTaQaQp+HWv0uaX0dCsgMCFW/TooLj8yJOg==
-
-graphql-playground-middleware-express@^1.7.14:
-  version "1.7.14"
-  resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.14.tgz#19ec806c54e3d8c213e1bf00088e9e236f49b258"
-  integrity sha512-EqoAhbRBd7rEEEDFfvECQVmZnC4cOEmRc5goiiZldozt2GZB2UBK3/7p0DAtflg6S1w6SNUR8Tg9cDLjiL1Dew==
+graphql-playground-html@1.6.25:
+  version "1.6.25"
+  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.25.tgz#2d8fa250cec4036a4f5b7f8ad069c86d6d64c95f"
+  integrity sha512-wMNvGsQ0OwBVhn72VVi7OdpI85IxiIZT43glRx7gQIwQ6NvhFnzMYBIVmcJAJ4UlXRYiWtrQhuOItDXObiR3kg==
   dependencies:
-    graphql-playground-html "^1.6.19"
+    xss "^1.0.6"
+
+graphql-playground-middleware-express@^1.7.14, graphql-playground-middleware-express@^1.7.18:
+  version "1.7.18"
+  resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.18.tgz#306d64d54ccb531baf7df0699df3220ca4e25364"
+  integrity sha512-EywRL+iBa4u//5YbY1iJxrl0n4IKyomBKgLXrMbG8gHJUwxmFs5FCWJJ4Q6moSn5Q3RgMZvrWzXB27lKwN8Kgw==
+  dependencies:
+    graphql-playground-html "1.6.25"
 
 graphql-request@^1.5.0:
   version "1.8.2"
@@ -25890,6 +25897,14 @@ xregexp@^4.3.0:
   integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
+
+xss@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.7.tgz#a554cbd5e909324bd6893fb47fff441ad54e2a95"
+  integrity sha512-A9v7tblGvxu8TWXQC9rlpW96a+LN1lyw6wyhpTmmGW+FwRMactchBR3ROKSi33UPCUcUHSu8s9YP6F+K3Mw//w==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 xstate@^4.9.1:
   version "4.9.1"


### PR DESCRIPTION
Using [yarn resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this) to update a vulnerable sub-dependency detected by dependabot (https://github.com/twilio-labs/paste/pull/494)

I also add a `RESOLUTIONS.md` file to keep notes on why these lines exist. We can't add comments to the package.json file directly, so this was my next best approach.