### PR TITLE
fix: update the readme for first time installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For usage guidelines, please see our [documentation website](https://paste.twili
 Clone the repo then run the following commands from within the repo's folder:
 
 ```
-yarn clean # bootstraps the repo and downloads packages
+yarn # bootstraps the repo and downloads packages
 yarn build # builds all of Paste
 ```
 


### PR DESCRIPTION
You must `yarn` before doing anything in the repo.

