### PR TITLE
chore(form): guard against 'text-transform: uppercase' on FormLabel

### DIFF
--- a/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
@@ -13,6 +13,7 @@ exports[`Combobox  Render should render 1`] = `
   margin-bottom: space10;
   padding-left: space0;
   padding-right: space0;
+  text-transform: none;
 }
 
 .emotion-1 {

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`FormLabel render it should render 1`] = `
   margin-bottom: 0.125rem;
   padding-left: 0;
   padding-right: 0;
+  text-transform: none;
 }
 
 .emotion-1 {
@@ -85,6 +86,7 @@ exports[`FormLabel render it should render with required 1`] = `
   margin-bottom: 0.125rem;
   padding-left: 0;
   padding-right: 0;
+  text-transform: none;
 }
 
 .emotion-3 {

--- a/packages/paste-core/components/form/src/FormLabel.tsx
+++ b/packages/paste-core/components/form/src/FormLabel.tsx
@@ -18,7 +18,7 @@ export interface FormLabelProps extends React.LabelHTMLAttributes<HTMLLabelEleme
 }
 
 // eslint-disable-next-line emotion/syntax-preference
-const StyledRequiredDot = styled(Text)(() =>
+const StyledRequiredDot = styled(Text)(
   css({
     display: 'block',
     width: '4px',
@@ -39,6 +39,7 @@ const FormLabel: React.FC<FormLabelProps> = ({as, marginBottom, required, disabl
       marginBottom={marginBottom || 'space10'}
       paddingLeft="space0"
       paddingRight="space0"
+      textTransform="none"
     >
       <Flex as="span" vAlignContent="center">
         {required ? (

--- a/packages/paste-core/components/tabs/__tests__/__snapshots__/tabs.test.tsx.snap
+++ b/packages/paste-core/components/tabs/__tests__/__snapshots__/tabs.test.tsx.snap
@@ -61,6 +61,8 @@ exports[`Tabs Render horizontally and vertically 1`] = `
   color: colorTextWeak;
   font-size: fontSize40;
   font-weight: fontWeightMedium;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
   line-height: lineHeight30;
 }
 
@@ -98,6 +100,8 @@ exports[`Tabs Render horizontally and vertically 1`] = `
   color: colorTextWeaker;
   font-size: fontSize40;
   font-weight: fontWeightMedium;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
   line-height: lineHeight30;
 }
 
@@ -107,6 +111,8 @@ exports[`Tabs Render horizontally and vertically 1`] = `
   color: colorText;
   font-size: fontSize40;
   font-weight: fontWeightMedium;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
   line-height: lineHeight30;
 }
 
@@ -250,6 +256,8 @@ exports[`Tabs Render horizontally and vertically 1`] = `
   color: colorTextWeak;
   font-size: fontSize40;
   font-weight: fontWeightMedium;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
   line-height: lineHeight30;
 }
 
@@ -263,6 +271,8 @@ exports[`Tabs Render horizontally and vertically 1`] = `
   color: colorText;
   font-size: fontSize40;
   font-weight: fontWeightMedium;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
   line-height: lineHeight30;
 }
 

--- a/packages/paste-core/primitives/box/src/BoxPropTypes.ts
+++ b/packages/paste-core/primitives/box/src/BoxPropTypes.ts
@@ -42,6 +42,7 @@ export const BoxPropTypes = {
   float: ResponsiveProp(PropTypes.string),
   willChange: ResponsiveProp(PropTypes.string),
   textDecoration: ResponsiveProp(PropTypes.string),
+  textTransform: ResponsiveProp(PropTypes.string),
   // layout
   width: isWidthTokenProp,
   minWidth: isMinWidthTokenProp,

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -44,6 +44,7 @@ import {
   FloatProperty,
   WillChangeProperty,
   TextOverflowProperty,
+  TextTransformProperty,
 } from 'csstype';
 import {PseudoPropStyles} from './PseudoPropStyles';
 import {BoxPropTypes} from './BoxPropTypes';
@@ -82,6 +83,8 @@ export interface BaseBoxProps
   float?: FloatProperty;
   willChange?: WillChangeProperty;
   textDecoration?: TypographyProps['textDecoration'];
+  // Do not document, we prefer if folks do not use this property for i18n.
+  textTransform?: TextTransformProperty;
   /** Typed as any because Box can literally be any HTML element */
   ref?: any | null;
 }
@@ -149,6 +152,7 @@ const extraConfig = system({
   float: true,
   willChange: true,
   textDecoration: true,
+  textTransform: true,
 });
 
 const getPseudoStyles = (props: BoxProps): {} => {

--- a/packages/paste-core/primitives/text/src/TextPropTypes.ts
+++ b/packages/paste-core/primitives/text/src/TextPropTypes.ts
@@ -41,4 +41,5 @@ export const TextPropTypes = {
   verticalAlign: ResponsiveProp(PropTypes.string),
   whiteSpace: ResponsiveProp(PropTypes.string),
   transition: ResponsiveProp(PropTypes.string),
+  textTransform: ResponsiveProp(PropTypes.string),
 };

--- a/packages/paste-core/primitives/text/src/index.tsx
+++ b/packages/paste-core/primitives/text/src/index.tsx
@@ -10,7 +10,7 @@ import {
   system,
   position,
 } from '@twilio-paste/styling-library';
-import {CursorProperty} from 'csstype';
+import {CursorProperty, TextTransformProperty, TransitionProperty} from 'csstype';
 import {
   SpaceProps,
   Display,
@@ -35,7 +35,9 @@ interface BaseTextProps
   cursor?: CursorProperty;
   display?: Display;
   verticalAlign?: VerticalAlign;
-  transition?: string;
+  transition?: TransitionProperty;
+  // Do not document, we prefer if folks do not use this property for i18n.
+  textTransform?: TextTransformProperty;
 }
 
 interface PseudoStylesProps {
@@ -73,6 +75,8 @@ const extraConfig = system({
     scale: 'textColors',
   },
   cursor: true,
+  transition: true,
+  textTransform: true,
 });
 
 const textDecoration = system({textDecoration: true});


### PR DESCRIPTION
Resolves https://github.com/twilio-labs/paste/issues/497

Explicitly sets `text-transform: none` to guard against bootstrap.css overriding label and legend styles.
This PR also enables the `textTransform` prop on our Box component.