### PR TITLE
fix(tooltip): move arrow to StyedBase to prevent line-height override

### DIFF
--- a/packages/paste-core/components/popover/src/Popover.tsx
+++ b/packages/paste-core/components/popover/src/Popover.tsx
@@ -38,9 +38,9 @@ const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(({children, ...pr
   const popover = React.useContext(PopoverContext);
   return (
     <NonModalDialogPrimitive {...(popover as any)} {...props} as={StyledPopover} ref={ref}>
-      <PopoverArrow {...(popover as any)} />
       {/* import Paste Theme Based Styles due to portal positioning. */}
       <StyledBase>
+        <PopoverArrow {...(popover as any)} />
         <Box padding="space50" paddingLeft="space70" paddingRight="space70">
           {children}
           <Absolute preset="top_right" top={8} right={8}>

--- a/packages/paste-core/components/tooltip/src/index.tsx
+++ b/packages/paste-core/components/tooltip/src/index.tsx
@@ -49,9 +49,9 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(({baseId, childre
         </TooltipPrimitiveReference>
       )}
       <TooltipPrimitive {...tooltip} {...props} as={StyledTooltip}>
-        <TooltipArrow {...tooltip} />
         {/* import Paste Theme Based Styles due to portal positioning. */}
         <StyledBase>
+          <TooltipArrow {...tooltip} />
           <Text as="span">{text}</Text>
         </StyledBase>
       </TooltipPrimitive>


### PR DESCRIPTION
Resolves: https://github.com/twilio-labs/paste/issues/548

- [x] Move Tooltip arrow to `StyledBase` to prevent bootstrap override
- [x] Move Popover arrow to `StyledBase` to prevent bootstrap override