### PR TITLE
docs(list): fix typo in example

### DIFF
--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -60,7 +60,7 @@ export const pageQuery = graphql`
     Tamir Rice
   </ListItem>
   <ListItem>
-    Philando Casitle
+    Philando Castile
   </ListItem>
   <ListItem>
     Trayvon Martin
@@ -122,7 +122,7 @@ Use unordered list to display a basic list of items. This is the default variant
     Tamir Rice
   </ListItem>
   <ListItem>
-    Philando Casitle
+    Philando Castile
   </ListItem>
   <ListItem>
     Trayvon Martin


### PR DESCRIPTION
We had a typo in the list example. Fixed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
