### PR TITLE
chore: updates to combobox and primitive docs

### DIFF
--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -235,12 +235,11 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
           <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
             <StyledInputAsSelect
               {...getToggleButtonProps({tabIndex: 0})}
-              {...getInputProps({disabled})}
+              {...getInputProps({disabled, ref})}
               {...(!autocomplete ? {onChange: event => event.preventDefault()} : undefined)}
               aria-describedby={helpTextId}
               {...props}
               type="text"
-              ref={ref}
               paddingRight="space90"
             />
             <SelectIconWrapper>
@@ -248,20 +247,18 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
             </SelectIconWrapper>
           </ComboboxInputWrapper>
         </FormControlWrapper>
-        {isOpen && (
-          <ComboboxListbox {...getMenuProps()}>
-            {renderListBox({
-              items,
-              getItemProps,
-              highlightedIndex,
-              optionTemplate,
-              groupItemsBy,
-              groupLabelTemplate,
-              optionUID,
-              groupUID,
-            })}
-          </ComboboxListbox>
-        )}
+        <ComboboxListbox hidden={!isOpen} {...getMenuProps()}>
+          {renderListBox({
+            items,
+            getItemProps,
+            highlightedIndex,
+            optionTemplate,
+            groupItemsBy,
+            groupLabelTemplate,
+            optionUID,
+            groupUID,
+          })}
+        </ComboboxListbox>
         {helpText && (
           <FormHelpText id={helpTextId} variant={getHelpTextVariant(variant, hasError)}>
             {helpText}

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -149,145 +149,442 @@ customer needs to filter a list of available options, or provide a custom free f
 
 ### useComboboxPrimitive Arguments
 
-##### `items: Item[]`
+#### Basic Props
 
-Array of items to be displayed in the option list.
+This is the list of props that you should probably know about. There are some
+[advanced props](#advanced-props) below as well.
 
-##### `itemToString?: (item: Item) => string`
+##### items `any[]` | _required_
 
-If items are stored as an object, used to convert item to a string.
+The main difference from vanilla `Downshift` is that we pass the items we want
+to render to the hook as well. Opening the menu with an item already selected
+means the hook has to know in advance what items you plan to render and what is
+the position of that item in the list. Consequently, there won't be any need for
+two state changes: one for opening the menu and one for setting the highlighted
+index, like in `Downshift`.
 
-##### `getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string`
+##### itemToString `function(item: any)` | defaults to: `item => (item ? String(item) : '')`
 
-Passed to a `Status` component nested within and allows you to create your own assertive ARIA statuses.
+If your items are stored as, say, objects instead of strings, downshift still
+needs a string representation for each one. This is required for accessibility
+messages (e.g., after making a selection).
 
-##### `circularNavigation?: boolean`
+**Note:** This callback _must_ include a null check: it is invoked with `null`
+whenever the user abandons input via `<Esc>`.
 
-Should the keyboard navigation in the option list be circular?
+##### onSelectedItemChange `function(changes: object)` | optional, no useful default
 
-##### `highlightedIndex?: number`
+Called each time the selected item was changed. Selection can be performed by
+item click, Enter Key while item is highlighted or by blurring the menu while an
+item is highlighted (Tab, Shift-Tab or clicking away).
 
-To highlight an item in the option list set the highlighted Index to the number that matches
-the index of the target item in the items array.
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `selectedItem` property
+  with the newly selected value. This also has a `type` property which you can
+  learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
+  property will be part of the actions that can trigger a `selectedItem` change,
+  for example `useCombobox.stateChangeTypes.ItemClick`.
 
-##### `initialHighlightedIndex?: number`
+##### stateReducer `function(state: object, actionAndChanges: object)` | optional
 
-Set the option to be highlighted when the option list is opened
+**🚨 This is a really handy power feature 🚨**
 
-##### `defaultHighlightedIndex?: number`
+This function will be called each time `useCombobox` sets its internal state (or
+calls your `onStateChange` handler for control props). It allows you to modify
+the state change that will take place which can give you fine grain control over
+how the component interacts with user updates. It gives you the current state
+and the state that will be set, and you return the state that you want to set.
 
-This is the value to set the `highlightedIndex` to anytime a Combobox is reset, when the selection is cleared,
-when an item is selected or when the `inputValue` is changed.
+- `state`: The full current state of downshift.
+- `actionAndChanges`: Object that contains the action `type`, props needed to
+  return a new state based on that type and the changes suggested by the
+  Downshift default reducer. About the `type` property you can learn more about
+  in the [`stateChangeTypes`](#statechangetypes) section.
 
-##### `isOpen?: boolean`
+#### Advanced Props
 
-Whether the menu should be considered open or closed.
+##### initialSelectedItem `any` | defaults to `null`
 
-##### `initialIsOpen?: boolean`
+Pass an item that should be selected when downshift is initialized.
 
-This is the initial `isOpen` value when initialized.
+##### initialIsOpen `boolean` | defaults to `false`
 
-##### `defaultIsOpen?: boolean`
+Pass a boolean that sets the open state of the menu when downshift is
+initialized.
 
-This is the value to set the `isOpen` to anytime a Combobox is reset, when the the selection is
-cleared, or when an item is selected.
+##### initialHighlightedIndex `number` | defaults to `-1`
 
-##### `selectedItem?: Item`
+Pass a number that sets the index of the highlighted item when downshift is
+initialized.
 
-Set the selected item by passing the item you wish to select
+##### initialInputValue `string` | defaults to `''`
 
-##### `initialSelectedItem?: Item`
+Pass a string that sets the content of the input when downshift is initialized.
 
-Pass an item or an array of items that should be selected when a Combobox is initialized.
+##### defaultSelectedItem `any` | defaults to `null`
 
-##### `id?: string`
+Pass an item that should be selected when downshift is reset.
 
-Manually override the id of the Combobox trigger
+##### defaultIsOpen `boolean` | defaults to `false`
 
-##### `labelId?: string`
+Pass a boolean that sets the open state of the menu when downshift is reset or
+when an item is selected.
 
-Manually override the id of the Combobox label
+##### defaultHighlightedIndex `number` | defaults to `-1`
 
-##### `menuId?: string`
+Pass a number that sets the index of the highlighted item when downshift is
+reset or when an item is selected.
 
-Manually override the id of the Combobox option list
+##### defaultInputValue `string` | defaults to `''`
 
-##### `toggleButtonId?: string`
+Pass a string that sets the content of the input when downshift is reset or when
+an item is selected.
 
-Manually override the id of the Combobox toggle button if one is used
+##### getA11yStatusMessage `function({/* see below */})` | default messages provided in English
 
-##### `getItemId?: (index: number) => string`
+This function is passed as props to a status updating function nested within
+that allows you to create your own ARIA statuses. It is called when one of the
+following props change: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
 
-Used for aria attributes and the id prop of the element you use `getInputProps` with.
+A default `getA11yStatusMessage` function is provided that will check
+`resultCount` and return "No results are available." or if there are results ,
+"`resultCount` results are available, use up and down arrow keys to navigate.
+Press Enter key to select."
 
-##### `stateReducer?: (state: UseSelectState<Item>, actionAndChanges: UseSelectStateChangeOptions<Item>) => UseSelectState<Item>`
+##### getA11ySelectionMessage `function({/* see below */})` | default messages provided in English
 
-Called each time a Combobox sets its internal state. It allows you to modify the state change that will take place which
-can give you control over how the component interacts with user updates. It gives you the current state and the state
-that will be set, and you return the state that you want to set.
+This function is similar to the `getA11yStatusMessage` but it is generating a
+message when an item is selected. It is passed as props to a status updating
+function nested within that allows you to create your own ARIA statuses. It is
+called when `selectedItem` changes.
 
-##### `onStateChange?: (changes: Partial<UseSelectState<Item>>) => void`
+A default `getA11ySelectionMessage` function is provided. When an item is
+selected, the message is a selection related one, narrating
+"`itemToString(selectedItem)` has been selected".
 
-Called anytime the internal state changes. This can be useful if you're using a Combobox as a "controlled" component,
-where you manage some or all of the state and then pass it as props.
+The object you are passed to generate your status message, for both
+`getA11yStatusMessage` and `getA11ySelectionMessage`, has the following
+properties:
 
-##### `environment?: Environment`
+| property              | type            | description                                                                                  |
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `highlightedIndex`    | `number`        | The currently highlighted index                                                              |
+| `highlightedItem`     | `any`           | The value of the highlighted item                                                            |
+| `isOpen`              | `boolean`       | The `isOpen` state                                                                           |
+| `inputValue`          | `string`        | The value in the text input.                                                                 |
+| `itemToString`        | `function(any)` | The `itemToString` function (see props) for getting the string value from one of the options |
+| `previousResultCount` | `number`        | The total items showing in the dropdown the last time the status was updated                 |
+| `resultCount`         | `number`        | The total items showing in the dropdown                                                      |
+| `selectedItem`        | `any`           | The value of the currently selected item                                                     |
 
-A different `window` context from where your JavaScript is running; i.e., an iframe or a shadow-root.
+##### onHighlightedIndexChange `function(changes: object)` | optional, no useful default
+
+Called each time the highlighted item was changed. Items can be highlighted
+while hovering the mouse over them or by keyboard keys such as Up Arrow, Down
+Arrow, Home and End. Arrow keys can be combined with Shift to move by a step of
+5 positions instead of 1. Items can also be highlighted by hitting character
+keys that are part of their starting string equivalent.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `highlightedIndex`
+  property with the new value. This also has a `type` property which you can
+  learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
+  property will be part of the actions that can trigger a `highlightedIndex`
+  change, for example `useCombobox.stateChangeTypes.MenuKeyDownArrowUp`.
+
+##### onIsOpenChange `function(changes: object)` | optional, no useful default
+
+Called each time the menu is open or closed. Menu can be open by toggle button
+click, Enter, Space, Up Arrow or Down Arrow keys. Can be closed by selecting an
+item, blur (Tab, Shift-Tab or clicking outside), clicking the toggle button
+again or hitting Escape key.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `isOpen` property with
+  the new value. This also has a `type` property which you can learn more about
+  in the [`stateChangeTypes`](#statechangetypes) section. This property will be
+  part of the actions that can trigger a `isOpen` change, for example
+  `useCombobox.stateChangeTypes.ToggleButtonClick`.
+
+##### onInputValueChange `function(changes: object)` | optional, no useful default
+
+Called each time the value in the input text changes. The input value should
+change like any input of type text, at any character key press, `Space`,
+`Backspace`, `Escape` etc.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `inputValue` property
+  with the new value. This also has a `type` property which you can learn more
+  about in the [`stateChangeTypes`](#statechangetypes) section. This property
+  will be part of the actions that can trigger a `inputValue` change, for
+  example `useCombobox.stateChangeTypes.InputChange`.
+
+##### onStateChange `function(changes: object)` | optional, no useful default
+
+This function is called anytime the internal state changes. This can be useful
+if you're using downshift as a "controlled" component, where you manage some or
+all of the state (e.g., isOpen, selectedItem, highlightedIndex, etc) and then
+pass it as props, rather than letting downshift control all its state itself.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This also has a `type` property which you can learn more about
+  in the [`stateChangeTypes`](#statechangetypes) section.
+
+##### highlightedIndex
+
+> `number`
+
+The index of the item that should be highlighted when menu is open.
+
+##### isOpen `boolean`
+
+The open state of the menu.
+
+##### selectedItem `any`
+
+The item that should be selected.
+
+##### inputValue `string`
+
+The value to be displayed in the text input.
+
+##### id `string` | defaults to a generated ID
+
+Used to generate the first part of the `Downshift` id on the elements. You can
+override this `id` with one of your own, provided as a prop, or you can override
+the `id` for each element altogether using the props below.
+
+##### labelId `string` | defaults to a generated ID
+
+Used for `aria` attributes and the `id` prop of the element (`label`) you use
+[`getLabelProps`](#getlabelprops) with.
+
+##### menuId `string` | defaults to a generated ID
+
+Used for `aria` attributes and the `id` prop of the element (`ul`) you use
+[`getMenuProps`](#getmenuprops) with.
+
+##### toggleButtonId `string` | defaults to a generated ID
+
+Used for `aria` attributes and the `id` prop of the element (`button`) you use
+[`getToggleButtonProps`](#gettogglebuttonprops) with.
+
+##### inputId `string` | defaults to a generated ID
+
+Used for `aria` attributes and the `id` prop of the element (`input`) you use
+[`getInputProps`](#getmenuprops) with.
+
+##### getItemId `function(index)` | defaults to a function that generates an ID based on the
+
+> index
+
+Used for `aria` attributes and the `id` prop of the element (`li`) you use
+[`getItemProps`](#getitemprops) with.
+
+##### environment `window` | defaults to `window`
+
+This prop is only useful if you're rendering downshift within a different
+`window` context from where your JavaScript is running; for example, an iframe
+or a shadow-root. If the given context is lacking `document` and/or
+`add|removeEventListener` on its prototype (as is the case for a shadow-root)
+then you will need to pass in a custom object that is able to provide
+[access to these properties](https://gist.github.com/Rendez/1dd55882e9b850dd3990feefc9d6e177)
+for downshift.
+
+##### circularNavigation `boolean` | defaults to `true`
+
+Controls the circular keyboard navigation between items. If set to `true`, when
+first item is highlighted, the Arrow Up will move highlight to the last item,
+and viceversa using Arrow Down.
 
 ### useComboboxPrimitive Returned
 
-##### `highlightedIndex: number`
+##### getLabelProps
 
-The currently highlighted index.
+This method should be applied to the `label` you render. It will generate an
+`id` that will be used to label the toggle button and the menu.
 
-##### `selectedItem: Item`
+There are no required properties for this method.
 
-The value of the currently selected item
+> Note: For accessibility purposes, calling this method is highly recommended.
 
-##### `isOpen: boolean`
+##### getMenuProps
 
-The `isOpen` state
+This method should be applied to the element which contains your list of items.
+Typically, this will be a `<div>` or a `<ul>` that surrounds a `map` expression.
+This handles the proper ARIA roles and attributes.
 
-##### `getToggleButtonProps: (options?: UseSelectGetToggleButtonPropsOptions) => any`
+Optional properties:
 
-Returns the props you should apply to any menu toggle button element you render.
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getMenuProps({refKey: 'innerRef'})` and
+  your composite component would forward like: `<ul ref={props.innerRef} />`.
+  However, if you are just rendering a primitive component like `<div>`, there
+  is no need to specify this property. It defaults to `ref`.
 
-##### `getLabelProps: (options?: UseSelectGetLabelPropsOptions) => any`
+  Please keep in mind that menus, for accessiblity purposes, should always be
+  rendered, regardless of whether you hide it or not. Otherwise, `getMenuProps`
+  may throw error if you unmount and remount the menu.
 
-Returns the props you should apply to the `label` element that you render.
+- `aria-label`: By default the menu will add an `aria-labelledby` that refers to
+  the `<label>` rendered with `getLabelProps`. However, if you provide
+  `aria-label` to give a more specific label that describes the options
+  available, then `aria-labelledby` will not be provided and screen readers can
+  use your `aria-label` instead.
 
-##### `getMenuProps: (options?: UseSelectGetMenuPropsOptions) => any`
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getMenuProps`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
 
-Returns the props you should apply to the `ul` element (or root of your menu) that you render.
+> Note that for accessibility reasons it's best if you always render this
+> element whether or not downshift is in an `isOpen` state.
 
-##### `getItemProps: (options: UseSelectGetItemPropsOptions<Item>) => any`
+##### getItemProps
 
-Returns the props you should apply to any menu item elements you render.
+The props returned from calling this function should be applied to any menu
+items you render.
 
-##### `reset: () => void`
+**This is an impure function**, so it should only be called when you will
+actually be applying the props to an item.
 
-Resets the Combobox state to a default.
+Required properties:
 
-##### `OpenMenu: () => void`
+The main difference from vanilla `Downshift` is that we require the items as
+props before rendering. The reason is to open the menu with items already
+highlighted, and we need to know the items before the actual render. It is still
+required to pass either `item` or `index` to `getItemProps`.
 
-Opens the menu.
+- `item`: this is the item data that will be selected when the user selects a
+  particular item.
+- `index`: This is how `downshift` keeps track of your item when updating the
+  `highlightedIndex` as the user keys around. By default, `downshift` will
+  assume the `index` is the order in which you're calling `getItemProps`. This
+  is often good enough, but if you find odd behavior, try setting this
+  explicitly. It's probably best to be explicit about `index` when using a
+  windowing library like `react-virtualized`.
 
-##### `closeMenu: () => void`
+Optional properties:
 
-Closes the menu.
+- `ref`: if you need to access the item element via a ref object, you'd call the
+  function like this: `getItemProps({ref: yourItemRef})`. As a result, the item
+  element will receive a composed `ref` property, which guarantees that both
+  your code and `useCombobox` use the same correct reference to the element.
 
-##### `toggleMenu: () => void`
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getItemProps({refKey: 'innerRef'})` and
+  your composite component would forward like: `<li ref={props.innerRef} />`.
+  However, if you are just rendering a primitive component like `<div>`, there
+  is no need to specify this property. It defaults to `ref`.
 
-Toggle the menu open state.
+- `disabled`: If this is set to `true`, then all of the downshift item event
+  handlers will be omitted. Items will not be highlighted when hovered, and
+  items will not be selected when clicked.
 
-##### `selectItem: (item: Item) => void`
+##### getToggleButtonProps
 
-Selects the given item.
+Call this and apply the returned props to a `button`. It allows you to toggle
+the `Menu` component.
 
-##### `setHighlightedIndex: (index: number) => void`
+Optional properties:
 
-Call to set a new highlighted index.
+- `ref`: if you need to access the button element via a ref object, you'd call
+  the function like this: `getToggleButton({ref: yourButtonRef})`. As a result,
+  the button element will receive a composed `ref` property, which guarantees
+  that both your code and `useCombobox` use the same correct reference to the
+  element.
+
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getToggleButton({refKey: 'innerRef'})`
+  and your composite component would forward like:
+  `<button ref={props.innerRef} />`. However, if you are just rendering a
+  primitive component like `<div>`, there is no need to specify this property.
+  It defaults to `ref`.
+
+- `disabled`: If this is set to `true`, then all of the downshift button event
+  handlers will be omitted (it won't toggle the menu when clicked).
+
+##### getInputProps
+
+This method should be applied to the `input` you render. It is recommended that
+you pass all props as an object to this method which will compose together any
+of the event handlers you need to apply to the `input` while preserving the ones
+that `downshift` needs to apply to make the `input` behave.
+
+There are no required properties for this method.
+
+Optional properties:
+
+- `disabled`: If this is set to true, then no event handlers will be returned
+  from `getInputProps` and a `disabled` prop will be returned (effectively
+  disabling the input).
+
+- `ref`: if you need to access the input element via a ref object, you'd call
+  the function like this: `getInputProps({ref: yourInputRef})`. As a result, the
+  input element will receive a composed `ref` property, which guarantees that
+  both your code and `useCombobox` use the same correct reference to the
+  element.
+
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getInputProps({refKey: 'innerRef'})` and
+  your composite component would forward like: `<input ref={props.innerRef} />`.
+  However, if you are just rendering a primitive component like `<div>`, there
+  is no need to specify this property. It defaults to `ref`.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getInput`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
+
+##### getComboboxProps
+
+This method should be applied to the `input` wrapper element. It has similar
+return values to the `getRootProps` from vanilla `Downshift`, but renaming it as
+it's not a root element anymore. We are encouraging the correct `combobox` HTML
+structure as having the combobox wrapper as a root for the rest of the elements
+broke navigation and readings with assistive technologies. The wrapper should
+contain the `input` and the `toggleButton` and it should be on the same level
+with the `menu`.
+
+There are no required properties for this method.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getComboboxProps`. **Please use it with extreme care and only if you are
+absolutely sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
+
+#### Actions
+
+These are functions you can call to change the state of the downshift
+`useCombobox` hook.
+
+| property              | type                      | description                                           |
+| --------------------- | ------------------------- | ----------------------------------------------------- |
+| `closeMenu`           | `function()`              | closes the menu                                       |
+| `openMenu`            | `function()`              | opens the menu                                        |
+| `selectItem`          | `function(item: any)`     | selects the given item                                |
+| `setHighlightedIndex` | `function(index: number)` | call to set a new highlighted index                   |
+| `setInputValue`       | `function(value: string)` | call to set a new value in the input                  |
+| `toggleMenu`          | `function()`              | toggle the menu open state                            |
+| `reset`               | `function()`              | this resets downshift's state to a reasonable default |
+
+#### State
+
+These are values that represent the current state of the downshift component.
+
+| property           | type      | description                       |
+| ------------------ | --------- | --------------------------------- |
+| `highlightedIndex` | `number`  | the currently highlighted item    |
+| `isOpen`           | `boolean` | the menu open state               |
+| `selectedItem`     | `any`     | the currently selected item input |
+| `inputValue`       | `string`  | the value in the input            |
 
 <ChangelogRevealer>
   <Changelog />


### PR DESCRIPTION
- fix(combobox): handling refs in downshift v6 is different
- docs(combobox-primitive): update to reflect v6 of downshift
