### PR TITLE
feat(docs): add office hours sign-up sheet link

### DIFF
--- a/packages/paste-website/src/pages/getting-started/working-guide/index.mdx
+++ b/packages/paste-website/src/pages/getting-started/working-guide/index.mdx
@@ -79,9 +79,8 @@ It's important to note that the Design Systems team does not directly talk to cu
 
 These meetings should be visible on the UX Calendar. If you have trouble finding them, reach out at #help-design-system on Slack.
 
-- **Weekly Design System office hours** on Thursdays alternating North America and Europe friendly time zones. Use these sessions to plan out your UI needs, get feedback on implementation, or debug an issue. 
-- **Weekly design critique** on Tuesdays that are specifically a space for product designers to get feedback on their work.
-- **Monthly Design System guild meeting** for developers, designers, and product managers interested in building better experiences for customers.
+- **Weekly Design Systems office hours** on Tuesdays and alternating Thursdays (between North America and Europe friendly time zones). Use these sessions to plan out your UI needs, get feedback on design work or component implementation, or debug an issue. [Sign up for office hours here.](https://docs.google.com/spreadsheets/d/10vD91zdwr9hjgDOV3HSGnoC0LgvYw-thmn3X_kvW0xk/edit?usp=sharing)
+- **Monthly Design Systems guild meeting** for developers, designers, and product managers interested in building better experiences for customers.
 
 </content>
 


### PR DESCRIPTION
https://paste-git-featdocs-add-office-hours-sign-up-sheet.twilio-dsys.vercel.app/getting-started/working-guide