### PR TITLE
feat(website): add ChangelogRevealer shortcode to wrap changelogs everywhere

### DIFF
--- a/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
@@ -86,7 +86,7 @@ const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosur
             as="span"
             display="flex"
             transform={props['aria-expanded'] ? 'rotate(0deg)' : 'rotate(-90deg)'}
-            transition="all 200ms linear"
+            transition="transform 100ms ease-out"
           >
             <ChevronDownIcon decorative size={getIconSize(variant)} />
           </Box>

--- a/packages/paste-website/gatsby-config.js
+++ b/packages/paste-website/gatsby-config.js
@@ -100,7 +100,7 @@ module.exports = {
         extensions: [`.mdx`, `.md`],
         defaultLayouts: {
           default: require.resolve('./src/layouts/DefaultLayout.tsx'),
-          packages: require.resolve('./src/layouts/GenericLayout.tsx'),
+          packages: require.resolve('./src/layouts/ChangelogLayout.tsx'),
           websiteCore: require.resolve('./src/layouts/GenericLayout.tsx'),
         },
         gatsbyRemarkPlugins: [

--- a/packages/paste-website/src/components/paste-mdx-provider/index.tsx
+++ b/packages/paste-website/src/components/paste-mdx-provider/index.tsx
@@ -16,6 +16,7 @@ import {LivePreview} from '../shortcodes/live-preview';
 import {TableOfContents} from '../shortcodes/table-of-contents';
 import {QuestionMenu} from '../shortcodes/question-menu';
 import {PageAside} from '../shortcodes/PageAside';
+import {ChangelogRevealer} from '../shortcodes/ChangelogRevealer';
 
 interface PasteMDXProviderProps {
   children?: React.ReactElement;
@@ -38,7 +39,7 @@ const StyledSup = styled.sup`
   top: -0.4rem;
 `;
 
-const shortcodes = {ComponentHeader, LivePreview, PageAside, QuestionMenu, TableOfContents};
+const shortcodes = {ComponentHeader, LivePreview, PageAside, QuestionMenu, TableOfContents, ChangelogRevealer};
 
 const MDXPoviderComponents = {
   ...shortcodes,

--- a/packages/paste-website/src/components/paste-mdx-provider/index.tsx
+++ b/packages/paste-website/src/components/paste-mdx-provider/index.tsx
@@ -40,53 +40,58 @@ const StyledSup = styled.sup`
 
 const shortcodes = {ComponentHeader, LivePreview, PageAside, QuestionMenu, TableOfContents};
 
+const MDXPoviderComponents = {
+  ...shortcodes,
+  h1: (props: HeadingProps): React.ReactElement => <Heading {...props} as="h1" variant="heading10" />,
+  h2: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h2" variant="heading20" />,
+  h3: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h3" variant="heading30" />,
+  h4: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h4" variant="heading40" />,
+  h5: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h5" variant="heading50" />,
+  h6: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h6" variant="heading60" />,
+  p: (props: React.ComponentProps<typeof Paragraph>): React.ReactElement => <Paragraph {...props} />,
+  ul: (props: React.ComponentProps<typeof UnorderedList>): React.ReactElement => <UnorderedList {...props} />,
+  ol: (props: React.ComponentProps<typeof OrderedList>): React.ReactElement => <OrderedList {...props} />,
+  li: (props: React.ComponentProps<typeof ListItem>): React.ReactElement => <ListItem {...props} />,
+  blockquote: (props: React.ComponentProps<'blockquote'>): React.ReactElement => <blockquote {...props} />,
+  table: (props: React.ComponentProps<'table'>): React.ReactElement => <Table {...props} />,
+  thead: (props: React.ComponentProps<'thead'>): React.ReactElement => <thead {...props} />,
+  tbody: (props: React.ComponentProps<'tbody'>): React.ReactElement => <Tbody {...props} />,
+  tfoot: (props: React.ComponentProps<'tfoot'>): React.ReactElement => <tfoot {...props} />,
+  tr: (props: React.ComponentProps<'tr'>): React.ReactElement => <Tr {...props} />,
+  th: (props: React.ComponentProps<'th'>): React.ReactElement => <Th {...props} />,
+  td: (props: React.ComponentProps<'td'>): React.ReactElement => <Td {...props} />,
+  pre: (props: React.ComponentProps<'pre'>): React.ReactElement => <Pre {...props} />,
+  code: (props: CodeblockProps): React.ReactElement => <Codeblock {...props} />,
+  inlineCode: (props: React.ComponentProps<typeof InlineCode>): React.ReactElement => <InlineCode {...props} />,
+  em: (props: React.ComponentProps<'em'>): React.ReactElement => <em {...props} />,
+  strong: (props: React.ComponentProps<'strong'>): React.ReactElement => <strong {...props} />,
+  del: (props: React.ComponentProps<'del'>): React.ReactElement => <del {...props} />,
+  hr: (props: SeparatorProps): React.ReactElement => (
+    <Separator orientation="horizontal" verticalSpacing="space70" {...props} />
+  ),
+  a: (props: AnchorProps): React.ReactElement => <Anchor {...props} />, // eslint-disable-line jsx-a11y/anchor-has-content
+  img: (props: React.ComponentProps<'img'>): React.ReactElement => <img {...props} />, // eslint-disable-line jsx-a11y/alt-text
+  sup: (props: React.ComponentProps<'sup'>): React.ReactElement => <StyledSup {...props} />,
+  content: (props: React.ComponentProps<'div'>): React.ReactElement => <StyledContent {...props} />,
+  contentwrapper: (props: React.ComponentProps<'div'>): React.ReactElement => <StyledContentWrapper {...props} />,
+};
+
 /* eslint-disable no-shadow */
 /*
   "error  'props' is already declared in the upper scope": these errors I don't
   think are actually real. Because top level props is actually a different set of
   props than that are passed to the components. I think eslint is confused.
 */
-export const PasteMDXProvider: React.FC<PasteMDXProviderProps> = (props: PasteMDXProviderProps): React.ReactElement => {
-  return (
-    <MDXProvider
-      components={{
-        ...shortcodes,
-        h1: (props: HeadingProps): React.ReactElement => <Heading {...props} as="h1" variant="heading10" />,
-        h2: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h2" variant="heading20" />,
-        h3: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h3" variant="heading30" />,
-        h4: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h4" variant="heading40" />,
-        h5: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h5" variant="heading50" />,
-        h6: (props: HeadingProps): React.ReactElement => <AnchoredHeading {...props} as="h6" variant="heading60" />,
-        p: (props: React.ComponentProps<typeof Paragraph>): React.ReactElement => <Paragraph {...props} />,
-        ul: (props: React.ComponentProps<typeof UnorderedList>): React.ReactElement => <UnorderedList {...props} />,
-        ol: (props: React.ComponentProps<typeof OrderedList>): React.ReactElement => <OrderedList {...props} />,
-        li: (props: React.ComponentProps<typeof ListItem>): React.ReactElement => <ListItem {...props} />,
-        blockquote: (props: React.ComponentProps<'blockquote'>): React.ReactElement => <blockquote {...props} />,
-        table: (props: React.ComponentProps<'table'>): React.ReactElement => <Table {...props} />,
-        thead: (props: React.ComponentProps<'thead'>): React.ReactElement => <thead {...props} />,
-        tbody: (props: React.ComponentProps<'tbody'>): React.ReactElement => <Tbody {...props} />,
-        tfoot: (props: React.ComponentProps<'tfoot'>): React.ReactElement => <tfoot {...props} />,
-        tr: (props: React.ComponentProps<'tr'>): React.ReactElement => <Tr {...props} />,
-        th: (props: React.ComponentProps<'th'>): React.ReactElement => <Th {...props} />,
-        td: (props: React.ComponentProps<'td'>): React.ReactElement => <Td {...props} />,
-        pre: (props: React.ComponentProps<'pre'>): React.ReactElement => <Pre {...props} />,
-        code: (props: CodeblockProps): React.ReactElement => <Codeblock {...props} />,
-        inlineCode: (props: React.ComponentProps<typeof InlineCode>): React.ReactElement => <InlineCode {...props} />,
-        em: (props: React.ComponentProps<'em'>): React.ReactElement => <em {...props} />,
-        strong: (props: React.ComponentProps<'strong'>): React.ReactElement => <strong {...props} />,
-        del: (props: React.ComponentProps<'del'>): React.ReactElement => <del {...props} />,
-        hr: (props: SeparatorProps): React.ReactElement => (
-          <Separator orientation="horizontal" verticalSpacing="space70" {...props} />
-        ),
-        a: (props: AnchorProps): React.ReactElement => <Anchor {...props} />, // eslint-disable-line jsx-a11y/anchor-has-content
-        img: (props: React.ComponentProps<'img'>): React.ReactElement => <img {...props} />, // eslint-disable-line jsx-a11y/alt-text
-        sup: (props: React.ComponentProps<'sup'>): React.ReactElement => <StyledSup {...props} />,
-        content: (props: React.ComponentProps<'div'>): React.ReactElement => <StyledContent {...props} />,
-        contentwrapper: (props: React.ComponentProps<'div'>): React.ReactElement => <StyledContentWrapper {...props} />,
-      }}
-    >
-      {props.children}
-    </MDXProvider>
-  );
+interface PasteMDXProviderProps {
+  componentOverrides?: {[key: string]: (props: {}) => React.ReactNode};
+}
+export const PasteMDXProvider: React.FC<PasteMDXProviderProps> = ({
+  componentOverrides,
+  children,
+}): React.ReactElement => {
+  const components =
+    componentOverrides != null ? {...MDXPoviderComponents, ...componentOverrides} : MDXPoviderComponents;
+
+  return <MDXProvider components={components}>{children}</MDXProvider>;
 };
 /* eslint-enable no-shadow */

--- a/packages/paste-website/src/components/shortcodes/ChangelogRevealer.tsx
+++ b/packages/paste-website/src/components/shortcodes/ChangelogRevealer.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import {Separator} from '@twilio-paste/separator';
+import {Disclosure, DisclosureContent, DisclosureHeading} from '@twilio-paste/disclosure';
+
+export const ChangelogRevealer: React.FC<{children: NonNullable<React.ReactNode>}> = ({children}) => {
+  return (
+    <>
+      <Separator orientation="horizontal" verticalSpacing="space140" />
+      <Disclosure>
+        <DisclosureHeading as="h2" variant="heading20">
+          Changelog
+        </DisclosureHeading>
+        <DisclosureContent>{children}</DisclosureContent>
+      </Disclosure>
+    </>
+  );
+};

--- a/packages/paste-website/src/layouts/ChangelogLayout.tsx
+++ b/packages/paste-website/src/layouts/ChangelogLayout.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import {PasteMDXProvider} from '../components/paste-mdx-provider';
+
+interface ChangelogLayoutProps {
+  children?: React.ReactElement;
+}
+
+// Don't display the H1 in Changelogs
+const componentOverrides = {
+  h1: () => null,
+};
+
+const ChangelogLayout: React.FC<ChangelogLayoutProps> = ({children}) => {
+  return <PasteMDXProvider componentOverrides={componentOverrides}>{children}</PasteMDXProvider>;
+};
+
+export default ChangelogLayout;

--- a/packages/paste-website/src/layouts/GenericLayout.tsx
+++ b/packages/paste-website/src/layouts/GenericLayout.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {PasteMDXProvider} from '../components/paste-mdx-provider';
 
-interface ChangelogLayoutProps {
+interface GenericLayoutProps {
   children?: React.ReactElement;
 }
 
-const ChangelogLayout: React.FC<ChangelogLayoutProps> = ({children}) => {
+const GenericLayout: React.FC<GenericLayoutProps> = ({children}) => {
   return <PasteMDXProvider>{children}</PasteMDXProvider>;
 };
 
-export default ChangelogLayout;
+export default GenericLayout;

--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -362,9 +362,9 @@ const Component = () => (
 | role?      | `string`     | Provide a specific ARIA role to the alert that overrides the calculated one set by the component | null    |
 | variant?   | `string`     | `error` / `neutral` / `warning`                                                                  | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -159,9 +159,9 @@ const Component = () => <Anchor href="https://paste.twilio.design">Go to Paste</
 | onFocus?  | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                         | null    |
 | onBlur?   | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                         | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -527,9 +527,9 @@ All the valid HTML attributes for `button` are supported including the following
 | onFocus?      | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                  | null      |
 | onBlur?       | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                  | null      |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -339,9 +339,9 @@ highlighted.
 
 This function allows you to use your own `jsx` template for the items in the drop-down list.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -418,9 +418,9 @@ When an element is `disabled`, it may still be `focusable`. It works similarly t
 
 All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -216,9 +216,9 @@ const Component = () => (
 | marginBottom? | `oneOf(['space0'])` | Currently we only allow `space0` to remove bottom margin                     | null    |
 | variant       | `headingVariants`   | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60' | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -336,9 +336,9 @@ const Component = () => (
 | marginTop?    | `ResponsiveValue<keyof ThemeShape['space']>` |             | null      |
 | marginBottom? | `ResponsiveValue<keyof ThemeShape['space']>` |             | 'space70' |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -358,9 +358,9 @@ No props to show
 | id       | `string, undefined`         | Same as the HTML attribute.                                                                                                                        |         |
 | name     | `string`                    | MenuItemRadio's name as in `menu.values`.                                                                                                          |         |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -440,9 +440,9 @@ const ModalTrigger = () => {
 | children | `ReactNode`               |             | null    |
 | justify? | `oneOf(['start', 'end'])` |             | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -244,9 +244,9 @@ Only allows passing 'space0' to unset the bottom margin. Useful
 when using Paragraph as the last child of a wrapping component, like
 a Card.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/popover/index.mdx
+++ b/packages/paste-website/src/pages/components/popover/index.mdx
@@ -200,9 +200,9 @@ Sets the placement of popover in relation to the `PopoverButton`. Available opti
 
 Required label for this Popover component. Titles the entire popover context for screen readers.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
+++ b/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
@@ -205,9 +205,9 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 | ---- | ----------------------------- | ----------------- | ------- |
 | as?  | `keyof JSX.IntrinsicElements` | A custom HTML tag | `span`  |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/separator/index.mdx
+++ b/packages/paste-website/src/pages/components/separator/index.mdx
@@ -175,9 +175,9 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 | horizontalSpacing? | ResponsiveValue<[Spacing](/tokens/#spacings)> | Space left and right of the separator |         |
 | verticalSpacing?   | ResponsiveValue<[Spacing](/tokens/#spacings)> | Space top and bottom of the separator |         |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -178,9 +178,9 @@ Sets the icon color to any of our text color tokens or currentColor, which inher
 
 Time delay in milliseconds of the animation.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/form-elements/checkbox/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/checkbox/index.mdx
@@ -378,9 +378,9 @@ All the valid HTML attributes for `input[type=checkbox]` are supported including
 | onFocus?   | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
 | onBlur?    | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/form-elements/input/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/input/index.mdx
@@ -687,9 +687,9 @@ All the valid HTML attributes (role, aria-\*, type, and so on) including the fol
 | marginTop? | 'space0', 'space20' |                                      | 'space20' |
 | variant?   | 'error'             | Sets the help text to an error state | 'space20' |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/form-elements/radio-group/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/radio-group/index.mdx
@@ -281,9 +281,9 @@ All the valid HTML attributes for `input[type=radio]` are supported including th
 | onFocus?    | `(event: React.MouseEvent<HTMLElement>)` |             | null     |
 | onBlur?     | `(event: React.MouseEvent<HTMLElement>)` |             | null     |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/form-elements/select/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/select/index.mdx
@@ -914,9 +914,9 @@ All the <Anchor target="_blank" href="https://developer.mozilla.org/en-US/docs/W
 | marginTop? | 'space0', 'space20' |                                      | 'space20' |
 | variant?   | 'error'             | Sets the help text to an error state | 'space20' |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/form-elements/textarea/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/textarea/index.mdx
@@ -627,9 +627,9 @@ All the valid HTML attributes (role, aria-\*, type, and so on) including the fol
 | marginTop? | 'space0', 'space20' |                                      | 'space20' |
 | variant?   | 'error'             | Sets the help text to an error state | 'space20' |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/icon-system/index.mdx
+++ b/packages/paste-website/src/pages/icon-system/index.mdx
@@ -226,9 +226,9 @@ Curious why we chose to make React component icons? Check our [write-up document
 
 ---
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 </contentwrapper>

--- a/packages/paste-website/src/pages/layout/aspect-ratio/index.mdx
+++ b/packages/paste-website/src/pages/layout/aspect-ratio/index.mdx
@@ -190,9 +190,9 @@ const Component = () => (
 | ----- | ------ | --------------------------------------------------------------------------------------------------------- | ------- |
 | ratio | string | Determines the aspect ratio of the element. Use a colon separated number pattern (width:height). Required | 4:3     |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/layout/flex/index.mdx
+++ b/packages/paste-website/src/pages/layout/flex/index.mdx
@@ -319,9 +319,9 @@ const Component = () => <Flex>Foo</Flex>;
 | vertical?      | `boolean, number, ResponsiveValue<boolean, number>` | Flex direction property       |         |
 | wrap?          | `boolean, number, ResponsiveValue<boolean, number>` | Flex wrap property            |         |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/layout/grid/index.mdx
+++ b/packages/paste-website/src/pages/layout/grid/index.mdx
@@ -582,9 +582,9 @@ We use grid symbols instead of Sketch Layout Settings for two reasons:
 1. Resizing a symbol better represents the behavior of a fluid grid in a responsive layout. You might be designing for multiple screen widths in a single Sketch file. Sketch Layout Settings, however, restricts you to a single setting of grid width, column width, gutter width, and number of columns for each file.
 2. Symbols allow you to place a grid within a component or container on an artboard, whereas Sketch Layout Settings can be applied only to a whole artboard.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/layout/stack/index.mdx
+++ b/packages/paste-website/src/pages/layout/stack/index.mdx
@@ -159,9 +159,9 @@ import {Stack} from '@twilio-paste/stack';
 | orientation | ResponsiveValue<'horizontal', 'vertical'> |             | null    |
 | spacing     | [Spacing](/tokens/#spacings)              |             | null    |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -327,9 +327,9 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 | \_focusWithin?           | BoxProps                                                |         |
 | \_placeholder?           | BoxProps                                                |         |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
@@ -257,9 +257,9 @@ No props to show
 | id       | `string, undefined`         | Same as the HTML attribute.                                                                                                                        |
 | name     | `string`                    | MenuItemRadio's name as in `menu.values`.                                                                                                          |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
@@ -262,9 +262,9 @@ Sets the disclosure to disabled.
 
 Sets the disclosure to be focusable or not.
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/primitives/text/index.mdx
+++ b/packages/paste-website/src/pages/primitives/text/index.mdx
@@ -281,9 +281,9 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 | \_notFirst?     | TextProps                                                                     |                           |         |
 | \_notLast?      | TextProps                                                                     |                           |         |
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
@@ -219,9 +219,9 @@ Sets the fill color of the arrow svg path
 
 Sets the stroke color of the arrow svg path
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/tokens/design-tokens-package/index.mdx
+++ b/packages/paste-website/src/pages/tokens/design-tokens-package/index.mdx
@@ -111,9 +111,9 @@ As you use Paste, you'll likely encounter things that _don't seem right_. Please
 
 ---
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 

--- a/packages/paste-website/src/pages/tokens/theme-package/index.mdx
+++ b/packages/paste-website/src/pages/tokens/theme-package/index.mdx
@@ -178,9 +178,9 @@ As you use Paste, you'll likely encounter things that _don't seem right_. Please
 
 ---
 
-<Box marginTop="space90">
+<ChangelogRevealer>
   <Changelog />
-</Box>
+</ChangelogRevealer>
 
 </content>
 


### PR DESCRIPTION
- [x] Refactors some Gatsby configs to remove the h1 `Changelog` text at the top of the `changelog.md` file when rendering, so that the Disclosure header isn't repeating itself
- [x] Add a new shortcode for a ChangelogRevealer component that wraps Changelogs everywhere
- [x] Speed up Disclosure animation so it feels better