### PR TITLE
fix(button): remove unnecessary link error

### DIFF
--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -236,6 +236,17 @@ describe('Button data attributes', () => {
   });
 });
 
+describe('Button render as', () => {
+  it('Renders a button as a link', () => {
+    const wrapper: ReactWrapper = mount(
+      <Button as="a" variant="secondary" href="/tests">
+        button
+      </Button>
+    );
+    expect(wrapper.exists('a')).toEqual(true);
+  });
+});
+
 describe('button event handlers', () => {
   it('Should call the appropriate event handlers', () => {
     const onClickMock: jest.Mock = jest.fn();

--- a/packages/paste-core/components/button/src/index.tsx
+++ b/packages/paste-core/components/button/src/index.tsx
@@ -65,11 +65,6 @@ const handlePropValidation = ({as, href, tabIndex, variant, size, fullWidth, chi
   if (as === 'a' && variant === 'link') {
     throw new Error(`[Paste: Button] This should be a link. Use the [Paste: Anchor] component.`);
   }
-  if (variant !== 'link' && variant !== 'destructive_link' && hasHref) {
-    throw new Error(
-      `[Paste: Button] You cannot pass href into a button without the 'a' tag.  Use 'variant="link"' or 'variant="destructive_link"'.`
-    );
-  }
   if (variant === 'reset' && size !== 'reset') {
     throw new Error('[Paste: Button] The "RESET" variant can only be used with the "RESET" size.');
   }


### PR DESCRIPTION
- [x] Removed link error.
- [x] Added test to verify you can pass a button `as="a" variant="secondary" href="/tests"`, and it will render.