### PR TITLE
chore: improve build:dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "watch:icons": "yarn workspace @twilio-paste/icons watch",
     "prebuild": "node ./tools/build/pre-build.js",
     "build": "lerna run build --ignore @twilio-paste/website",
-    "build:dev": "yarn prebuild && yarn build:tokens && lerna run build:dev",
+    "build:dev": "yarn prebuild && lerna run build:dev --since HEAD --ignore @twilio-paste/website",
     "build:tokens": "yarn workspace @twilio-paste/design-tokens tokens",
     "build:icons": "yarn workspace @twilio-paste/icons build",
     "build:storybook": "build-storybook -c .storybook -o ./docs",

--- a/packages/paste-core/components/alert/package.json
+++ b/packages/paste-core/components/alert/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/anchor/package.json
+++ b/packages/paste-core/components/anchor/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/combobox/package.json
+++ b/packages/paste-core/components/combobox/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/list/package.json
+++ b/packages/paste-core/components/list/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/menu/package.json
+++ b/packages/paste-core/components/menu/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/modal/package.json
+++ b/packages/paste-core/components/modal/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/paragraph/package.json
+++ b/packages/paste-core/components/paragraph/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/popover/package.json
+++ b/packages/paste-core/components/popover/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/components/typography/package.json
+++ b/packages/paste-core/components/typography/package.json
@@ -22,7 +22,7 @@
     "build:dev": "yarn clean && yarn compile:dev",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -22,7 +22,7 @@
     "build:dev": "yarn clean && yarn compile:dev",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/combobox/package.json
+++ b/packages/paste-core/primitives/combobox/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/disclosure/package.json
+++ b/packages/paste-core/primitives/disclosure/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/menu/package.json
+++ b/packages/paste-core/primitives/menu/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/modal-dialog/package.json
+++ b/packages/paste-core/primitives/modal-dialog/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/non-modal-dialog/package.json
+++ b/packages/paste-core/primitives/non-modal-dialog/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-core/primitives/tabs/package.json
+++ b/packages/paste-core/primitives/tabs/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-design-tokens/package.json
+++ b/packages/paste-design-tokens/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "build": "yarn clean && gulp",
-    "build:dev": "yarn clean && gulp dev",
+    "build:dev": "yarn build",
+    "build:watch": "yarn clean && gulp dev",
     "clean": "rm -rf ./dist",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit",

--- a/packages/paste-libraries/dropdown/package.json
+++ b/packages/paste-libraries/dropdown/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-libraries/reakit/package.json
+++ b/packages/paste-libraries/reakit/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },

--- a/packages/paste-libraries/styling/package.json
+++ b/packages/paste-libraries/styling/package.json
@@ -23,7 +23,7 @@
     "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo && rm -rf .rpt2_cache",
     "compile": "rollup -c --environment NODE_ENV:production",
-    "compile:dev": "rollup -cw --environment NODE_ENV:development",
+    "compile:dev": "rollup -c --environment NODE_ENV:development",
     "prepublishOnly": "yarn build",
     "type-check": "tsc --noEmit"
   },


### PR DESCRIPTION
Since local builds have been rather slow on my machine, I took a little time to research ways to improve that DX. This PR does a couple things:

1. It fixes the `build:dev` command by removing the `w` in the `rollup -cw` part of every package. The `w` makes rollup startup a watcher, which basically pauses the build on the first package. We've never really used it since our dev cycle involves storybook which operates on the src files anyways, so we won't miss this.

2. It adds the lerna `--since HEAD` flag (https://github.com/lerna/lerna/issues/2211#issuecomment-535943543) which makes lerna only build packages with changes. There are one gotcha with this flag that I'm aware of:
   1. You can get into a weird state if you exclusively run `yarn build:dev` where, some of your packages might have been built on one unmerged branch, you switch branches, and those packages are now still built and stale. Previously since we always rebuilt everything, we would always be in a clean state. Also not a big deal, but something to be mindful of - we should periodically rebuild all the things to get back into a "clean" state.

