### PR TITLE
fix(website): redirect trailing slash to no slash

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,34 +2,14 @@
   "name": "paste",
   "scope": "twilio-dsys",
   "version": 2,
-  "builds": [{
-    "src": "now-build.sh",
-    "use": "@now/static-build",
-    "config": {
-      "distDir": "packages/paste-website/public"
-    }
-  }],
-  "routes": [{
-      "src": "/form-elements",
-      "status": 301,
-      "headers": {
-        "Location": "form-elements/input/"
+  "trailingSlash": true,
+  "builds": [
+    {
+      "src": "now-build.sh",
+      "use": "@now/static-build",
+      "config": {
+        "distDir": "packages/paste-website/public"
       }
-    },
-    {
-      "src": "/form/input",
-      "status": 301,
-      "headers": {
-        "Location": "form-elements/input/"
-      }
-    },
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/.*",
-      "status": 404,
-      "dest": "404/index.html"
     }
   ]
 }


### PR DESCRIPTION
per https://github.com/algolia/docsearch-configs/pull/2349#issuecomment-685426430

> When trailingSlash: undefined, visiting a path with or without a trailing slash will not redirect.
> For example, both /about and /about/ will serve the same content without redirecting.
> This is not recommended because it could lead to search engines indexing two different pages with duplicate content.

https://vercel.com/docs/configuration#project/trailingslash