### PR TITLE
fix(radio): allow passing disable to individual radio in radioGroups

### DIFF
--- a/packages/paste-core/components/form/__tests__/radio.test.tsx
+++ b/packages/paste-core/components/form/__tests__/radio.test.tsx
@@ -133,7 +133,7 @@ describe('Radio Group', () => {
         <Radio {...defaultProps}>foo</Radio>
       </RadioGroup>
     );
-    expect(getByRole('radio').name).toBe('bar');
+    expect(getByRole('radio').name).toBe(defaultProps.name);
   });
 
   it('renders a helpText message when helpText prop is present', () => {

--- a/packages/paste-core/components/form/src/RadioContext.tsx
+++ b/packages/paste-core/components/form/src/RadioContext.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+interface RadioContextValue {
+  name: string;
+  value: string;
+  disabled: boolean;
+  hasError: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const RadioContext = React.createContext<RadioContextValue>({
+  name: '',
+  value: '',
+  disabled: false,
+  hasError: false,
+  onChange: () => {},
+});
+
+export {RadioContext};

--- a/packages/paste-core/components/form/src/RadioGroup.tsx
+++ b/packages/paste-core/components/form/src/RadioGroup.tsx
@@ -1,31 +1,46 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {InlineControlGroup, InlineControlGroupProps} from './shared/InlineControlGroup';
+import {RadioContext} from './RadioContext';
 
 export interface RadioGroupProps extends InlineControlGroupProps {
-  name?: string;
+  name: string;
   onChange: (value: string) => void;
 }
 
-const RadioGroup: React.FC<RadioGroupProps> = ({onChange, children, errorText, name, value, disabled, ...props}) => {
+const RadioGroup: React.FC<RadioGroupProps> = ({
+  name,
+  value,
+  onChange,
+  disabled = false,
+  errorText,
+  children,
+  ...props
+}) => {
+  const onChangeHandler = React.useMemo(() => {
+    return (event: React.ChangeEvent<HTMLInputElement>): void => {
+      if (onChange != null) {
+        onChange(event.target.value);
+      }
+    };
+  }, [onChange]);
+
+  const contextValue = React.useMemo(() => {
+    return {
+      name,
+      value: value || '',
+      disabled,
+      hasError: errorText != null,
+      onChange: onChangeHandler,
+    };
+  }, [name, value, disabled, errorText, onChangeHandler]);
+
   return (
-    <InlineControlGroup {...props} disabled={disabled} errorText={errorText} name={name}>
-      {React.Children.map(children, child => {
-        return React.isValidElement(child)
-          ? React.cloneElement(child, {
-              checked: child.props.value === value,
-              disabled,
-              hasError: errorText != null,
-              name,
-              onChange: (event: React.ChangeEvent<HTMLInputElement>): void => {
-                if (onChange != null) {
-                  onChange(event.target.value);
-                }
-              },
-            })
-          : child;
-      })}
-    </InlineControlGroup>
+    <RadioContext.Provider value={contextValue}>
+      <InlineControlGroup {...props} disabled={disabled} errorText={errorText} name={name}>
+        {children}
+      </InlineControlGroup>
+    </RadioContext.Provider>
   );
 };
 
@@ -33,7 +48,7 @@ RadioGroup.displayName = 'RadioGroup';
 
 if (process.env.NODE_ENV === 'development') {
   RadioGroup.propTypes = {
-    name: PropTypes.string,
+    name: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 }

--- a/packages/paste-core/components/form/stories/radio.stories.tsx
+++ b/packages/paste-core/components/form/stories/radio.stories.tsx
@@ -94,6 +94,44 @@ storiesOf('Forms|Radio', module)
       </Radio>
     );
   })
+  .add('Radios - Controlled', () => {
+    const [value, setValue] = React.useState('1');
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => setValue(event.target.value);
+    return (
+      <>
+        <Radio
+          id={useUID()}
+          value="1"
+          onChange={handleChange}
+          checked={value === '1'}
+          name="foo"
+          helpText="This is some help text."
+        >
+          First
+        </Radio>
+        <Radio
+          id={useUID()}
+          value="2"
+          onChange={handleChange}
+          checked={value === '2'}
+          name="foo"
+          helpText="This is some help text."
+        >
+          Second
+        </Radio>
+        <Radio
+          id={useUID()}
+          value="3"
+          onChange={handleChange}
+          checked={value === '3'}
+          name="foo"
+          helpText="This is some help text."
+        >
+          Third
+        </Radio>
+      </>
+    );
+  })
   .add('Radio Group', () => {
     const [value, setValue] = React.useState('2');
     return (
@@ -187,6 +225,31 @@ storiesOf('Forms|Radio', module)
           Second
         </Radio>
         <Radio id={useUID()} value="3" name="foo" helpText="This is some help text.">
+          Third
+        </Radio>
+      </RadioGroup>
+    );
+  })
+
+  .add('Radio Group - Override Disable', () => {
+    const [value, setValue] = React.useState('1');
+    return (
+      <RadioGroup
+        name="bar"
+        value={value}
+        legend="This is the legend text"
+        disabled
+        onChange={newValue => {
+          setValue(newValue);
+        }}
+      >
+        <Radio id={useUID()} value="1" name="foo" helpText="This is some help text.">
+          First
+        </Radio>
+        <Radio id={useUID()} value="2" name="foo" helpText="This is some help text.">
+          Second
+        </Radio>
+        <Radio id={useUID()} value="3" name="foo" helpText="This is some help text." disabled={false}>
           Third
         </Radio>
       </RadioGroup>

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -45,6 +45,7 @@ import {
   WillChangeProperty,
   TextOverflowProperty,
   TextTransformProperty,
+  ClipProperty,
 } from 'csstype';
 import {PseudoPropStyles} from './PseudoPropStyles';
 import {BoxPropTypes} from './BoxPropTypes';
@@ -83,6 +84,8 @@ export interface BaseBoxProps
   float?: FloatProperty;
   willChange?: WillChangeProperty;
   textDecoration?: TypographyProps['textDecoration'];
+  clip?: ClipProperty;
+  type?: string;
   // Do not document, we prefer if folks do not use this property for i18n.
   textTransform?: TextTransformProperty;
   /** Typed as any because Box can literally be any HTML element */
@@ -156,6 +159,7 @@ const extraConfig = system({
   willChange: true,
   textDecoration: true,
   textTransform: true,
+  clip: true,
 });
 
 const getPseudoStyles = (props: BoxProps): {} => {

--- a/packages/paste-style-props/src/types/border.ts
+++ b/packages/paste-style-props/src/types/border.ts
@@ -59,9 +59,9 @@ export interface BorderStyleProps {
 
 // Styled-system grouping
 export interface BorderProps extends BorderWidthProps, BorderStyleProps, BorderColorProps, BorderRadiusProps {
-  border?: never;
-  borderTop?: never;
-  borderRight?: never;
-  borderBottom?: never;
-  borderLeft?: never;
+  border?: 'none';
+  borderTop?: 'none';
+  borderRight?: 'none';
+  borderBottom?: 'none';
+  borderLeft?: 'none';
 }


### PR DESCRIPTION
Fixes https://github.com/twilio-labs/paste/discussions/535

- [x] Allow passing props directly to Radio, instead of solely retrieving them via RadioGroup. Defaults to direct props, fallback to context from RadioGroup.
- [x]  Radios now work in a controlled manner, and without RadioGroups.
- [x] Updated types to allow passing `border[dir]="none"` instead of never allowing `border` style prop.