### PR TITLE
fix(modal): add '__console_patch' prop to fix bug in Console

### DIFF
--- a/packages/paste-core/components/modal/src/Modal.tsx
+++ b/packages/paste-core/components/modal/src/Modal.tsx
@@ -5,6 +5,7 @@ import {useTransition, animated} from '@twilio-paste/animation-library';
 import {pasteBaseStyles} from '@twilio-paste/theme';
 import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '@twilio-paste/modal-dialog-primitive';
 import {ModalContext} from './ModalContext';
+import {addConsoleHeightPatch, removeConsoleHeightPatch} from './utils/consoleUtils';
 
 const ModalDialogOverlay = animated(
   /* eslint-disable emotion/syntax-preference */
@@ -67,6 +68,8 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   size: Sizes;
   initialFocusRef?: React.RefObject<any>;
   ariaLabelledby: string;
+  // Adds an 80px margin to the root elements on the Console application
+  __console_patch?: boolean;
 }
 
 const AnimationStates = {
@@ -89,9 +92,23 @@ const Modal: React.FC<ModalProps> = ({
   initialFocusRef,
   ariaLabelledby,
   size,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  __console_patch = false,
   ...props
 }) => {
   const transitions = useTransition(isOpen, AnimationStates);
+
+  React.useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    if (__console_patch) {
+      if (isOpen) {
+        addConsoleHeightPatch();
+      } else {
+        removeConsoleHeightPatch();
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/camelcase
+  }, [isOpen, __console_patch]);
 
   return (
     <ModalContext.Provider value={{onDismiss}}>

--- a/packages/paste-core/components/modal/src/utils/consoleUtils.ts
+++ b/packages/paste-core/components/modal/src/utils/consoleUtils.ts
@@ -1,0 +1,45 @@
+/*
+ * HACK NOTICE:
+ * This is an eggregious hack but currently the best way for us
+ * to maintain accessibility in our modal and keep it functional
+ * in Twilio's Console application.
+ *
+ * For more info, see: https://github.com/reach/reach-ui/issues/610
+ *
+ * FIXME: when the Console app redesigns navigation
+ */
+
+// 80px because the issue is the `calc(100vh - 80px)`
+const MARGIN_AMOUNT_BASED_ON_CALC_OFFSET = '80px';
+
+export function addConsoleHeightPatch(): void {
+  if (document == null) {
+    return;
+  }
+
+  const CONTENT_WRAPPER = document.querySelector('#content') as HTMLElement;
+  const SIDEBAR_WRAPPER = document.querySelector('#sidebar-wrapper') as HTMLElement;
+
+  if (CONTENT_WRAPPER != null) {
+    CONTENT_WRAPPER.style.marginTop = MARGIN_AMOUNT_BASED_ON_CALC_OFFSET;
+  }
+  if (SIDEBAR_WRAPPER != null) {
+    SIDEBAR_WRAPPER.style.marginTop = MARGIN_AMOUNT_BASED_ON_CALC_OFFSET;
+  }
+}
+
+export function removeConsoleHeightPatch(): void {
+  if (document == null) {
+    return;
+  }
+
+  const CONTENT_WRAPPER = document.querySelector('#content') as HTMLElement;
+  const SIDEBAR_WRAPPER = document.querySelector('#sidebar-wrapper') as HTMLElement;
+
+  if (CONTENT_WRAPPER != null) {
+    CONTENT_WRAPPER.style.marginTop = '';
+  }
+  if (SIDEBAR_WRAPPER != null) {
+    SIDEBAR_WRAPPER.style.marginTop = '';
+  }
+}

--- a/packages/paste-core/components/modal/stories/index.stories.tsx
+++ b/packages/paste-core/components/modal/stories/index.stories.tsx
@@ -419,4 +419,38 @@ storiesOf('Components|Modal', module)
         </Modal>
       </div>
     );
+  })
+  .add('console patch prop', () => {
+    const [isOpen, setIsOpen] = React.useState(true);
+    const handleOpen = (): void => setIsOpen(true);
+    const handleClose = (): void => setIsOpen(false);
+    const modalHeadingID = useUID();
+    return (
+      <Flex>
+        <div id="sidebar-wrapper">Sidebar</div>
+        <div id="content">
+          <Button variant="primary" onClick={handleOpen}>
+            Open Modal
+          </Button>
+          <Modal ariaLabelledby={modalHeadingID} isOpen={isOpen} onDismiss={handleClose} size="default" __console_patch>
+            <ModalHeader>
+              <ModalHeading as="h3" id={modalHeadingID}>
+                Modal Heading
+              </ModalHeading>
+            </ModalHeader>
+            <ModalBody>Look at the background, behind the dark overlay.</ModalBody>
+            <ModalFooter>
+              <ModalFooterActions>
+                <Button variant="secondary" onClick={handleClose}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={handleClose}>
+                  Submit
+                </Button>
+              </ModalFooterActions>
+            </ModalFooter>
+          </Modal>
+        </div>
+      </Flex>
+    );
   });

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -392,15 +392,16 @@ const ModalTrigger = () => {
 
 #### Modal Props
 
-| Prop             | Type                         | Description | Default |
-| ---------------- | ---------------------------- | ----------- | ------- |
-| children         | `ReactNode`                  |             | null    |
-| isOpen           | `boolean`                    |             | null    |
-| onDismiss        | `Function() => void`         |             | null    |
-| allowPinchZoom?  | `boolean`                    |             | true    |
-| size             | `oneOf(['default', 'wide'])` |             | null    |
-| initialFocusRef? | `RefObject`                  |             | null    |
-| ariaLabelledby   | `string`                     |             | null    |
+| Prop              | Type                         | Description                                               | Default |
+| ----------------- | ---------------------------- | --------------------------------------------------------- | ------- |
+| children          | `ReactNode`                  |                                                           | null    |
+| isOpen            | `boolean`                    |                                                           | null    |
+| onDismiss         | `Function() => void`         |                                                           | null    |
+| allowPinchZoom?   | `boolean`                    |                                                           | true    |
+| size              | `oneOf(['default', 'wide'])` |                                                           | null    |
+| initialFocusRef?  | `RefObject`                  |                                                           | null    |
+| ariaLabelledby    | `string`                     |                                                           | null    |
+| `__console_patch` | `boolean`                    | Enable to fix Console's marginBottom bug when modal opens | null    |
 
 #### ModalHeader Props
 


### PR DESCRIPTION
Fixes an issue specific to Twilio's Console application which causes the page to shift upwards by 80px when the modal opens. This happens because of styling set on the app which clashes with the scroll-lock functionality of reach's modal. This prop is the least worst solution to a problem currently blocking adoption on the Modal component.