### PR TITLE
docs(box): fix typo in example

### DIFF
--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -148,7 +148,7 @@ compose the modal using Box:
   <Box backgroundColor="colorBackgroundPrimaryLightest" padding="space40">
     Body area
     <Box
-      width="sizes10"
+      width="size20"
       marginTop="space30"
       marginBottom="space30"
       padding="space30"


### PR DESCRIPTION
Box had an example using `sizes10` instead of `size10` as a token, breaking the example

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
