### PR TITLE
allow Anchor prop override

### DIFF
--- a/packages/paste-core/components/anchor/src/DefaultAnchor.tsx
+++ b/packages/paste-core/components/anchor/src/DefaultAnchor.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import {Box} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import {AnchorProps, AnchorPropTypes} from './types';
 
 const DefaultAnchor = React.forwardRef<HTMLAnchorElement, AnchorProps>((props, ref) => (
   <Box
-    {...props}
     as="a"
     color="colorTextLink"
     fontSize="inherit"
@@ -13,6 +12,7 @@ const DefaultAnchor = React.forwardRef<HTMLAnchorElement, AnchorProps>((props, r
     outline="none"
     ref={ref}
     textDecoration="underline"
+    {...safelySpreadBoxProps(props)}
     _active={{
       color: 'colorTextLinkDarker',
       textDecoration: 'none',


### PR DESCRIPTION
Note: I made this PR from the Github UI; will let the PR build and see how it turns out first

This PR allows the user to override provided props if needed. My original use-case was to add custom ~line-height~ flex styling to an Anchor, but saw that it was always being overriden by the provided props (which might be by design).

edit: I probably won't merge this in as I see that I've bypassed the commitlint hook 😅  but I hope it at least shows the intent of the change

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
