### PR TITLE
chore(aspect-ratio): update border color to colorBorderLighter

### DIFF
--- a/packages/paste-core/layout/aspect-ratio/stories/index.stories.tsx
+++ b/packages/paste-core/layout/aspect-ratio/stories/index.stories.tsx
@@ -12,7 +12,7 @@ storiesOf('Layout|Aspect Ratio', module)
       <Box
         padding="space30"
         maxWidth="size40"
-        borderColor="colorBorderLight"
+        borderColor="colorBorderLighter"
         borderStyle="solid"
         borderWidth="borderWidth10"
       >

--- a/packages/paste-website/src/pages/components/card/index.mdx
+++ b/packages/paste-website/src/pages/components/card/index.mdx
@@ -227,7 +227,7 @@ Ultimately, Card is a very flexible component that can fit a variety of needs. I
 | background-color | color-background-body | No          |
 | border-width     | border-width-20       | No          |
 | border-radius    | border-radius-20      | No          |
-| border-color     | color-border-light    | No          |
+| border-color     | color-border-lighter  | No          |
 | padding          | space-60              | Yes         |
 
 ---

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -191,7 +191,7 @@ The `optionTemplate` prop allows you to pass `jsx` in order to display more comp
       <td>
         <UnorderedList marginBottom="space0">
           <ListItem>Background: $color-background</ListItem>
-          <ListItem>Border: $color-border-light</ListItem>
+          <ListItem>Border: $color-border-lighter</ListItem>
         </UnorderedList>
       </td>
       <td>No</td>

--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -345,11 +345,11 @@ Same Anatomy as [Heading](/components/heading), plus:
 
 ### DisclosureContent
 
-| Property         | Default token      | Modifiable? |
-| ---------------- | ------------------ | ----------- |
-| border-top-width | border-width-20    | No          |
-| border-top-color | color-border-light | No          |
-| padding          | space-50           | No          |
+| Property         | Default token        | Modifiable? |
+| ---------------- | -------------------- | ----------- |
+| border-top-width | border-width-20      | No          |
+| border-top-color | color-border-lighter | No          |
+| padding          | space-50             | No          |
 
 ---
 

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -217,7 +217,7 @@ See the [button](/components/button) component.
 | ---------------- | --------------------- | ----------- |
 | background-color | color-background-body | No          |
 | border-width     | border-width-10       | No          |
-| border-color     | color-border-light    | No          |
+| border-color     | color-border-lighter  | No          |
 | border-radius    | border-radius-20      | No          |
 | box-shadow       | shadow-card           | No          |
 | max-width        | size-30               | No          |

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -321,14 +321,14 @@ If you need to show an important warning to prevent or correct critical errors, 
 
 ### ModalHeader
 
-| Property            | Default token/child | Modifiable? |
-| ------------------- | ------------------- | ----------- |
-| Heading             | h3                  | No          |
-| close-icon-color    | color-text-weak     | No          |
-| close-icon-size     | size-icon-60        | No          |
-| padding             | space-50            | No          |
-| bottom-border-width | border-width-10     | No          |
-| bottom-border-color | color-border-light  | No          |
+| Property            | Default token/child  | Modifiable? |
+| ------------------- | -------------------- | ----------- |
+| Heading             | h3                   | No          |
+| close-icon-color    | color-text-weak      | No          |
+| close-icon-size     | size-icon-60         | No          |
+| padding             | space-50             | No          |
+| bottom-border-width | border-width-10      | No          |
+| bottom-border-color | color-border-lighter | No          |
 
 ### ModalBody
 
@@ -338,11 +338,11 @@ If you need to show an important warning to prevent or correct critical errors, 
 
 ### ModalFooter
 
-| Property         | Default token      | Modifiable? |
-| ---------------- | ------------------ | ----------- |
-| padding          | space-50           | No          |
-| top-border-width | border-width-10    | No          |
-| top-border-color | color-border-light | No          |
+| Property         | Default token        | Modifiable? |
+| ---------------- | -------------------- | ----------- |
+| padding          | space-50             | No          |
+| top-border-width | border-width-10      | No          |
+| top-border-color | color-border-lighter | No          |
 
 ---
 

--- a/packages/paste-website/src/pages/components/popover/index.mdx
+++ b/packages/paste-website/src/pages/components/popover/index.mdx
@@ -133,6 +133,9 @@ See the [button](/components/button) component.
 | border-radius    | border-radius-20      | No          |
 | box-shadow       | shadow-card           | No          |
 | max-width        | size-30               | No          |
+| padding          | space-50              | No          |
+| padding-left     | space-70              | No          |
+| padding-right    | space-70              | No          |
 | z-index          | z-index-80            | No          |
 
 ---

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -166,7 +166,7 @@ The Tabs component allows a user to flip through multiple views within the same 
       <td>Tab List Border</td>
       <td>
         <UnorderedList marginBottom="space0">
-          <ListItem>Always: $color-border-light</ListItem>
+          <ListItem>Always: $color-border-lighter</ListItem>
         </UnorderedList>
       </td>
       <td>No</td>


### PR DESCRIPTION
Missed this layout component when I changed components to use `colorBorderLighter`. Also updated the doc site anatomy tables.