### PR TITLE
feat:(combobox):  option groups and controlled input

### DIFF
--- a/packages/paste-core/components/combobox/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/combobox/__tests__/index.spec.tsx
@@ -7,6 +7,22 @@ import {useCombobox, Combobox, ComboboxInputWrapper, ComboboxListbox, ComboboxLi
 
 const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
 
+const groupedItems = [
+  {group: 'Components', label: 'Alert'},
+  {group: 'Components', label: 'Anchor'},
+  {group: 'Components', label: 'Button'},
+  {group: 'Components', label: 'Card'},
+  {group: 'Components', label: 'Heading'},
+  {group: 'Components', label: 'List'},
+  {group: 'Components', label: 'Modal'},
+  {group: 'Components', label: 'Paragraph'},
+  {group: 'Primitives', label: 'Box'},
+  {group: 'Primitives', label: 'Text'},
+  {group: 'Primitives', label: 'Non-modal dialog'},
+  {group: 'Layout', label: 'Grid'},
+  {label: 'Design Tokens'},
+];
+
 const ComboboxMock: React.FC<{}> = () => {
   const [inputItems, setInputItems] = React.useState(items);
   return (
@@ -72,6 +88,20 @@ const ComboboxPartsMock: React.FC<{}> = () => {
   );
 };
 
+const GroupedMockCombobox: React.FC = () => {
+  return (
+    <Combobox
+      initialIsOpen
+      groupItemsBy="group"
+      items={groupedItems}
+      labelText="Choose a component:"
+      helpText="This is group"
+      optionTemplate={(item: any) => <div>{item.label}</div>}
+      itemToString={item => (item ? item.label : null)}
+    />
+  );
+};
+
 describe('Combobox ', () => {
   describe('Render', () => {
     it('should render', () => {
@@ -106,6 +136,30 @@ describe('Combobox ', () => {
       const renderedLabel = screen.getByTestId('label');
       const renderedTextbox = screen.getByTestId('textbox');
       expect(renderedLabel.getAttribute('for')).toEqual(renderedTextbox.getAttribute('id'));
+    });
+  });
+
+  describe('Groups', () => {
+    it('should render a group of options', () => {
+      render(<GroupedMockCombobox />);
+      const renderedGroups = screen.getAllByRole('group');
+      // check groups, group label and number of options per group
+      expect(renderedGroups[0].getAttribute('aria-label')).toEqual('Components');
+      expect(renderedGroups[0].querySelectorAll('[role="option"]').length).toEqual(8);
+      expect(renderedGroups[1].getAttribute('aria-label')).toEqual('Primitives');
+      expect(renderedGroups[1].querySelectorAll('[role="option"]').length).toEqual(3);
+      expect(renderedGroups[2].getAttribute('aria-label')).toEqual('Layout');
+      expect(renderedGroups[2].querySelectorAll('[role="option"]').length).toEqual(1);
+    });
+
+    it('should render any items not identified as part of the group as ungrouped options', () => {
+      render(<GroupedMockCombobox />);
+      const renderedListbox = screen.getByRole('listbox');
+      const renderedGroups = screen.getAllByRole('group');
+      // check we have 3 groups
+      expect(renderedGroups.length).toEqual(3);
+      // check any options that are not nested in groups
+      expect(renderedListbox.querySelectorAll('[role="listbox"] > [role="option"]').length).toEqual(1);
     });
   });
 

--- a/packages/paste-core/components/combobox/package.json
+++ b/packages/paste-core/components/combobox/package.json
@@ -47,6 +47,10 @@
     "@twilio-paste/form": "^1.6.0",
     "@twilio-paste/icons": "^2.6.1",
     "@twilio-paste/styling-library": "^0.1.1",
-    "@twilio-paste/text": "^2.2.6"
+    "@twilio-paste/text": "^2.2.6",
+    "@types/lodash.groupby": "^4.6.6"
+  },
+  "dependencies": {
+    "lodash.groupby": "^4.6.0"
   }
 }

--- a/packages/paste-core/components/combobox/src/ComboboxListboxGroup.tsx
+++ b/packages/paste-core/components/combobox/src/ComboboxListboxGroup.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import {Box} from '@twilio-paste/box';
+import {Text} from '@twilio-paste/text';
+
+export interface ComboboxListboxGroupProps {
+  children: NonNullable<React.ReactNode>;
+  groupName: string;
+}
+
+const ComboboxListboxGroup: React.FC<ComboboxListboxGroupProps> = ({children, groupName}) => {
+  return (
+    <Box as="div" role="group" aria-label={groupName} paddingTop="space20">
+      <Box
+        as="div"
+        role="presentation"
+        padding="space30"
+        paddingBottom="space20"
+        paddingLeft="space50"
+        paddingRight="space50"
+      >
+        <Text as="span" fontWeight="fontWeightSemibold">
+          {groupName}
+        </Text>
+      </Box>
+      {children}
+    </Box>
+  );
+};
+
+ComboboxListboxGroup.displayName = 'ComboboxListboxGroup';
+
+ComboboxListboxGroup.propTypes = {
+  children: PropTypes.node.isRequired,
+  groupName: PropTypes.string.isRequired,
+};
+
+export {ComboboxListboxGroup};

--- a/packages/paste-core/components/combobox/src/ComboboxListboxOption.tsx
+++ b/packages/paste-core/components/combobox/src/ComboboxListboxOption.tsx
@@ -1,25 +1,37 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import {Space} from '@twilio-paste/style-props';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
 
 export interface ComboboxListboxOptionProps {
   children: NonNullable<React.ReactNode>;
   highlighted?: boolean;
+  variant: 'default' | 'groupOption';
 }
 
+const VariantStyles = {
+  groupOption: {
+    paddingLeft: 'space70' as Space,
+    paddingRight: 'space70' as Space,
+  },
+  default: {
+    paddingLeft: 'space50' as Space,
+    paddingRight: 'space50' as Space,
+  },
+};
+
 const ComboboxListboxOption = React.forwardRef<HTMLLIElement, ComboboxListboxOptionProps>(
-  ({children, highlighted, ...props}, ref) => {
+  ({children, highlighted, variant = 'default', ...props}, ref) => {
     return (
       <Box
         {...safelySpreadBoxProps(props)}
         as="li"
         padding="space30"
-        paddingLeft="space50"
-        paddingRight="space50"
         backgroundColor={highlighted ? 'colorBackgroundPrimaryLightest' : null}
         cursor="pointer"
         ref={ref}
+        {...VariantStyles[variant]}
       >
         <Text as="span" textDecoration={highlighted ? 'underline' : null}>
           {children}
@@ -35,6 +47,7 @@ if (process.env.NODE_ENV === 'development') {
   ComboboxListboxOption.propTypes = {
     children: PropTypes.node.isRequired,
     highlighted: PropTypes.bool,
+    variant: PropTypes.oneOf(['default', 'groupOption']).isRequired as any,
   };
 }
 

--- a/packages/paste-core/components/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/index.stories.tsx
@@ -48,6 +48,22 @@ const objectItems = [
   {code: 'AT', label: 'Austria', phone: '43'},
 ];
 
+const groupedItems = [
+  {group: 'Components', label: 'Alert'},
+  {group: 'Components', label: 'Anchor'},
+  {group: 'Components', label: 'Button'},
+  {group: 'Components', label: 'Card'},
+  {group: 'Components', label: 'Heading'},
+  {group: 'Components', label: 'List'},
+  {group: 'Components', label: 'Modal'},
+  {group: 'Components', label: 'Paragraph'},
+  {group: 'Primitives', label: 'Box'},
+  {group: 'Primitives', label: 'Text'},
+  {group: 'Primitives', label: 'Non-modal dialog'},
+  {group: 'Layout', label: 'Grid'},
+  {label: 'Design Tokens'},
+];
+
 const CustomInputCombobox: React.FC<{}> = () => {
   const {
     getComboboxProps,
@@ -222,5 +238,77 @@ storiesOf('Components|Combobox', module)
           }}
         />
       </Box>
+    );
+  })
+  .add('Combobox - Controlled', () => {
+    const [value, setValue] = React.useState('');
+    const [selectedItem, setSelectedItem] = React.useState();
+    const [inputItems, setInputItems] = React.useState(objectItems);
+    return (
+      <>
+        <Combobox
+          autocomplete
+          items={inputItems}
+          labelText="Choose a country:"
+          helpText="This is the help text"
+          optionTemplate={(item: any) => (
+            <div>
+              {item.code} | {item.label} | {item.phone}
+            </div>
+          )}
+          onInputValueChange={({inputValue}) => {
+            if (inputValue !== undefined) {
+              setInputItems(
+                _.filter(objectItems, (item: any) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+              );
+              setValue(inputValue);
+            }
+          }}
+          itemToString={item => (item ? item.label : null)}
+          selectedItem={selectedItem}
+          onSelectedItemChange={changes => {
+            setSelectedItem(changes.selectedItem);
+          }}
+          inputValue={value}
+        />
+        <Box paddingTop="space70">
+          Input value state: {JSON.stringify(value)}
+          <br />
+          Selected item state: {JSON.stringify(selectedItem)}
+        </Box>
+      </>
+    );
+  })
+  .add('Combobox - Option groups', () => {
+    return (
+      <Combobox
+        groupItemsBy="group"
+        items={groupedItems}
+        labelText="Choose a component:"
+        helpText="This is group"
+        optionTemplate={(item: any) => <div>{item.label}</div>}
+        itemToString={item => (item ? item.label : null)}
+      />
+    );
+  })
+  .add('Combobox - Option groups typeahead', () => {
+    const [inputItems, setInputItems] = React.useState(groupedItems);
+    return (
+      <Combobox
+        autocomplete
+        groupItemsBy="group"
+        items={inputItems}
+        labelText="Choose a component:"
+        helpText="This is the help text"
+        optionTemplate={(item: any) => <div>{item.label}</div>}
+        onInputValueChange={({inputValue}) => {
+          if (inputValue !== undefined) {
+            setInputItems(
+              _.filter(groupedItems, (item: any) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+            );
+          }
+        }}
+        itemToString={item => (item ? item.label : null)}
+      />
     );
   });

--- a/packages/paste-website/src/component-examples/ComboboxExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxExamples.ts
@@ -3,9 +3,7 @@ const authors = ['James Baldwin', 'Adrienne Maree Brown', 'Octavia Butler', 'Ta-
 
 const BasicCombobox = () => {
   return (
-    <>
-      <Combobox items={authors} labelText="Select an author" required />
-    </>
+    <Combobox items={authors} labelText="Select an author" required />
   );
 };
 
@@ -19,18 +17,16 @@ const numbers = ['(415) 555-CATS', '(415) 555-DOGS', '(415) 555-MICE'];
 
 const PrefixSuffixCombobox = () => {
   return (
-    <>
-      <Combobox
-        items={numbers}
-        labelText="Select a Phone Number"
-        insertBefore={<div>+1</div>}
-        insertAfter={
-          <Anchor href="#" display="flex">
-            <InformationIcon decorative={false} title="Get more info" />
-          </Anchor>
-        }
-      />
-    </>
+    <Combobox
+      items={numbers}
+      labelText="Select a Phone Number"
+      insertBefore={<div>+1</div>}
+      insertAfter={
+        <Anchor href="#" display="flex">
+          <InformationIcon decorative={false} title="Get more info" />
+        </Anchor>
+      }
+    />
   );
 };
 
@@ -45,19 +41,17 @@ const products = ['SMS', 'Phone Numbers', 'Video'];
 const AutoCompleteCombobox = () => {
   const [inputItems, setInputItems] = React.useState(products);
   return (
-    <>
-      <Combobox
-        autocomplete
-        items={inputItems}
-        labelText="Select a Product"
-        helpText="Please choose a Twilio product."
-        onInputValueChange={({inputValue}) => {
-          if (inputValue !== undefined) {
-            setInputItems(products.filter(item => item.toLowerCase().startsWith(inputValue.toLowerCase())));
-          }
-        }}
-      />
-    </>
+    <Combobox
+      autocomplete
+      items={inputItems}
+      labelText="Select a Product"
+      helpText="Please choose a Twilio product."
+      onInputValueChange={({inputValue}) => {
+        if (inputValue !== undefined) {
+          setInputItems(products.filter(item => item.toLowerCase().startsWith(inputValue.toLowerCase())));
+        }
+      }}
+    />
   );
 };
 
@@ -76,9 +70,51 @@ const months = [
 
 const OptionTemplateCombobox = () => {
   return (
+    <Combobox
+      items={months}
+      labelText="Select a Month"
+      optionTemplate={(item) => (
+        <MediaObject verticalAlign="center">
+          <MediaBody>
+            <Text as="span" fontStyle="italic" color="colorTextWeak">
+            ({item.abbr}){' '}
+            </Text>
+            <Text as="span">
+              {item.label} {item.year}
+            </Text>
+          </MediaBody>
+          <MediaFigure spacing="space20">
+            <LinkExternalIcon decorative={false} title="external" />
+          </MediaFigure>
+        </MediaObject>
+      )}
+      itemToString={item => (item ? String(item.label) : null)}
+    />
+  );
+};
+
+render(
+  <OptionTemplateCombobox />
+)
+`.trim();
+
+export const controlledComboboxExample = `
+const months = [
+  {label: 'November', year: '2020', abbr: 'Nov'},
+  {label: 'December', year: '2020', abbr: 'Dec'},
+  {label: 'January', year: '2021', abbr: 'Jan'},
+  {label: 'February', year: '2021', abbr: 'Feb'},
+];
+
+const ControlledCombobox = () => {
+  const [value, setValue] = React.useState('');
+  const [selectedItem, setSelectedItem] = React.useState();
+  const [items, setItems] = React.useState(months);
+  return (
     <>
       <Combobox
-        items={months}
+        autocomplete
+        items={items}
         labelText="Select a Month"
         optionTemplate={(item) => (
           <MediaObject verticalAlign="center">
@@ -96,13 +132,77 @@ const OptionTemplateCombobox = () => {
           </MediaObject>
         )}
         itemToString={item => (item ? String(item.label) : null)}
+        onInputValueChange={({inputValue}) => {
+          if (inputValue !== undefined) {
+            setItems(months.filter(item => {
+              return item.label.toLowerCase().startsWith(inputValue.toLowerCase())
+            }));
+            setValue(inputValue);
+          }
+        }}
+        selectedItem={selectedItem}
+        onSelectedItemChange={changes => {
+          setSelectedItem(changes.selectedItem);
+        }}
+        inputValue={value}
       />
+      <Box paddingTop="space70">
+        Input value state: {JSON.stringify(value)}
+        <br />
+        Selected item state: {JSON.stringify(selectedItem)}
+        <br />
+        Items state: {JSON.stringify(items)}
+      </Box>
     </>
   );
 };
 
 render(
-  <OptionTemplateCombobox />
+  <ControlledCombobox />
+)
+`.trim();
+
+export const groupedComboboxExample = `
+const groupedItems = [
+  {type: 'Components', label: 'Alert'},
+  {type: 'Components', label: 'Anchor'},
+  {type: 'Components', label: 'Button'},
+  {type: 'Components', label: 'Card'},
+  {type: 'Components', label: 'Heading'},
+  {type: 'Components', label: 'List'},
+  {type: 'Components', label: 'Modal'},
+  {type: 'Components', label: 'Paragraph'},
+  {type: 'Primitives', label: 'Box'},
+  {type: 'Primitives', label: 'Text'},
+  {type: 'Primitives', label: 'Non-modal dialog'},
+  {type: 'Layout', label: 'Grid'},
+  {label: 'Design Tokens'},
+];
+
+const GroupedCombobox = () => {
+  const [inputItems, setInputItems] = React.useState(groupedItems);
+  return (
+    <Combobox
+      autocomplete
+      groupItemsBy="type"
+      items={inputItems}
+      labelText="Choose a component:"
+      helpText="This is the help text"
+      optionTemplate={(item) => <div>{item.label}</div>}
+      onInputValueChange={({inputValue}) => {
+        if (inputValue !== undefined) {
+          setInputItems(
+            _.filter(groupedItems, (item) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+          );
+        }
+      }}
+      itemToString={item => (item ? item.label : null)}
+    />
+  );
+};
+
+render(
+  <GroupedCombobox />
 )
 `.trim();
 
@@ -111,9 +211,7 @@ const products = ['SMS', 'Phone Numbers', 'Video'];
 
 const ErrorCombobox = () => {
   return (
-    <>
-      <Combobox items={products} labelText="Select a Product" helpText="This is the error message" hasError />
-    </>
+    <Combobox items={products} labelText="Select a Product" helpText="This is the error message" hasError />
   );
 };
 
@@ -127,9 +225,7 @@ const products = ['SMS', 'Phone Numbers', 'Video'];
 
 const RequiredCombobox = () => {
   return (
-    <>
-      <Combobox items={products} labelText="Select a Product" required />
-    </>
+    <Combobox items={products} labelText="Select a Product" required />
   );
 };
 
@@ -143,9 +239,7 @@ const products = ['SMS', 'Phone Numbers', 'Video'];
 
 const DisabledCombobox = () => {
   return (
-    <>
-      <Combobox items={products} labelText="Select a Product" disabled />
-    </>
+    <Combobox items={products} labelText="Select a Product" disabled />
   );
 };
 

--- a/packages/paste-website/src/components/search/index.tsx
+++ b/packages/paste-website/src/components/search/index.tsx
@@ -19,15 +19,15 @@ const SearchCombobox: React.FC<SearchComboboxProps> = ({refine, hits, currentRef
       labelText={<ScreenReaderOnly>Search</ScreenReaderOnly>}
       placeholder="Jump to..."
       items={hits}
-      itemToString={i => (i ? i.name : i)}
-      value={currentRefinement}
+      itemToString={i => (i && typeof i !== 'string' ? i.name : i)}
+      inputValue={currentRefinement}
       onInputValueChange={({inputValue}) => {
         if (inputValue !== undefined) {
           refine(inputValue);
         }
       }}
       onSelectedItemChange={(changes: Partial<UseComboboxState<any>>) => {
-        if (changes !== undefined) {
+        if (changes != null && changes.selectedItem != null) {
           navigate(changes.selectedItem.slug);
         }
       }}

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -24,6 +24,8 @@ import {
   errorExample,
   disabledExample,
   prefixSuffixExample,
+  controlledComboboxExample,
+  groupedComboboxExample,
 } from '../../../component-examples/ComboboxExamples';
 
 export const pageQuery = graphql`
@@ -82,6 +84,8 @@ export const pageQuery = graphql`
 
 ### About Combobox
 
+The Combobox is an opinionated implementation and wrapper around the **very excellent [Downshift component](https://downshift.netlify.app/downshift)**.
+
 Combobox allows a user to make a selection from a styled list box of options. Each option can consist of more than just text,
 _e.g._ text paired with an icon. It can also be set up with autocomplete/typeahead functionality so users can easily find a
 specific option.
@@ -115,6 +119,30 @@ The `optionTemplate` prop allows you to pass `jsx` in order to display more comp
 
 <LivePreview scope={{Combobox, Anchor, InformationIcon}} noInline language="jsx">
   {prefixSuffixExample}
+</LivePreview>
+
+#### Combobox with option groups
+
+The list of options shown to the user, known as the `Listbox`, can be grouped to create labelled sections. Structure your data into an array of objects and use a key on each object as the grouping identifier. Then tell the Combobox what you would like to group the items by, by setting `groupItemsBy` to match the intended group identifier.
+
+In the example below we have a list of components and we are grouping them based on their type.
+
+<LivePreview scope={{Combobox}} noInline language="jsx">
+  {groupedComboboxExample}
+</LivePreview>
+
+#### Controlled Combobox
+
+The Combobox can be used as a [controlled component](https://reactjs.org/docs/forms.html#controlled-components) when you would like full control over your state. Use the properties `selectedItem`, `inputValue`, `onInputValueChange` and `onSelectedItemChange` to control the value of the Combobox via your own application state.
+
+In the example below the value of the Combobox is stored in a piece of our application state. We update that value based on user input into the Combobox, resetting the value of the Combobox. Upon the user selecting a defined option, we hook into `onSelectedItemChange` to set our selectedItem state value based on user selection.
+
+<LivePreview
+  scope={{Combobox, Box, LinkExternalIcon, MediaBody, MediaObject, MediaFigure, Text}}
+  noInline
+  language="jsx"
+>
+  {controlledComboboxExample}
 </LivePreview>
 
 ## States
@@ -297,13 +325,25 @@ All the valid HTML attributes for `input` are supported including the following 
 
 Allows autocomplete/typehead feature.
 
+##### `groupItemsBy?: string`
+
+The name of the key in your item objects that you would like Combobox to group the items by.
+
 ##### `helpText?: string | React.ReactNode`
 
 The contents of the help and error text.
 
+##### `initialIsOpen?: boolean`
+
+Sets whether the Combobox is open on initial render.
+
 ##### `initialSelectedItem?: Item`
 
 Sets the initial item selected when a Combobox is initialized.
+
+##### `inputValue?: string`
+
+Sets the value of the input inside the Combobox.
 
 ##### `items: Item[]`
 
@@ -338,6 +378,10 @@ highlighted.
 ##### `optionTemplate?: (item: string | {}) => React.ReactNode`
 
 This function allows you to use your own `jsx` template for the items in the drop-down list.
+
+##### `selectedItem?: any`
+
+Used to set the Selected Item of the Combobox.
 
 <ChangelogRevealer>
   <Changelog />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,6 +4497,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/lodash.groupby@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz#4d9b61a4d8b0d83d384975cabfed4c1769d6792e"
+  integrity sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.158"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
+  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
+
 "@types/lodash@^4.14.136", "@types/lodash@^4.14.92":
   version "4.14.150"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
@@ -16672,6 +16684,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.groupby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
 
 lodash.isequal@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
This PR introduces the ability to create options groups and use Combobox as a controlled input.

- Add the ability to create options groups within the Combobox Listbox.
- Add necessary props to use Combobox as a controlled component.
- Document options groups and controlled component