### PR TITLE
fix(website): fix topbar zIndex

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
@@ -57,7 +57,7 @@ const PsaAlert: React.FC = () => {
       justifyContent="center"
       position="sticky"
       top="0"
-      zIndex="zIndex20"
+      zIndex="zIndex90"
     >
       <Text as="span" fontWeight="fontWeightBold" color="colorTextBrandInverse" marginRight="space30">
         {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}

--- a/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
@@ -23,7 +23,7 @@ export const SiteHeader: React.FC<{}> = () => {
       paddingBottom="space50"
       position="sticky"
       top="0"
-      zIndex="zIndex10"
+      zIndex="zIndex90"
     >
       <Box
         display="flex"


### PR DESCRIPTION
Prevents Combobox, Menu, and Popover from overlapping the top bar area of the docs site.

**QUESTION:**
Does not fix the Tooltip overlap. We intentionally set tooltip to have our highest zIndex token. So tooltips will always overlap. Should we change the Tooltip zIndex?

**ANSWER:**
No, this feels very intentional and expected behaviour.