### PR TITLE
feat(web): add design guidelines back to nav

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
@@ -141,6 +141,7 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
           <SiteNavNestList isOpen={gettingStartedOpen}>
             <SiteNavItem>
               <SiteNavAnchor to="/getting-started/engineering">Engineering Guidelines</SiteNavAnchor>
+              <SiteNavAnchor to="/getting-started/design">Design Guidelines</SiteNavAnchor>
               <SiteNavAnchor to="/getting-started/about-paste">About Paste</SiteNavAnchor>
             </SiteNavItem>
           </SiteNavNestList>


### PR DESCRIPTION
Our design guidelines were not linked in nav, adding it now

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
