### PR TITLE
fix(modal): fix console-patch jank by removing animation on modal close

### DIFF
--- a/packages/paste-core/components/modal/src/Modal.tsx
+++ b/packages/paste-core/components/modal/src/Modal.tsx
@@ -69,17 +69,22 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   __console_patch?: boolean;
 }
 
-const AnimationStates = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getAnimationStates = (isConsole: boolean): any => ({
   from: {opacity: 0, transform: `scale(0.675)`},
   enter: {opacity: 1, transform: `scale(1)`},
-  leave: {opacity: 0, transform: `scale(0.675)`},
+  // FIXME: We remove the animation on modal close in console because
+  // react-spring v9 currently doesn't have a hook into animation destroyed
+  // Ideally it should still animate and the hack should be applied after
+  // the animation ends.
+  leave: isConsole ? null : {opacity: 0, transform: `scale(0.675)`},
   // https://www.react-spring.io/docs/hooks/api
   config: {
     mass: 0.5,
     tension: 370,
     friction: 26,
   },
-};
+});
 
 const Modal: React.FC<ModalProps> = ({
   children,
@@ -93,7 +98,7 @@ const Modal: React.FC<ModalProps> = ({
   __console_patch = false,
   ...props
 }) => {
-  const transitions = useTransition(isOpen, AnimationStates);
+  const transitions = useTransition(isOpen, getAnimationStates(__console_patch));
 
   React.useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/camelcase


### PR DESCRIPTION
The Modal component has some jittering in console because our hack to fix the paddingTop on the page body is getting removed before the modal close animation completes.

Currently react-spring v9 doesn't have a mechanism to tap into `onDestroyed` like v8 had (https://github.com/pmndrs/react-spring/issues/1114#issuecomment-675076537). To be fair, this is a pretty hacky fix on our part anyways, so this shouldn't be an issue that comes up frequently.

That said, the experience is suboptimal on Console so I've gone ahead and disabled the animation on Modal close if the patch is applied.  This removes the jank at not much visual cost, since the Modal still animates in.



