### PR TITLE
docs(button): give the inverse example a little room to breath

### DIFF
--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -199,7 +199,7 @@ The inverse button is best used over very strong colored backgrounds. In a light
 Do reach for the other variants first and only use the inverse as a backup option.
 
 <LivePreview scope={{Box, Button}} language="jsx">
-  {`<Box backgroundColor="colorBackgroundBodyInverse">
+  {`<Box backgroundColor="colorBackgroundBodyInverse" padding="space60">
   <Button variant="inverse">
     View Profile
   </Button>


### PR DESCRIPTION
It's very tight to the background edge so doesn't really give a good showcase of what it looks like
 
![image](https://user-images.githubusercontent.com/368249/90042538-abd45c80-dc7f-11ea-9fbb-8e1db265fb8c.png)
