### PR TITLE
fix(core-bundle): make react-uid a dependency for easier usage

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -11,8 +11,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.3",
-    "react-uid": "^2.3.0"
+    "react-scripts": "3.4.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -78,14 +78,14 @@
     "@twilio-paste/tooltip": "^0.3.11",
     "@twilio-paste/tooltip-primitive": "^0.1.6",
     "@twilio-paste/truncate": "^1.0.13",
-    "@twilio-paste/types": "^3.0.27"
+    "@twilio-paste/types": "^3.0.27",
+    "react-uid": "^2.2.0"
   },
   "peerDependencies": {
     "@twilio-paste/icons": "^3.6.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-uid": "^2.2.0"
+    "react-dom": "^16.8.6"
   },
   "devDependencies": {
     "@twilio-paste/icons": "^3.6.1"

--- a/packages/paste-core/core-bundle/tools/generate.js
+++ b/packages/paste-core/core-bundle/tools/generate.js
@@ -53,7 +53,13 @@ const {
   const packageJson = require(CORE_BUNDLE_PACKAGE_PATH);
   const newPackageJson = {
     ...packageJson,
-    dependencies: generateVersionedDependencyList(sortedPackageList),
+    /* FIXME: should just be when we wrap react-uid into @twilio-paste/uid
+     *dependencies: generateVersionedDependencyList(sortedPackageList),
+     */
+    dependencies: {
+      ...generateVersionedDependencyList(sortedPackageList),
+      'react-uid': '^2.2.0',
+    },
   };
   const newPackageJsonString = `${JSON.stringify(newPackageJson, null, 2)}\n`;
   writeToFile(CORE_BUNDLE_PACKAGE_PATH, newPackageJsonString, {


### PR DESCRIPTION
Having to install `react-uid` manually when using only `@twilio-paste/core` is not an ideal DX. I hardcode it as a dependency for now as a fast-follow to the unbarrel PR, and in the future we will wrap the implementation with our own `@twilio-paste/uid` library package which will automatically address this issue.