### PR TITLE
fix(input docs): typo in accessibility section

### DIFF
--- a/packages/paste-website/src/pages/form-elements/input/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/input/index.mdx
@@ -113,7 +113,7 @@ You can set the input to more [specific types](#input-types) if needed.
     changed.
   </ListItem>
   <ListItem>
-    If the input has assicated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on
+    If the input has associated help text or error text, include the <inlineCode>aria-describedby</inlineCode> prop on
     the input. This should match the <inlineCode>id</inlineCode> of the help or error text.
   </ListItem>
 </UnorderedList>

--- a/packages/paste-website/src/pages/form-elements/input/index.mdx
+++ b/packages/paste-website/src/pages/form-elements/input/index.mdx
@@ -77,7 +77,7 @@ You can set the input to more [specific types](#input-types) if needed.
     Include a visible label on <strong>all</strong> form fields.
   </ListItem>
   <ListItem>
-    Each lable must use the <inlineCode>htmlFor</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the
+    Each label must use the <inlineCode>htmlFor</inlineCode> prop that equals the <inlineCode>id</inlineCode> of the
     associated input.
   </ListItem>
   <ListItem>


### PR DESCRIPTION
- "lable" --> "label"
- "assicated" --> "associated"