### PR TITLE
chore(menu): updated font color, width, and zindex styles

### DIFF
--- a/packages/paste-core/components/menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -141,8 +141,8 @@ exports[`Menu  Render should render 1`] = `
   border-radius: borderRadius20;
   box-shadow: shadowCard;
   max-width: size30;
-  min-width: size30;
-  z-index: zIndex10;
+  min-width: size10;
+  z-index: zIndex20;
 }
 
 .emotion-14:focus {
@@ -180,7 +180,7 @@ exports[`Menu  Render should render 1`] = `
 .emotion-0 {
   margin: 0;
   padding: 0;
-  color: colorTextLink;
+  color: colorText;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   font-size: fontSize30;
@@ -208,7 +208,7 @@ exports[`Menu  Render should render 1`] = `
 .emotion-2 {
   margin: 0;
   padding: 0;
-  color: colorTextLink;
+  color: colorText;
   font-size: fontSize30;
   line-height: lineHeight30;
 }
@@ -235,7 +235,7 @@ exports[`Menu  Render should render 1`] = `
     >
       <div
         class="emotion-0"
-        color="colorTextLink"
+        color="colorText"
         font-size="fontSize30"
         text-decoration="underline"
       >
@@ -252,7 +252,7 @@ exports[`Menu  Render should render 1`] = `
     >
       <div
         class="emotion-2"
-        color="colorTextLink"
+        color="colorText"
         font-size="fontSize30"
       >
         Check for Updates...
@@ -306,7 +306,7 @@ exports[`Menu  Render should render 1`] = `
       >
         <div
           class="emotion-0"
-          color="colorTextLink"
+          color="colorText"
           font-size="fontSize30"
           text-decoration="underline"
         >
@@ -347,7 +347,7 @@ exports[`Menu  Render should render 1`] = `
       >
         <div
           class="emotion-2"
-          color="colorTextLink"
+          color="colorText"
           font-size="fontSize30"
         >
           Keyboard shortcuts

--- a/packages/paste-core/components/menu/src/index.tsx
+++ b/packages/paste-core/components/menu/src/index.tsx
@@ -41,8 +41,8 @@ const StyledMenu = React.forwardRef<HTMLDivElement, BoxProps>(({style, ...props}
       borderRadius="borderRadius20"
       boxShadow="shadowCard"
       maxWidth="size30"
-      minWidth="size30"
-      zIndex="zIndex10"
+      minWidth="size10"
+      zIndex="zIndex20"
       _focus={{outline: 'none'}}
       style={style}
       ref={ref}
@@ -74,7 +74,7 @@ const StyledMenuItem = React.forwardRef<HTMLDivElement | HTMLAnchorElement, Styl
       >
         <Text
           as="div"
-          color={props['aria-disabled'] ? 'colorTextWeaker' : 'colorTextLink'}
+          color={props['aria-disabled'] ? 'colorTextWeaker' : 'colorText'}
           textDecoration={props.tabIndex === 0 ? 'underline' : null}
         >
           {children}


### PR DESCRIPTION
Updates:
- Changed default fontColor for menuitem to colorText from colorTextLink
- Updated minWidth to the smallest token (sketch had a smaller value :/)
- Updated zIndex to the 20 value. For any overlay type component I think 20 is a safer default value because developer code can occasionally use zIndex10.