### PR TITLE
fix(combobox): provide a means to use action methods from state hook

### DIFF
--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -165,6 +165,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       groupItemsBy,
       groupLabelTemplate,
       variant = 'default',
+      state,
       ...props
     },
     ref
@@ -178,18 +179,36 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       getToggleButtonProps,
       highlightedIndex,
       isOpen,
-    } = useComboboxPrimitive({
-      initialSelectedItem,
-      items,
-      onHighlightedIndexChange,
-      onInputValueChange,
-      onIsOpenChange,
-      onSelectedItemChange,
-      ...(itemToString && {itemToString}),
-      ...(initialIsOpen && {initialIsOpen}),
-      ...(inputValue && {inputValue}),
-      ...(selectedItem && {selectedItem}),
-    });
+    } =
+      state ||
+      useComboboxPrimitive({
+        initialSelectedItem,
+        items,
+        onHighlightedIndexChange,
+        onInputValueChange,
+        onIsOpenChange,
+        onSelectedItemChange,
+        ...(itemToString && {itemToString}),
+        ...(initialIsOpen && {initialIsOpen}),
+        ...(inputValue && {inputValue}),
+        ...(selectedItem && {selectedItem}),
+      });
+
+    if (
+      getComboboxProps === undefined ||
+      getInputProps === undefined ||
+      getItemProps === undefined ||
+      getLabelProps === undefined ||
+      getMenuProps === undefined ||
+      getToggleButtonProps === undefined ||
+      highlightedIndex === undefined ||
+      isOpen === undefined
+    ) {
+      throw new Error(
+        '[Combobox]: One of getComboboxProps, getInputProps, getItemProps, getLabelProps, getMenuProps, getToggleButtonProps, highlightedIndex or isOpen is missing from the state object. Please make sure this is provided.'
+      );
+    }
+
     const helpTextId = useUID();
     const groupUID = useUIDSeed();
     const optionUID = useUIDSeed();

--- a/packages/paste-core/components/combobox/src/index.tsx
+++ b/packages/paste-core/components/combobox/src/index.tsx
@@ -7,3 +7,4 @@ export * from './ComboboxInputWrapper';
 export * from './ComboboxListbox';
 export * from './ComboboxListboxOption';
 export * from './ComboboxListboxGroup';
+export {ComboboxProps} from './types';

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -1,4 +1,8 @@
-import {UseComboboxPrimitiveProps, UseComboboxPrimitiveState} from '@twilio-paste/combobox-primitive';
+import {
+  UseComboboxPrimitiveProps,
+  UseComboboxPrimitiveState,
+  UseComboboxPrimitiveReturnValue,
+} from '@twilio-paste/combobox-primitive';
 import {FieldVariants, FormInputProps} from '@twilio-paste/form';
 
 type Item = string | {[key: string]: any};
@@ -21,6 +25,7 @@ export interface ComboboxProps extends Omit<FormInputProps, 'id' | 'type' | 'val
   inputValue?: UseComboboxPrimitiveProps<Item>['inputValue'];
   groupItemsBy?: string;
   variant?: FieldVariants;
