### PR TITLE
fix(modal): a possibly better console_patch fix

### DIFF
--- a/packages/paste-core/components/modal/src/Modal.tsx
+++ b/packages/paste-core/components/modal/src/Modal.tsx
@@ -94,23 +94,23 @@ const Modal: React.FC<ModalProps> = ({
   initialFocusRef,
   ariaLabelledby,
   size,
-  // eslint-disable-next-line @typescript-eslint/camelcase
+  /* eslint-disable @typescript-eslint/camelcase */
   __console_patch = false,
   ...props
 }) => {
   const transitions = useTransition(isOpen, getAnimationStates(__console_patch));
 
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    if (__console_patch) {
-      if (isOpen) {
-        addConsoleHeightPatch();
-      } else {
+    if (__console_patch && isOpen) {
+      addConsoleHeightPatch();
+    }
+    return () => {
+      if (__console_patch) {
         removeConsoleHeightPatch();
       }
-    }
-    // eslint-disable-next-line @typescript-eslint/camelcase
+    };
   }, [isOpen, __console_patch]);
+  /* eslint-enable @typescript-eslint/camelcase */
 
   return (
     <ModalContext.Provider value={{onDismiss}}>

--- a/packages/paste-core/components/modal/src/utils/consoleUtils.ts
+++ b/packages/paste-core/components/modal/src/utils/consoleUtils.ts
@@ -37,9 +37,9 @@ export function removeConsoleHeightPatch(): void {
   const SIDEBAR_WRAPPER = document.querySelector('#sidebar-wrapper') as HTMLElement;
 
   if (CONTENT_WRAPPER != null) {
-    CONTENT_WRAPPER.style.marginTop = '';
+    CONTENT_WRAPPER.style.removeProperty('margin-top');
   }
   if (SIDEBAR_WRAPPER != null) {
-    SIDEBAR_WRAPPER.style.marginTop = '';
+    SIDEBAR_WRAPPER.style.removeProperty('margin-top');
   }
 }


### PR DESCRIPTION
The previous patch wasn't using the `useEffect` unmount mechanism by returning a function, instead relying on a re-render which only fired occasionally.  This hopefully addresses that to make the fix more versatile.