### PR TITLE
fix(animation-library): make sure babel is run correctly

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,8 +9,6 @@ const getPresets = isDev => [
         chrome: '67',
         safari: '11.1',
       },
-      useBuiltIns: 'usage',
-      corejs: '3.6.4',
     },
   ],
   '@babel/preset-react',
@@ -27,7 +25,12 @@ const getPresets = isDev => [
   ],
 ];
 
-const BASE_PLUGINS = ['macros', '@babel/proposal-class-properties', '@babel/proposal-object-rest-spread'];
+const BASE_PLUGINS = [
+  'macros',
+  '@babel/proposal-class-properties',
+  '@babel/proposal-object-rest-spread',
+  '@babel/plugin-transform-runtime',
+];
 
 module.exports = {
   env: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.12.0",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",

--- a/packages/paste-libraries/animation/babel.config.json
+++ b/packages/paste-libraries/animation/babel.config.json
@@ -1,0 +1,1 @@
+{"extends": "../../../babel.config.js"}

--- a/packages/paste-libraries/animation/rollup.config.js
+++ b/packages/paste-libraries/animation/rollup.config.js
@@ -27,6 +27,7 @@ export default {
       tsconfig: './tsconfig.build.json',
     }),
     babel({
+      runtimeHelpers: true,
       exclude: 'node_modules/**',
     }),
     process.env.NODE_ENV === 'production' ? terser({output: {comments: false}}) : null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,16 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
+"@babel/plugin-transform-runtime@^7.12.0":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.0.tgz#01f67ea62662e7de401af7567b6054e6a4807d65"
+  integrity sha512-BC8wiTo+0kEG8M6wuEBeuG7AIazTan02/Bh4dgi+wdDBE+p2iv5AXO8OUjrwD100223S/2WbALSqj7c290XTKg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-runtime@^7.8.3", "@babel/plugin-transform-runtime@^7.9.0":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz#3ba804438ad0d880a17bca5eaa0cdf1edeedb2fd"
@@ -3513,7 +3523,7 @@
     react-layout-effect "^1.0.1"
     use-memo-one "^1.1.0"
 
-"@react-spring/shared@9.0.0-rc.3":
+"@react-spring/shared@9.0.0-rc.3", "@react-spring/shared@^9.0.0-rc.3":
   version "9.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.0.0-rc.3.tgz#3f4c9d90accc20fef51a283a7806d78390b84161"
   integrity sha512-dd50TxwwMWd+dSB0InjndUN9w17cbnMCPy+0sag6zRxxKIo7eOyWSliOtLKxvufgmdC8Prm4M3GT5dmB1yxKEQ==


### PR DESCRIPTION
Fixes: https://github.com/twilio-labs/paste/issues/810.

Seems like the babel.config.js in our repo root isn't being picked up by our rollup-babel plugin. This fix only applies to the animation package. I plan to roll this out (and other improvements) elsewhere soon.  