+  state?: Partial<UseComboboxPrimitiveReturnValue<Item>>;
 }
 
 export interface RenderItemProps extends Pick<ComboboxProps, 'optionTemplate'> {

--- a/packages/paste-core/components/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/index.stories.tsx
@@ -4,12 +4,14 @@ import _ from 'lodash';
 import {storiesOf} from '@storybook/react';
 import {withKnobs} from '@storybook/addon-knobs';
 import {Anchor} from '@twilio-paste/anchor';
+import {Button} from '@twilio-paste/button';
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
 import {FormLabel} from '@twilio-paste/form';
 import {MediaObject, MediaFigure, MediaBody} from '@twilio-paste/media-object';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {AttachIcon} from '@twilio-paste/icons/esm/AttachIcon';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {useCombobox, Combobox, ComboboxInputWrapper, ComboboxListbox, ComboboxListboxOption} from '../src';
 
 const items = [
@@ -24,6 +26,11 @@ const items = [
   'Paragraph',
 ];
 
+interface IconItems {
+  label: string;
+  iconRight?: boolean;
+  iconLeft?: undefined;
+}
 const iconItems = [
   {label: 'Alert', iconRight: true},
   {label: 'Anchor'},
@@ -35,6 +42,11 @@ const iconItems = [
   {label: 'Paragraph', iconRight: true},
 ];
 
+interface ObjectItem {
+  code: string;
+  label: string;
+  phone: string;
+}
 const objectItems = [
   {code: 'AD', label: 'Andorra', phone: '376'},
   {code: 'AE', label: 'United Arab Emirates', phone: '971'},
@@ -50,6 +62,10 @@ const objectItems = [
   {code: 'AT', label: 'Austria', phone: '43'},
 ];
 
+interface GroupedItem {
+  group?: string;
+  label: string;
+}
 const groupedItems = [
   {group: 'Components', label: 'Alert'},
   {group: 'Components', label: 'Anchor'},
@@ -66,49 +82,6 @@ const groupedItems = [
   {label: 'Design Tokens'},
 ];
 
-const CustomInputCombobox: React.FC<{}> = () => {
-  const {
-    getComboboxProps,
-    getInputProps,
-    getItemProps,
-    getLabelProps,
-    getMenuProps,
-    getToggleButtonProps,
-    highlightedIndex,
-    isOpen,
-    selectedItem,
-  } = useCombobox({items});
-  const fieldID = useUID();
-  return (
-    <Box position="relative">
-      <FormLabel htmlFor={fieldID} {...getLabelProps()}>
-        Choose a component:
-      </FormLabel>
-      <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
-        <input
-          id={fieldID}
-          type="text"
-          {...getInputProps()}
-          {...getToggleButtonProps({tabIndex: 0})}
-          value={selectedItem || ''}
-        />
-      </ComboboxInputWrapper>
-      <ComboboxListbox {...getMenuProps()}>
-        {isOpen &&
-          items.map((item, index) => (
-            <ComboboxListboxOption
-              {...getItemProps({item, index})}
-              highlighted={highlightedIndex === index}
-              key={uid(item)}
-            >
-              {item}
-            </ComboboxListboxOption>
-          ))}
-      </ComboboxListbox>
-    </Box>
-  );
-};
-
 storiesOf('Components|Combobox', module)
   .addDecorator(withKnobs)
   .add('Combobox', () => {
@@ -117,7 +90,7 @@ storiesOf('Components|Combobox', module)
         items={iconItems}
         labelText="Choose a component:"
         helpText="This is the help text"
-        optionTemplate={(item: any) => (
+        optionTemplate={(item: IconItems) => (
           <MediaObject verticalAlign="center">
             {item.iconLeft ? (
               <MediaFigure spacing="space20">
@@ -133,7 +106,7 @@ storiesOf('Components|Combobox', module)
             ) : null}
           </MediaObject>
         )}
-        itemToString={item => (item ? String(item.label) : null)}
+        itemToString={(item: IconItems) => (item ? String(item.label) : null)}
       />
     );
   })
@@ -144,7 +117,7 @@ storiesOf('Components|Combobox', module)
           items={iconItems}
           labelText="Choose a component:"
           helpText="This is the help text"
-          optionTemplate={(item: any) => (
+          optionTemplate={(item: IconItems) => (
             <MediaObject verticalAlign="center">
               {item.iconLeft ? (
                 <MediaFigure spacing="space20">
@@ -160,7 +133,7 @@ storiesOf('Components|Combobox', module)
               ) : null}
             </MediaObject>
           )}
-          itemToString={item => (item ? String(item.label) : null)}
+          itemToString={(item: IconItems) => (item ? String(item.label) : null)}
           variant="inverse"
         />
       </Box>
@@ -314,7 +287,7 @@ storiesOf('Components|Combobox', module)
         items={inputItems}
         labelText="Choose a country:"
         helpText="This is the help text"
-        optionTemplate={(item: any) => (
+        optionTemplate={(item: ObjectItem) => (
           <div>
             {item.code} | {item.label} | {item.phone}
           </div>
@@ -322,16 +295,13 @@ storiesOf('Components|Combobox', module)
         onInputValueChange={({inputValue}) => {
           if (inputValue !== undefined) {
             setInputItems(
-              _.filter(objectItems, (item: any) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+              _.filter(objectItems, (item: ObjectItem) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
             );
           }
         }}
-        itemToString={item => (item ? item.label : null)}
+        itemToString={(item: ObjectItem) => (item ? item.label : null)}
       />
     );
-  })
-  .add('Combobox - Custom Input', () => {
-    return <CustomInputCombobox />;
   })
   .add('Combobox - overflow long value', () => {
     const [inputItems, setInputItems] = React.useState(items);
@@ -353,7 +323,7 @@ storiesOf('Components|Combobox', module)
   })
   .add('Combobox - Controlled', () => {
     const [value, setValue] = React.useState('');
-    const [selectedItem, setSelectedItem] = React.useState();
+    const [selectedItem, setSelectedItem] = React.useState({});
     const [inputItems, setInputItems] = React.useState(objectItems);
     return (
       <>
@@ -362,7 +332,7 @@ storiesOf('Components|Combobox', module)
           items={inputItems}
           labelText="Choose a country:"
           helpText="This is the help text"
-          optionTemplate={(item: any) => (
+          optionTemplate={(item: ObjectItem) => (
             <div>
               {item.code} | {item.label} | {item.phone}
             </div>
@@ -370,17 +340,72 @@ storiesOf('Components|Combobox', module)
           onInputValueChange={({inputValue}) => {
             if (inputValue !== undefined) {
               setInputItems(
-                _.filter(objectItems, (item: any) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+                _.filter(objectItems, (item: ObjectItem) =>
+                  item.label.toLowerCase().startsWith(inputValue.toLowerCase())
+                )
               );
               setValue(inputValue);
             }
           }}
-          itemToString={item => (item ? item.label : null)}
+          itemToString={(item: ObjectItem) => (item ? item.label : null)}
           selectedItem={selectedItem}
           onSelectedItemChange={changes => {
             setSelectedItem(changes.selectedItem);
           }}
           inputValue={value}
+        />
+        <Box paddingTop="space70">
+          Input value state: {JSON.stringify(value)}
+          <br />
+          Selected item state: {JSON.stringify(selectedItem)}
+        </Box>
+      </>
+    );
+  })
+  .add('Combobox - Controlled using state', () => {
+    const [value, setValue] = React.useState('');
+    const [selectedItem, setSelectedItem] = React.useState({});
+    const [inputItems, setInputItems] = React.useState(objectItems);
+    const {reset, ...state} = useCombobox({
+      items: inputItems,
+      itemToString: item => (item ? item.label : null),
+      onSelectedItemChange: changes => {
+        setSelectedItem(changes.selectedItem);
+      },
+      onInputValueChange: ({inputValue}) => {
+        if (inputValue !== undefined) {
+          setInputItems(
+            _.filter(objectItems, (item: ObjectItem) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+          );
+          setValue(inputValue);
+        }
+      },
+      inputValue: value,
+    });
+    return (
+      <>
+        <Combobox
+          state={state}
+          items={inputItems}
+          autocomplete
+          labelText="Choose a country:"
+          helpText="This is the help text"
+          optionTemplate={(item: ObjectItem) => (
+            <div>
+              {item.code} | {item.label} | {item.phone}
+            </div>
+          )}
+          insertAfter={
+            <Button
+              variant="link"
+              size="reset"
+              onClick={() => {
+                reset();
+              }}
+            >
+              <CloseIcon decorative={false} title="Clear" />
+            </Button>
+          }
         />
         <Box paddingTop="space70">
           Input value state: {JSON.stringify(value)}
@@ -396,8 +421,8 @@ storiesOf('Components|Combobox', module)
         items={objectItems}
         labelText="Choose a country:"
         initialIsOpen
-        optionTemplate={(item: any) => <div>{item.label}</div>}
-        itemToString={item => (item ? item.label : null)}
+        optionTemplate={(item: ObjectItem) => <div>{item.label}</div>}
+        itemToString={(item: ObjectItem) => (item ? item.label : null)}
       />
     );
   })
@@ -408,8 +433,8 @@ storiesOf('Components|Combobox', module)
         items={groupedItems}
         labelText="Choose a component:"
         helpText="This is group"
-        optionTemplate={(item: any) => <div>{item.label}</div>}
-        itemToString={item => (item ? item.label : null)}
+        optionTemplate={(item: GroupedItem) => <div>{item.label}</div>}
+        itemToString={(item: GroupedItem) => (item ? item.label : null)}
       />
     );
   })
@@ -421,7 +446,7 @@ storiesOf('Components|Combobox', module)
         labelText="Choose a component:"
         helpText="This is group"
         initialIsOpen
-        optionTemplate={(item: any) => <div>{item.label}</div>}
+        optionTemplate={(item: GroupedItem) => <div>{item.label}</div>}
         groupLabelTemplate={(groupName: string) => {
           if (groupName === 'Components') {
             return (
@@ -435,7 +460,7 @@ storiesOf('Components|Combobox', module)
           }
           return groupName;
         }}
-        itemToString={item => (item ? item.label : null)}
+        itemToString={(item: GroupedItem) => (item ? item.label : null)}
       />
     );
   })
@@ -448,15 +473,17 @@ storiesOf('Components|Combobox', module)
         items={inputItems}
         labelText="Choose a component:"
         helpText="This is the help text"
-        optionTemplate={(item: any) => <div>{item.label}</div>}
+        optionTemplate={(item: GroupedItem) => <div>{item.label}</div>}
         onInputValueChange={({inputValue}) => {
           if (inputValue !== undefined) {
             setInputItems(
-              _.filter(groupedItems, (item: any) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+              _.filter(groupedItems, (item: GroupedItem) =>
+                item.label.toLowerCase().startsWith(inputValue.toLowerCase())
+              )
             );
           }
         }}
-        itemToString={item => (item ? item.label : null)}
+        itemToString={(item: GroupedItem) => (item ? item.label : null)}
       />
     );
   });

--- a/packages/paste-core/primitives/combobox/src/index.tsx
+++ b/packages/paste-core/primitives/combobox/src/index.tsx
@@ -7,4 +7,5 @@ export {
   UseComboboxInterface as UseComboboxPrimitiveInterface,
   UseComboboxProps as UseComboboxPrimitiveProps,
   UseComboboxState as UseComboboxPrimitiveState,
+  UseComboboxReturnValue as UseComboboxPrimitiveReturnValue,
 } from '@twilio-paste/dropdown-library';

--- a/packages/paste-website/src/component-examples/ComboboxExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxExamples.ts
@@ -356,3 +356,79 @@ render(
   <InverseErrorCombobox />
 )
 `.trim();
+
+export const stateHookCombobox = `
+const objectItems = [
+  {code: 'AD', label: 'Andorra', phone: '376'},
+  {code: 'AE', label: 'United Arab Emirates', phone: '971'},
+  {code: 'AF', label: 'Afghanistan', phone: '93'},
+  {code: 'AG', label: 'Antigua and Barbuda', phone: '1-268'},
+  {code: 'AI', label: 'Anguilla', phone: '1-264'},
+  {code: 'AL', label: 'Albania', phone: '355'},
+  {code: 'AM', label: 'Armenia', phone: '374'},
+  {code: 'AO', label: 'Angola', phone: '244'},
+  {code: 'AQ', label: 'Antarctica', phone: '672'},
+  {code: 'AR', label: 'Argentina', phone: '54'},
+  {code: 'AS', label: 'American Samoa', phone: '1-684'},
+  {code: 'AT', label: 'Austria', phone: '43'},
+];
+
+const ComboboxUsingStatehook = () => {
+  const [value, setValue] = React.useState('');
+  const [selectedItem, setSelectedItem] = React.useState({});
+  const [inputItems, setInputItems] = React.useState(objectItems);
+
+  const {reset, ...state} = useCombobox({
+    items: inputItems,
+    itemToString: item => (item ? item.label : null),
+    onSelectedItemChange: changes => {
+      setSelectedItem(changes.selectedItem);
+    },
+    onInputValueChange: ({inputValue}) => {
+      if (inputValue !== undefined) {
+        setInputItems(
+          _.filter(objectItems, item => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+        );
+        setValue(inputValue);
+      }
+    },
+    inputValue: value,
+  });
+
+  return (
+    <>
+      <Combobox
+        state={state}
+        items={inputItems}
+        autocomplete
+        labelText="Choose a country:"
+        helpText="This is the help text"
+        optionTemplate={item => (
+          <div>
+            {item.code} | {item.label} | {item.phone}
+          </div>
+        )}
+        insertAfter={
+          <Button
+            variant="link"
+            size="reset"
+            onClick={() => {
+              reset();
+            }}
+          >
+            <CloseIcon decorative={false} title="Clear" />
+          </Button>
+        }
+      />
+      <Box paddingTop="space70">
+        Input value state: {JSON.stringify(value)}
+        <br />
+        Selected item state: {JSON.stringify(selectedItem)}
+      </Box>
+    </>
+  );
+}
+render(
+  <ComboboxUsingStatehook />
+)
+`.trim();

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -8,13 +8,15 @@ slug: /components/combobox/
 import {graphql} from 'gatsby';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
-import {Combobox} from '@twilio-paste/combobox';
+import {Combobox, useCombobox} from '@twilio-paste/combobox';
+import {Button} from '@twilio-paste/button';
 import {MediaObject, MediaFigure, MediaBody} from '@twilio-paste/media-object';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {LinkExternalIcon} from '@twilio-paste/icons/esm/LinkExternalIcon';
 import {ProductStudioIcon} from '@twilio-paste/icons/esm/ProductStudioIcon';
 import {ProductAutopilotIcon} from '@twilio-paste/icons/esm/ProductAutopilotIcon';
 import {ProductInsightsIcon} from '@twilio-paste/icons/esm/ProductInsightsIcon';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {Text} from '@twilio-paste/text';
 import {UnorderedList, ListItem} from '@twilio-paste/list';
 import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
@@ -30,6 +32,7 @@ import {
   controlledComboboxExample,
   groupedComboboxExample,
   groupedLabelComboboxExample,
+  stateHookCombobox,
 } from '../../../component-examples/ComboboxExamples';
 
 export const pageQuery = graphql`
@@ -161,6 +164,32 @@ In the example below the value of the Combobox is stored in a piece of our appli
   language="jsx"
 >
   {controlledComboboxExample}
+</LivePreview>
+
+#### useCombobox state hook.
+
+<Callout variant="warning">
+  <CalloutTitle>🚨Power user move!🚨</CalloutTitle>
+  <CalloutText>
+    Only use this property if you are a power user. It's very easy to break your implementation and unfortunately the
+    Paste team will not be able to debug this for you. Proceed with extreme caution.
+  </CalloutText>
+</Callout>
+
+In addition to being a controlled component, the Combobox comes with the option of "hooking" into the internal state by using the state hook originally provided by [Downshift](https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox).
+
+Rather than the state be internal to the component, you can use the `useCombobox` hook and pass the returned state to `Combobox` as the `state` prop.
+
+This allows you to destructure certain returned props from the state hook, including action methods like `reset`.
+
+An example usecase of this might be programmatically providing the user a way to clear or reset the Combobox of it's previous selections. In the example below we are providing a clear button as an input suffix. When pressed, it uses the `reset` action method from the hook to clear the input and select item values.
+
+It should be noted that when doing so, the `state` prop takes precident over the [other properties](#state-props) that affect the state or initial state of the `Combobox`. They will be ignored in favour of them being provided as arguments to the `useCombobox` hook.
+
+For full details on how to use the state hook, and what props to provide it, follow the [Combobox Primitive documentation](/primitives/combobox-primitive#usecomboboxprimitive-arguments). It's the same hook, just renamed.
+
+<LivePreview scope={{Combobox, Box, Button, CloseIcon, useCombobox}} noInline language="jsx">
+  {stateHookCombobox}
 </LivePreview>
 
 ## States
@@ -335,7 +364,7 @@ import {Combobox} from '@twilio-paste/combobox';
 const Component = () => <Combobox autocomplete items={foo} labelText="Foo" helpText="Bar" />;
 ```
 
-#### Props
+#### Component Props
 
 All the valid HTML attributes for `input` are supported including the following props:
 
@@ -354,6 +383,22 @@ This function allows you to use your own `jsx` template for the group label in t
 ##### `helpText?: string | React.ReactNode`
 
 The contents of the help and error text.
+
+##### `labelText: string | NonNullable<React.ReactNode>`
+
+The contents of the label text.
+
+##### `optionTemplate?: (item: string | {}) => React.ReactNode`
+
+This function allows you to use your own `jsx` template for the items in the drop-down list.
+
+##### `variant?: string`
+
+The variant of the Combobox. Available variants are `default` or `inverse`.
+
+#### State Props
+
+These props are used when want to create a Controlled Combobox. They control the state of the Combobox.
 
 ##### `initialIsOpen?: boolean`
 
@@ -375,10 +420,6 @@ Array of items to be displayed in the option list.
 
 If items are stored as an object, used to convert item to a string.
 
-##### `labelText: string | NonNullable<React.ReactNode>`
-
-The contents of the label text.
-
 ##### `onHighlightedIndexChange?: (changes: Partial<UseComboboxState<Item>>) => void`
 
 This function is called each time the highlighted item was changed. Items are highlighted if they are hovered over
@@ -397,17 +438,17 @@ This function is each time the value of the input changes.
 This function is called each time the selected item changes. Items are selected by click or the enter key while
 highlighted.
 
-##### `optionTemplate?: (item: string | {}) => React.ReactNode`
-
-This function allows you to use your own `jsx` template for the items in the drop-down list.
-
 ##### `selectedItem?: any`
 
 Used to set the Selected Item of the Combobox.
 
-##### `variant?: string`
+##### `state?: Partial<UseComboboxPrimitiveReturnValue<Item>>`
 
-The variant of the Combobox. Available variants are `default` or `inverse`.
+Used as a replacement the state props when coupled with using the `useCombobox` hook. When using this prop, all other state props are **ignored**. They must be passed to `useCombobox` as arguments instead.
+
+#### useCombobox Arguments
+
+Please see the [Combobox Primitive](/primitives/combobox-primitive#usecomboboxprimitive-arguments).
 
 <ChangelogRevealer>
   <Changelog />


### PR DESCRIPTION
When using the Combobox there are sometimes needs where you need that little bit of extra control, for example clearing a selection based on some application logic. 

Currently we don't provide a good enough means to clear the selection and input value together as they are not explicitly tied to each other, and a combobox can get into a strange state once a selection has been made.

By exposing the internal state hook provided by Downshift, and allowing a consumer to pass the returned state props to the component as `state` we allow the consumer to use some of the action methods provided by downshift, such as `reset`.

This PR introduces the ability to provide Combobox a state override by using the state hook. 