### PR TITLE
docs(modal): fix the link to the modal changelogs

### DIFF
--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -16,7 +16,7 @@ import {Button} from '@twilio-paste/button';
 import {Grid, Column} from '@twilio-paste/grid';
 import {Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading} from '@twilio-paste/modal';
 import {FormLabel, FormInput, Select, Option} from '@twilio-paste/form';
-import Changelog from '@twilio-paste/separator/CHANGELOG.md';
+import Changelog from '@twilio-paste/modal/CHANGELOG.md';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {Codeblock} from '../../../components/codeblock';
 import {SidebarCategoryRoutes} from '../../../constants';


### PR DESCRIPTION
Modal page was using the separator change log. Updating the package name to fix it.