### PR TITLE
fix(form): add border-bottom-width rule for bootstrap override

### DIFF
--- a/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`Combobox  Render should render 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
+  border-bottom-width: borderWidth0;
   display: block;
   margin-bottom: space10;
   padding-left: space0;

--- a/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
+++ b/packages/paste-core/components/form/__tests__/__snapshots__/formlabel.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FormLabel render it should render 1`] = `
 
 .emotion-2 {
   box-sizing: border-box;
+  border-bottom-width: 0;
   display: block;
   margin-bottom: 0.125rem;
   padding-left: 0;
@@ -82,6 +83,7 @@ exports[`FormLabel render it should render with required 1`] = `
 
 .emotion-4 {
   box-sizing: border-box;
+  border-bottom-width: 0;
   display: block;
   margin-bottom: 0.125rem;
   padding-left: 0;

--- a/packages/paste-core/components/form/src/FormLabel.tsx
+++ b/packages/paste-core/components/form/src/FormLabel.tsx
@@ -35,6 +35,9 @@ const FormLabel: React.FC<FormLabelProps> = ({as, marginBottom, required, disabl
     <Box
       {...safelySpreadBoxProps(props)}
       as={as}
+      // Setting a bottom border here to prevent Bootstrap's bottom border
+      // on legend in Console.
+      borderBottomWidth="borderWidth0"
       display="block"
       marginBottom={marginBottom || 'space10'}
       paddingLeft="space0"


### PR DESCRIPTION
Resolves: https://github.com/twilio-labs/paste/issues/556

- [x] Added `BorderBottomWidth: borderWidth0`