### PR TITLE
fix(combobox): correctly handle passed in values to state

### DIFF
--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -183,10 +183,10 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
         onInputValueChange,
         onIsOpenChange,
         onSelectedItemChange,
-        ...(itemToString && {itemToString}),
-        ...(initialIsOpen && {initialIsOpen}),
-        ...(inputValue && {inputValue}),
-        ...(selectedItem && {selectedItem}),
+        ...(itemToString != null && {itemToString}),
+        ...(initialIsOpen != null && {initialIsOpen}),
+        ...(inputValue != null && {inputValue}),
+        ...(selectedItem != null && {selectedItem}),
       });
 
     if (

--- a/packages/paste-libraries/dropdown/package.json
+++ b/packages/paste-libraries/dropdown/package.json
@@ -28,7 +28,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "downshift": "6.0.5"
+    "downshift": "6.0.6"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9709,10 +9709,10 @@ download@^7.1.0:
     p-event "^2.1.0"
     pify "^3.0.0"
 
-downshift@6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.0.5.tgz#a4f8b135c53d51cac232540988f401caf2a0c13a"
-  integrity sha512-GfoHu/zBuMROHipgkCE4r+bf+u+liGpeX4D+/McBODy0HBJJ4c87Ipkzv3HJOrAz1KeP7+6WszBPsTftEuY8fA==
+downshift@6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.0.6.tgz#82aee8e2e260d7ad99df8a0969bd002dd523abe8"
+  integrity sha512-tmLab3cXCn6PtZYl9V8r/nB2m+7/nCNrwo0B3kTHo/2lRBHr+1en1VNOQt2wIt0ajanAnxquZ00WPCyxe6cNFQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
     compute-scroll-into-view "^1.0.14"


### PR DESCRIPTION
Conditionally passing in controlled values didn't account for empty values. Checking for null instead will correctly pass an empty string from a piece of controlled state and not cause a switch from uncontrolled to controlled error.