### PR TITLE
fix(combobox docs): typo in useCombobox state hook heading

### DIFF
--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -166,7 +166,7 @@ In the example below the value of the Combobox is stored in a piece of our appli
   {controlledComboboxExample}
 </LivePreview>
 
-#### useCombobox state hook.
+#### useCombobox state hook
 
 <Callout variant="warning">
   <CalloutTitle>🚨Power user move!🚨</CalloutTitle>


### PR DESCRIPTION
- Remove extra period in [useCombobox state hook heading](https://paste.twilio.design/components/combobox#usecombobox-state-hook)