### PR TITLE
fix(button): reset variant should inherit type styles

### DIFF
--- a/packages/paste-core/components/button/src/ResetButton.tsx
+++ b/packages/paste-core/components/button/src/ResetButton.tsx
@@ -6,11 +6,15 @@ import {DirectButtonProps, DirectButtonPropTypes} from './types';
 // This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
 const merge = require('lodash.merge');
 
-const defaultStyles: BoxStyleProps = merge({}, BaseStyles.default);
+const defaultStyles: BoxStyleProps = merge({}, BaseStyles.default, {
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
+  color: 'inherit',
+});
 
-const loadingStyles: BoxStyleProps = merge({}, BaseStyles.loading);
+const loadingStyles: BoxStyleProps = merge({}, BaseStyles.loading, {fontSize: 'inherit', fontWeight: 'inherit'});
 
-const disabledStyles: BoxStyleProps = merge({}, BaseStyles.disabled);
+const disabledStyles: BoxStyleProps = merge({}, BaseStyles.disabled, {fontSize: 'inherit', fontWeight: 'inherit'});
 
 const ButtonStyleMapping = {
   default: defaultStyles,

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -3,6 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs} from '@storybook/addon-knobs';
 import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
 import {Box} from '@twilio-paste/box';
+import {Heading} from '@twilio-paste/heading';
 import {Stack} from '@twilio-paste/stack';
 import {isRenderingOnServer} from '@twilio-paste/animation-library';
 import {Button} from '../src';
@@ -23,6 +24,18 @@ const AllSizeOptions: React.FC<{variant: ButtonVariants}> = ({variant}) => {
           <Button variant={variant as ButtonVariants} size={size as ButtonSizes}>
             {children}
           </Button>
+          {size !== 'icon' && size !== 'reset' && (
+            <Button variant={variant as ButtonVariants} size={size as ButtonSizes}>
+              <PlusIcon title="Add item to cart" decorative={false} />
+              {children}
+            </Button>
+          )}
+          {size !== 'icon' && size !== 'reset' && (
+            <Button variant={variant as ButtonVariants} size={size as ButtonSizes}>
+              {children}
+              <PlusIcon title="Add item to cart" decorative={false} />
+            </Button>
+          )}
           <Button variant={variant as ButtonVariants} size={size as ButtonSizes} loading={!isRenderingOnServer}>
             {children}
           </Button>
@@ -49,4 +62,23 @@ storiesOf('Components|Button', module)
   .add('Destructive Button', () => <AllSizeOptions variant="destructive" />)
   .add('Destructive Link Button', () => <AllSizeOptions variant="destructive_link" />)
   .add('Link Button', () => <AllSizeOptions variant="link" />)
-  .add('Reset', () => <AllSizeOptions variant="reset" />);
+  .add('Reset', () => (
+    <>
+      <AllSizeOptions variant="reset" />
+      <Heading variant="heading10" as="h1">
+        <Button variant="reset" size="reset">
+          Example using reset button in composition
+        </Button>
+      </Heading>
+      <Heading variant="heading20" as="h1">
+        <Button variant="reset" size="reset">
+          Example using reset button in composition
+        </Button>
+      </Heading>
+      <Heading variant="heading20" as="h1">
+        <Button variant="reset" size="reset" disabled>
+          Example using reset button in composition
+        </Button>
+      </Heading>
+    </>
+  ));


### PR DESCRIPTION
With an update to the reset variant of button we accidentally regressed our roadmap page.

## Before button update: 

![image](https://user-images.githubusercontent.com/368249/90053946-01b10080-dc90-11ea-8571-364cb7e40a78.png)

## After button update:

![image](https://user-images.githubusercontent.com/368249/90053964-0675b480-dc90-11ea-84a5-6d5e351d753c.png)

This PR applies a small fix to the reset variant that puts it back to original behavior, but also inherits weight and color. This places the reset variant back to its original intended purpose; use in compositions.

I also noticed we don't actually regression test a pretty common use case for buttons, icon next to text. Adding for regression purposes.

**Code includes:**

- inherit font size, weight and color on reset variants of button
- add story examples to cover those use cases so we catch future regressions
- add missing button examples text with icon for regression purposes


**N.B.** I get it that ideally we'd just replace the roadmap custom disclosures with the _real_, since released Disclosure component but I wanted to get us back to a before state before doing that.