### PR TITLE
fix(disclosure docs): broken link in first paragraph

### DIFF
--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -75,7 +75,7 @@ export const pageQuery = graphql`
 
 ### About Disclosure
 
-<p>{props.pageContext.frontmatter.description} It uses the [Paste Heading](/components/heading) component to create consistency across pages and content hierarchy.</p>
+<p>{props.pageContext.frontmatter.description} It uses the{' '}<Anchor href="/components/heading">Paste Heading</Anchor> component to create consistency across pages and content hierarchy.</p>
 
 ### Accessibility
 


### PR DESCRIPTION
"`[Paste Heading](/components/heading)`" --> Anchor component

https://paste-git-fixdisclosure-docs-broken-link-in-first-paragraph.twilio-dsys.vercel.app/components/disclosure/