### PR TITLE
docs(getting-started): add missing dependency in yarn add

### DIFF
--- a/packages/paste-website/src/pages/getting-started/engineering/index.mdx
+++ b/packages/paste-website/src/pages/getting-started/engineering/index.mdx
@@ -153,7 +153,7 @@ Paste also requires these system dependencies:
 Install them using:
 
 ```shell
-yarn add @twilio-paste/types @twilio-paste/style-props @twilio-paste/design-tokens @twilio-paste/theme @twilio-paste/icons @twilio-paste/animation-library @twilio-paste/dropdown-library @twilio-paste/reakit-library
+yarn add @twilio-paste/types @twilio-paste/style-props @twilio-paste/design-tokens @twilio-paste/theme @twilio-paste/icons @twilio-paste/styling-library @twilio-paste/animation-library @twilio-paste/dropdown-library @twilio-paste/reakit-library
 ```
 
 #### Install the Paste Core package


### PR DESCRIPTION
Package @twilio-paste/styling-library seems to have been missing from getting started script.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
