### PR TITLE
chore: remove redundant CI steps on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,23 +29,6 @@ jobs:
         run: yarn install
       - name: Bootstrap repository
         run: yarn bootstrap
-      - name: Build packages
-        run: yarn build
-      - name: Build package props
-        run: yarn build:props
-      - name: Run type checker
-        run: yarn type-check
-      - name: Run eslint
-        run: yarn lint
-      - name: Run tests
-        run: yarn test
-      - name: Run prettier
-        run: yarn prettier
-      - name: Run applitools eyes-storybook
-        run: yarn test:vrt
-        env:
-          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
-          GITHUB_HEAD_SHA: ${{ github.sha }}
       - name: Publish packages
         run: yarn release:stable:ci
         env:


### PR DESCRIPTION
This PR removes redundant steps that happen in the PR from the publish that happens on merge to Main branch