### PR TITLE
chore(website): add event tracking examples

### DIFF
--- a/packages/paste-website/gatsby-config.js
+++ b/packages/paste-website/gatsby-config.js
@@ -15,6 +15,12 @@ const gatsbyConfig = {
     siteUrl: 'https://paste.twilio.design',
   },
   plugins: [
+    {
+      resolve: 'gatsby-plugin-google-analytics',
+      options: {
+        trackingId: 'UA-145457417-1',
+      },
+    },
     `gatsby-plugin-typescript`,
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-sass',
@@ -153,12 +159,6 @@ const gatsbyConfig = {
 
           return 'DefaultJson';
         },
-      },
-    },
-    {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        trackingId: 'UA-145457417-1',
       },
     },
     'gatsby-plugin-sitemap',

--- a/packages/paste-website/src/components/ContactUsMenu.tsx
+++ b/packages/paste-website/src/components/ContactUsMenu.tsx
@@ -1,27 +1,44 @@
 import * as React from 'react';
+import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {Menu, MenuButton, MenuItem, useMenuState} from '@twilio-paste/menu';
 import {ChevronDownIcon} from '@twilio-paste/icons/esm/ChevronDownIcon';
 
 export const ContactUsMenu: React.FC<{}> = () => {
   const menu = useMenuState();
 
-  const handleClick = (): void => menu.hide();
+  const handleClick = (category: string, label: string): void => {
+    menu.hide();
+    trackCustomEvent({
+      category,
+      action: 'Click',
+      label,
+    });
+  };
+
   return (
     <>
       <MenuButton {...menu} variant="link">
         Contact us <ChevronDownIcon decorative />
       </MenuButton>
       <Menu {...menu} aria-label="Contact us">
-        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions" onClick={handleClick}>
+        <MenuItem
+          {...menu}
+          href="https://github.com/twilio-labs/paste/discussions"
+          onClick={() => handleClick('Contact Menu', 'Ask a question')}
+        >
           Ask a question
         </MenuItem>
-        <MenuItem {...menu} href="https://github.com/twilio-labs/paste/discussions" onClick={handleClick}>
+        <MenuItem
+          {...menu}
+          href="https://github.com/twilio-labs/paste/discussions"
+          onClick={() => handleClick('Contact Menu', 'Request a feature')}
+        >
           Request a feature
         </MenuItem>
         <MenuItem
           {...menu}
           href="https://github.com/twilio-labs/paste/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md&title="
-          onClick={handleClick}
+          onClick={() => handleClick('Contact Menu', 'Report a bug')}
         >
           Report a bug
         </MenuItem>

--- a/packages/paste-website/src/components/ThemeSwitcher.tsx
+++ b/packages/paste-website/src/components/ThemeSwitcher.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {styled, css} from '@twilio-paste/styling-library';
 import {useUID} from 'react-uid';
 import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
@@ -69,6 +70,13 @@ export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = () => {
             onChange={handleChange}
             type="radio"
             value={ThemeVariants.CONSOLE}
+            onClick={() =>
+              trackCustomEvent({
+                category: 'Theme Switcher',
+                action: 'Click',
+                label: 'Current',
+              })
+            }
           />
         </StyledThemeSwitcherLabel>
 
@@ -81,6 +89,13 @@ export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = () => {
             onChange={handleChange}
             type="radio"
             value={ThemeVariants.DEFAULT}
+            onClick={() =>
+              trackCustomEvent({
+                category: 'Theme Switcher',
+                action: 'Click',
+                label: 'Default',
+              })
+            }
           />
         </StyledThemeSwitcherLabel>
       </Box>

--- a/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteHeader.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {Box} from '@twilio-paste/box';
 import {Stack} from '@twilio-paste/stack';
 import {Anchor} from '@twilio-paste/anchor';
@@ -56,7 +57,16 @@ export const SiteHeader: React.FC = () => {
               />
             </Box>
             <ContactUsMenu />
-            <Anchor href="https://www.github.com/twilio-labs/paste">
+            <Anchor
+              href="https://www.github.com/twilio-labs/paste"
+              onClick={() =>
+                trackCustomEvent({
+                  category: 'Header',
+                  action: 'Click',
+                  label: 'Github Icon',
+                })
+              }
+            >
               <GithubIcon
                 css={{height: theme.heights.sizeIcon30, width: theme.heights.sizeIcon30}}
                 title="View this project on github"

--- a/packages/paste-website/src/pages/index.tsx
+++ b/packages/paste-website/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Helmet} from 'react-helmet';
+import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {
   Box,
   Heading,
@@ -47,7 +48,16 @@ const IndexPage: React.FC<{}> = (): React.ReactElement => {
               </Heading>
               <Stack orientation="vertical" spacing="space30">
                 <SiteLink to="/getting-started/engineering">Guidelines for front-end engineers</SiteLink>
-                <Anchor href="https://codesandbox.io/s/paste-starter-kit-rj7yy">
+                <Anchor
+                  href="https://codesandbox.io/s/paste-starter-kit-rj7yy"
+                  onClick={() =>
+                    trackCustomEvent({
+                      category: 'Home',
+                      action: 'Click',
+                      label: 'Check out our components in a Code Sandbox',
+                    })
+                  }
+                >
                   Check out our components in a Code Sandbox
                 </Anchor>
               </Stack>


### PR DESCRIPTION
- [x] Setup initial click tracking examples for:
  - Theme switcher
  - Contact menu items
  - Github link
  - Home page code sandbox link
- [x] Move GA plugin up to fix potential tracking issue: https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#make-sure-plugin-and-script-are-loaded-first