### PR TITLE
fix(web): fix 404 links to github when logging in

### DIFF
--- a/packages/paste-website/src/components/ContactUsMenu.tsx
+++ b/packages/paste-website/src/components/ContactUsMenu.tsx
@@ -12,10 +12,10 @@ export const ContactUsMenu: React.FC<{}> = () => {
         Contact us <ChevronDownIcon decorative />
       </MenuButton>
       <Menu {...menu} aria-label="Contact us">
-        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions/new" onClick={handleClick}>
+        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions" onClick={handleClick}>
           Ask a question
         </MenuItem>
-        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions/new" onClick={handleClick}>
+        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions" onClick={handleClick}>
           Request a feature
         </MenuItem>
         <MenuItem


### PR DESCRIPTION
Removed `/new` from Discussions links to solve bug for login.

@SiTaggart Can you file a bug with discussions about this? At the same time, will be great to know if they support templates in discussions

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
