### PR TITLE
Update components card to use heading20 variant

### DIFF
--- a/packages/paste-website/src/pages/index.tsx
+++ b/packages/paste-website/src/pages/index.tsx
@@ -72,7 +72,7 @@ const IndexPage: React.FC<{}> = (): React.ReactElement => {
           <Column span={[12, 12, 4]}>
             <Box marginBottom="space40">
               <Card padding="space80">
-                <Heading as="h2" variant="heading30">
+                <Heading as="h2" variant="heading20">
                   <SiteLink to="/components">Components</SiteLink>
                 </Heading>
                 <Paragraph>Use Paste components in Sketch or React to compose your user interfaces.</Paragraph>


### PR DESCRIPTION
Fixes the components card on the homepage to style the h2 as heading20 to match the other two cards.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
