### PR TITLE
feat(codemods): add barreled-to-unbarreled codemod

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ rollup.config.js
 **/tsconfig.build.tsbuildinfo
 **/*.d.ts
 /packages/paste-website/public/
+__testfixtures__/

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ package-lock.json
 tools/.cache/packages.json
 docs
 
+# codemods package
+package/paste-codemods/tools/mappings.json
+
 # Cypress
 cypress/videos
 cypress/screenshots

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ __IconList.tsx
 rollup.icon-list.js
 *.d.ts
 .yarn/
+__testfixtures__

--- a/packages/paste-codemods/README.md
+++ b/packages/paste-codemods/README.md
@@ -1,0 +1,3 @@
+## Docs
+
+Please see the [Paste docs for Codemods](https://paste.twilio.design/libraries/codemods)

--- a/packages/paste-codemods/__tests__/tools.spec.tsx
+++ b/packages/paste-codemods/__tests__/tools.spec.tsx
@@ -1,0 +1,63 @@
+const {generatePackageExportsMap} = require('../tools/generatePackageExportsMap');
+
+// This is a simplified mock of paste packages
+// eslint-disable-next-line  @typescript-eslint/array-type
+const mockGetPastePackages = (): Array<{}> => [
+  {
+    name: '@twilio-paste/stack',
+    version: '0.1.49',
+    private: false,
+    location: '/Users/sisber/twilio/dsys/paste/packages/paste-core/layout/stack',
+  },
+  {
+    name: '@twilio-paste/box',
+    version: '2.11.6',
+    private: false,
+    location: '/Users/sisber/twilio/dsys/paste/packages/paste-core/primitives/box',
+  },
+  {
+    name: '@twilio-paste/combobox-primitive',
+    version: '0.1.9',
+    private: false,
+    location: '/Users/sisber/twilio/dsys/paste/packages/paste-core/primitives/combobox',
+  },
+  {
+    name: '@twilio-paste/disclosure-primitive',
+    version: '0.2.6',
+    private: false,
+    location: '/Users/sisber/twilio/dsys/paste/packages/paste-core/primitives/disclosure',
+  },
+];
+
+describe('generatePackageExportsMap', () => {
+  it('Creates mapping file successfully from mock', async () => {
+    const mockMapping = await generatePackageExportsMap(mockGetPastePackages);
+
+    expect(mockMapping).toEqual({
+      BOX_PROPS_TO_BLOCK: '@twilio-paste/core/box',
+      Box: '@twilio-paste/core/box',
+      ComboboxPrimitive: '@twilio-paste/core/combobox-primitive',
+      DisclosurePrimitive: '@twilio-paste/core/disclosure-primitive',
+      DisclosurePrimitiveContent: '@twilio-paste/core/disclosure-primitive',
+      Stack: '@twilio-paste/core/stack',
+      getStackChildMargins: '@twilio-paste/core/stack',
+      getStackDisplay: '@twilio-paste/core/stack',
+      getStackStyles: '@twilio-paste/core/stack',
+      safelySpreadBoxProps: '@twilio-paste/core/box',
+      useComboboxPrimitive: '@twilio-paste/core/combobox-primitive',
+      useDisclosurePrimitiveState: '@twilio-paste/core/disclosure-primitive',
+    });
+  });
+
+  /* Not useful, but leaving for documentation purposes
+  // This is the local cache of the last run of getPastePackages, which we also mock as `mockGetPastePackages`
+  // const pastePackagesFromCache = require('../../../tools/.cache/packages.json');
+  // This is the local cache of the last run of generateExportsMap
+  // const mappingsFromCache = require('../tools/mappings.json');
+
+  it('Creates mapping file successfully from cache', async () => {
+    const generatedMappings = await generatePackageExportsMap(() => pastePackagesFromCache);
+    expect(generatedMappings).toEqual(mappingsFromCache);
+  });
+  */
+});

--- a/packages/paste-codemods/bin/cli.js
+++ b/packages/paste-codemods/bin/cli.js
@@ -1,0 +1,209 @@
+// Heavy copy paste from https://github.com/reactjs/react-codemod/blob/master/bin/cli.js
+
+const globby = require('globby');
+const inquirer = require('inquirer');
+const meow = require('meow');
+const path = require('path');
+const execa = require('execa');
+const chalk = require('chalk');
+const isGitClean = require('is-git-clean');
+
+const transformerDirectory = path.join(__dirname, '../', 'transforms');
+const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
+
+function checkGitStatus(force) {
+  let clean = false;
+  let errorMessage = 'Unable to determine if git directory is clean';
+  try {
+    clean = isGitClean.sync(process.cwd());
+    errorMessage = 'Git directory is not clean';
+  } catch (err) {
+    if (err && err.stderr && err.stderr.indexOf('Not a git repository') >= 0) {
+      clean = true;
+    }
+  }
+
+  if (!clean) {
+    if (force) {
+      console.log(`WARNING: ${errorMessage}. Forcibly continuing.`);
+    } else {
+      console.log('Thank you for using @twilio-paste/codemods!');
+      console.log(chalk.yellow('\nBut before we continue, please stash or commit your git changes.'));
+      console.log('\nYou may use the --force flag to override this safety check.');
+      process.exit(1);
+    }
+  }
+}
+
+function runTransform({files, flags, parser, transformer}) {
+  const transformerPath = path.join(transformerDirectory, `${transformer}.js`);
+
+  let args = [];
+
+  const {dry, print, explicitRequire} = flags;
+
+  if (dry) {
+    args.push('--dry');
+  }
+  if (print) {
+    args.push('--print');
+  }
+
+  if (explicitRequire === 'true') {
+    args.push('--explicit-require=true');
+  }
+
+  args.push('--verbose=2');
+
+  args.push('--ignore-pattern=**/node_modules/**');
+
+  args.push('--parser', parser);
+
+  if (parser === 'tsx') {
+    args.push('--extensions=tsx,ts,jsx,js');
+  } else {
+    args.push('--extensions=jsx,js');
+  }
+
+  args = args.concat(['--transform', transformerPath]);
+
+  if (flags.jscodeshift) {
+    args = args.concat(flags.jscodeshift);
+  }
+
+  args = args.concat(files);
+
+  console.log(`Executing command: jscodeshift ${args.join(' ')}`);
+
+  const result = execa.sync(jscodeshiftExecutable, args, {
+    stdio: 'inherit',
+    stripEof: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+}
+
+const TRANSFORMER_INQUIRER_CHOICES = [
+  {
+    name: 'barreled-to-unbarreled: Converts barreled core imports to unbarreled imports.',
+    value: 'barreled-to-unbarreled',
+  },
+];
+
+const PARSER_INQUIRER_CHOICES = [
+  {
+    name: 'JavaScript',
+    value: 'babel',
+  },
+  {
+    name: 'TypeScript',
+    value: 'tsx',
+  },
+];
+
+function expandFilePathsIfNeeded(filesBeforeExpansion) {
+  const shouldExpandFiles = filesBeforeExpansion.some(file => file.includes('*'));
+  return shouldExpandFiles ? globby.sync(filesBeforeExpansion) : filesBeforeExpansion;
+}
+
+function run() {
+  const cli = meow(
+    {
+      description: 'Codemods for updating Paste projects.',
+      help: `
+    Usage
+      $ npx paste-codemod <transform> <path> <...options>
+
+        transform    One of the choices from https://github.com/twilio-labs/paste/tree/main/packages/paste-codemods
+        path         Files or directory to transform. Can be a glob like src/**.test.js
+
+    Options
+      --force            Bypass Git safety checks and forcibly run codemods
+      --dry              Dry run (no changes are made to files)
+      --print            Print transformed files to your terminal
+      --explicit-require Transform only if React is imported in the file (default: false)
+
+      --jscodeshift  (Advanced) Pass options directly to jscodeshift
+    `,
+    },
+    {
+      boolean: ['force', 'dry', 'print', 'explicit-require', 'help'],
+      string: ['_'],
+      alias: {
+        h: 'help',
+      },
+    }
+  );
+
+  if (!cli.flags.dry) {
+    checkGitStatus(cli.flags.force);
+  }
+
+  if (cli.input[0] && !TRANSFORMER_INQUIRER_CHOICES.find(x => x.value === cli.input[0])) {
+    console.error('Invalid transform choice, pick one of:');
+    console.error(TRANSFORMER_INQUIRER_CHOICES.map(x => '- ' + x.value).join('\n'));
+    process.exit(1);
+  }
+
+  inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'files',
+        message: 'On which files or directory should the codemods be applied?',
+        when: !cli.input[1],
+        default: '.',
+        // validate: () =>
+        filter: files => files.trim(),
+      },
+      {
+        type: 'list',
+        name: 'parser',
+        message: 'Which dialect of JavaScript do you use?',
+        default: 'tsx',
+        when: !cli.flags.parser,
+        pageSize: PARSER_INQUIRER_CHOICES.length,
+        choices: PARSER_INQUIRER_CHOICES,
+      },
+      {
+        type: 'list',
+        name: 'transformer',
+        message: 'Which transform would you like to apply?',
+        when: !cli.input[0],
+        pageSize: TRANSFORMER_INQUIRER_CHOICES.length,
+        choices: TRANSFORMER_INQUIRER_CHOICES,
+      },
+    ])
+    .then(answers => {
+      const {files, transformer, parser} = answers;
+
+      const filesBeforeExpansion = cli.input[1] || files;
+      const filesExpanded = expandFilePathsIfNeeded([filesBeforeExpansion]);
+
+      const selectedTransformer = cli.input[0] || transformer;
+      const selectedParser = cli.flags.parser || parser;
+
+      if (!filesExpanded.length) {
+        console.log(`No files found matching ${filesBeforeExpansion.join(' ')}`);
+        return null;
+      }
+
+      return runTransform({
+        files: filesExpanded,
+        flags: cli.flags,
+        parser: selectedParser,
+        transformer: selectedTransformer,
+        answers: answers,
+      });
+    });
+}
+
+module.exports = {
+  run: run,
+  runTransform: runTransform,
+  checkGitStatus: checkGitStatus,
+  jscodeshiftExecutable: jscodeshiftExecutable,
+  transformerDirectory: transformerDirectory,
+};

--- a/packages/paste-codemods/bin/paste-codemod.js
+++ b/packages/paste-codemods/bin/paste-codemod.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+// paste-codemod name-of-transform path [...options]
+
+require('./cli').run();

--- a/packages/paste-codemods/package.json
+++ b/packages/paste-codemods/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@twilio-paste/codemods",
+  "version": "0.0.1",
+  "status": "beta",
+  "description": "A collection of codemods for maintaining projects built with Paste.",
+  "author": "Twilio Inc.",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": "./bin/paste-codemod.js",
+  "scripts": {
+    "build": "node ./tools/create-package-mappings.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "chalk": "^2.4.2",
+    "execa": "^3.2.0",
+    "globby": "^10.0.1",
+    "inquirer": "^7.0.0",
+    "is-git-clean": "^1.1.0",
+    "jscodeshift": "^0.11.0",
+    "meow": "^5.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.11.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+    "@babel/preset-env": "^7.8.4",
+    "@twilio-paste/core": "*"
+  }
+}

--- a/packages/paste-codemods/tools/create-package-mappings.js
+++ b/packages/paste-codemods/tools/create-package-mappings.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const {writeToFile} = require('../../../tools/utils/writeToFile');
+const {generatePackageExportsMap} = require('./generatePackageExportsMap');
+
+(async () => {
+  const mapping = await generatePackageExportsMap();
+
+  // Write to disk
+  writeToFile(path.join(__dirname, 'mappings.json'), mapping, {
+    successMessage: 'Wrote core packages export mapping to mappings.json file!',
+    errorMessage: 'Could not generate mappings!',
+    formatJson: true,
+  });
+})();

--- a/packages/paste-codemods/tools/generatePackageExportsMap.js
+++ b/packages/paste-codemods/tools/generatePackageExportsMap.js
@@ -1,0 +1,37 @@
+const {getRepoPackages} = require('../../../tools/utils/getRepoPackages');
+
+const DEPRECATED_PACKAGES = ['@twilio-paste/typography', '@twilio-paste/form'];
+
+async function generatePackageExportsMap(getPackages = getRepoPackages) {
+  // Object to store all the generated mappings for our codemod
+  const mapping = {};
+
+  // Get all Paste packages
+  const allPastePackages = await getPackages();
+
+  // For each package in Paste:
+  allPastePackages.forEach(({name, location}) => {
+    // We don't want to use the 'form' or 'typography' packages because they are deprecated
+    // Skip them for now
+    if (DEPRECATED_PACKAGES.includes(name)) return;
+
+    // Only include core packages but not the core-bundle package
+    if (!location.includes('/paste-core/') || location.includes('/paste-core/core-bundle')) return;
+
+    // convert package name to core name
+    const corePackageName = `@twilio-paste/core/${name.split('/')[1]}`;
+
+    // Get the package's exported values to be mapped
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const packageExports = require(name);
+
+    // Now we create a mapping for every export to the core-bundle unbarreled package
+    Object.keys(packageExports).forEach(packageExportName => {
+      mapping[packageExportName] = corePackageName;
+    });
+  });
+
+  return mapping;
+}
+
+module.exports = {generatePackageExportsMap};

--- a/packages/paste-codemods/transforms/__testfixtures__/barreled-to-unbarreled.input.ts
+++ b/packages/paste-codemods/transforms/__testfixtures__/barreled-to-unbarreled.input.ts
@@ -1,0 +1,6 @@
+import {Button, Label, MediaObject, TBodyPropTypes} from '@twilio-paste/core';
+import {Table} from '@twilio-paste/core';
+import {Button as Stuffin} from '@twilio-paste/core';
+import {Button as Stuff} from '@sendgrid/ui-components';
+import {Input} from '@twilio-paste/core';
+import {Card} from '@twilio-paste/core/dist/card';

--- a/packages/paste-codemods/transforms/__testfixtures__/barreled-to-unbarreled.output.ts
+++ b/packages/paste-codemods/transforms/__testfixtures__/barreled-to-unbarreled.output.ts
@@ -1,0 +1,7 @@
+import { TBodyPropTypes, Table } from '@twilio-paste/core/table';
+import { MediaObject } from '@twilio-paste/core/media-object';
+import { Label } from '@twilio-paste/core/label';
+import { Button, Button as Stuffin } from '@twilio-paste/core/button';
+import {Button as Stuff} from '@sendgrid/ui-components';
+import {Card} from '@twilio-paste/core/dist/card';
+import { Input } from '@twilio-paste/core/input';

--- a/packages/paste-codemods/transforms/__tests__/barreled-to-unbarreled.spec.tsx
+++ b/packages/paste-codemods/transforms/__tests__/barreled-to-unbarreled.spec.tsx
@@ -1,0 +1,3 @@
+const {defineTest} = require('jscodeshift/dist/testUtils');
+
+defineTest(__dirname, 'barreled-to-unbarreled', null, 'barreled-to-unbarreled', {parser: 'ts'});

--- a/packages/paste-codemods/transforms/barreled-to-unbarreled.js
+++ b/packages/paste-codemods/transforms/barreled-to-unbarreled.js
@@ -1,0 +1,57 @@
+const ComponentLookup = require('../tools/mappings.json');
+
+module.exports = function barreledToUnbarreled(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const printOptions = options.printOptions || {quote: 'single', tabWidth: 2, trailingComma: true};
+  const root = j(fileInfo.source);
+  const importLookups = {};
+
+  const update = path => {
+    const importSource = path.value.source.value;
+
+    // If it isn't exactly from the package (i.e.: core/esm or core/dist etc) then skip it.
+    if (importSource !== '@twilio-paste/core') {
+      return;
+    }
+
+    const untransformedSpecifiers = [];
+    const transformedSpecifiers = [];
+
+    path.value.specifiers.forEach(s => {
+      if (ComponentLookup[s.imported.name]) {
+        transformedSpecifiers.push(s);
+      } else {
+        untransformedSpecifiers.push(s);
+      }
+    });
+
+    if (untransformedSpecifiers.length === 0) {
+      path.prune();
+    } else {
+      path.value.specifiers = untransformedSpecifiers;
+    }
+
+    transformedSpecifiers.forEach(s => {
+      // This may need to check the value but the original lookup should provide that
+      const properImport = ComponentLookup[s.imported.name];
+
+      const lookedUpImport = importLookups[properImport];
+
+      // Check if this exact import has been used previously. If it has push the specifier
+      // into the import instead of generating a new one
+      if (lookedUpImport) {
+        lookedUpImport.specifiers.push(s);
+      } else {
+        const newImport = j.importDeclaration([s], j.literal(properImport));
+
+        importLookups[properImport] = newImport;
+        j(path).insertAfter(newImport);
+      }
+    });
+  };
+
+  return root
+    .find(j.ImportDeclaration)
+    .forEach(update)
+    .toSource(printOptions);
+};

--- a/packages/paste-core/core-bundle/tools/constants.js
+++ b/packages/paste-core/core-bundle/tools/constants.js
@@ -8,6 +8,7 @@ const BLOCKLIST = [
   '@twilio-paste/icons',
   '@twilio-paste/website',
   '@twilio-paste/form',
+  '@twilio-paste/codemods',
 ];
 
 const CORE_BUNDLE_PATH = join(__dirname, '../');

--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
@@ -431,6 +431,11 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
                   UID
                 </SidebarAnchor>
               </SidebarNestedItem>
+              <SidebarNestedItem>
+                <SidebarAnchor nested to={`${SidebarCategoryRoutes.LIBRARIES}/codemods`}>
+                  Codemods
+                </SidebarAnchor>
+              </SidebarNestedItem>
             </SidebarNestedList>
           </DisclosurePrimitiveContent>
         </SidebarItem>

--- a/packages/paste-website/src/pages/libraries/codemods/index.mdx
+++ b/packages/paste-website/src/pages/libraries/codemods/index.mdx
@@ -1,0 +1,112 @@
+---
+title: Codemods
+description: A collection of jscodeshift codemods to help update projects built with Paste.
+slug: /libraries/codemods/
+---
+
+import {graphql} from 'gatsby';
+import {SidebarCategoryRoutes} from '../../../constants';
+import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
+
+export const pageQuery = graphql`
+  {
+    allPasteLibraries(filter: {name: {eq: "@twilio-paste/codemods"}}) {
+      edges {
+        node {
+          name
+          description
+          status
+          version
+        }
+      }
+    }
+    mdx(fields: {slug: {eq: "/libraries/codemods/"}}) {
+      fileAbsolutePath
+      frontmatter {
+        slug
+        title
+      }
+      headings {
+        depth
+        value
+      }
+    }
+  }
+`;
+
+<ComponentHeader
+  name="Codemods"
+  categoryRoute={SidebarCategoryRoutes.LIBRARIES}
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-codemods"
+  data={props.data.allPasteLibraries.edges}
+/>
+
+---
+
+<contentwrapper>
+<PageAside data={props.data.mdx} />
+<content>
+
+## About
+
+[Codemods](https://github.com/facebook/codemod#background) are a collection of scripts that
+update your codebase from old patterns to new patterns automatically. In this way
+we can effectively move APIs and patterns to newer versions without incurring
+tech debt across the Twilio organization.
+
+A notable user of this approach is the [React team](https://github.com/reactjs/react-codemod).
+They provide similar automation to downstream users when they introduce breaking changes
+in React, which helps to alleviate the pain points and provide a path forward.
+
+We hope these codemods make your experience using and maintaining the latest version
+of Paste easy and enjoyable.
+
+## Usage
+
+```
+npx @twilio-paste/codemods [...options]
+```
+
+Options:
+
+- `--dry` for a dry-run (doesn't change the files, just reports the status)
+- `--print` to print the output for comparison
+
+This will start an interactive wizard, and then run the specified transform.
+
+### Included Transforms
+
+#### barreled-to-unbarreled
+
+Converts old-style core imports to the new unbarreled style. (i.e.: `import {Button} from '@twilio-paste/core'` becomes `import {Button} from '@twilio-paste/core/button'`)
+
+```sh
+npx @twilio-paste/codemods barreled-to-unbarreled <path>
+```
+
+### jscodeshift options
+
+To pass more options directly to jscodeshift, use `--jscodeshift="..."`. For example:
+
+```sh
+npx @twilio-paste/codemods --jscodeshift="--run-in-band --verbose=2"
+```
+
+See [all available jscodeshift options](https://github.com/facebook/jscodeshift#usage-cli).
+
+### Recast Options
+
+Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
+through jscodeshift's `printOptions` command line argument
+
+```sh
+npx @twilio-paste/codemods <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
+```
+
+## Acknowledgements
+
+This project is heavily inspired from [react-codemods](https://github.com/reactjs/react-codemod).
+
+</content>
+
+</contentwrapper>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,5 +51,5 @@
     },
     "typeRoots": ["./@types", "node_modules/@types"]
   },
-  "exclude": ["node_modules", "docs", "dist"]
+  "exclude": ["node_modules", "docs", "dist", "__testfixtures__"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,6 +242,28 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.1.6":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
+  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.1"
+    "@babel/parser" "^7.12.3"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/core@^7.11.4":
   version "7.11.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
@@ -279,6 +301,15 @@
   integrity sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==
   dependencies:
     "@babel/types" "^7.11.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.1", "@babel/generator@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
+  integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
+  dependencies:
+    "@babel/types" "^7.12.5"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -334,6 +365,17 @@
     invariant "^2.2.4"
     levenary "^1.1.1"
     semver "^5.5.0"
+
+"@babel/helper-create-class-features-plugin@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz#3c45998f431edd4a9214c5f1d3ad1448a6137f6e"
+  integrity sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
+  dependencies:
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.10.4"
 
 "@babel/helper-create-class-features-plugin@^7.8.3", "@babel/helper-create-class-features-plugin@^7.9.6":
   version "7.9.6"
@@ -419,6 +461,13 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
+"@babel/helper-member-expression-to-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
+  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
 "@babel/helper-member-expression-to-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
@@ -440,6 +489,13 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
+"@babel/helper-module-imports@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359"
@@ -451,6 +507,21 @@
     "@babel/helper-split-export-declaration" "^7.11.0"
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.11.0"
+    lodash "^4.17.19"
+
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
     lodash "^4.17.19"
 
 "@babel/helper-module-transforms@^7.9.0":
@@ -518,6 +589,16 @@
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz#f009a17543bbbbce16b06206ae73b63d3fca68d9"
+  integrity sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-replace-supers@^7.8.3", "@babel/helper-replace-supers@^7.8.6", "@babel/helper-replace-supers@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz#03149d7e6a5586ab6764996cd31d6981a17e1444"
@@ -536,6 +617,13 @@
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helper-simple-access@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
 "@babel/helper-simple-access@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
@@ -544,7 +632,14 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-split-export-declaration@^7.11.0":
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
+  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
+"@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
   integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
@@ -587,6 +682,15 @@
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helpers@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.5.tgz#1a1ba4a768d9b58310eda516c449913fe647116e"
+  integrity sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
+
 "@babel/helpers@^7.9.0", "@babel/helpers@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.6.tgz#092c774743471d0bb6c7de3ad465ab3d3486d580"
@@ -619,6 +723,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
+"@babel/parser@^7.1.6", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
+  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
 "@babel/parser@^7.10.4", "@babel/parser@^7.11.0":
   version "7.11.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.4.tgz#6fa1a118b8b0d80d0267b719213dc947e88cc0ca"
@@ -645,6 +754,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
+  integrity sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-proposal-decorators@7.8.3":
   version "7.8.3"
@@ -677,6 +794,14 @@
   integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.1.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
+  integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
 "@babel/plugin-proposal-numeric-separator@7.8.3", "@babel/plugin-proposal-numeric-separator@^7.8.3":
@@ -719,6 +844,15 @@
   integrity sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.1.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz#cce122203fc8a32794296fc377c6dedaf4363797"
+  integrity sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.4.4", "@babel/plugin-proposal-unicode-property-regex@^7.8.3":
@@ -840,6 +974,13 @@
   integrity sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-syntax-typescript@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz#460ba9d77077653803c3dd2e673f76d66b4029e5"
+  integrity sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-syntax-typescript@^7.8.3":
   version "7.8.3"
@@ -974,6 +1115,16 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.1.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz#fa403124542636c786cf9b460a0ffbb48a86e648"
+  integrity sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-simple-access" "^7.12.1"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-commonjs@^7.9.0", "@babel/plugin-transform-modules-commonjs@^7.9.6":
@@ -1170,6 +1321,15 @@
   integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-typescript@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz#d92cc0af504d510e26a754a7dbc2e5c8cd9c7ab4"
+  integrity sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-typescript" "^7.12.1"
 
 "@babel/plugin-transform-typescript@^7.9.0":
   version "7.9.6"
@@ -1379,6 +1539,25 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
+"@babel/preset-typescript@^7.1.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz#86480b483bb97f75036e8864fe404cc782cc311b"
+  integrity sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-transform-typescript" "^7.12.1"
+
+"@babel/register@^7.0.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.12.1.tgz#cdb087bdfc4f7241c03231f22e15d211acf21438"
+  integrity sha512-XWcmseMIncOjoydKZnWvWi0/5CUCD+ZYKhRwgYlWOrA8fGZ/FjuLRpqtIhLOVD/fvR1b9DQHtZPn68VvhpYf+Q==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/register@^7.8.3":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.9.0.tgz#02464ede57548bddbb5e9f705d263b7c3f43d48b"
@@ -1502,6 +1681,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
+  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.5"
+    "@babel/types" "^7.12.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
@@ -1524,6 +1718,15 @@
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.1", "@babel/types@^7.12.5":
+  version "7.12.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
+  integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -6149,6 +6352,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
+  integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+
 array-differ@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
@@ -6318,7 +6526,7 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
@@ -6376,6 +6584,13 @@ ast-types@0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.3.tgz#c20757fe72ee71278ea0ff3d87e5c2ca30d9edf8"
   integrity sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==
+
+ast-types@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
 
 ast-types@0.9.6:
   version "0.9.6"
@@ -6562,7 +6777,7 @@ babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0:
+babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
@@ -9179,6 +9394,14 @@ cross-fetch@2.2.2:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
 
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  integrity sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
+
 cross-spawn@5.1.0, cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -11439,6 +11662,18 @@ execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
+  integrity sha1-TrZGejaglfq7KXD/nV4/t7zm68M=
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    is-stream "^1.1.0"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -12178,6 +12413,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flow-parser@0.*:
+  version "0.137.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.137.0.tgz#8c05612ff9344648d8bcdeaa4c58d131e875d842"
+  integrity sha512-i3KXJZ8lhlQI0n+BoZzIeH/rv+fNvAiu1i9/s64MklBV+HuhFbycUML7367J2eng0gapLnwvYPFNaPZys8POsA==
 
 fluids@^0.1.6:
   version "0.1.8"
@@ -15272,6 +15512,15 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-git-clean@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-git-clean/-/is-git-clean-1.1.0.tgz#13abd6dda711bb08aafd42604da487845ddcf88d"
+  integrity sha1-E6vW3acRuwiq/UJgTaSHhF3c+I0=
+  dependencies:
+    execa "^0.4.0"
+    is-obj "^1.0.1"
+    multimatch "^2.1.0"
+
 is-glob@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -15406,7 +15655,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -16638,6 +16887,31 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jscodeshift@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.11.0.tgz#4f95039408f3f06b0e39bb4d53bc3139f5330e2f"
+  integrity sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.1.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.1.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.1.0"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.2.4"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.20.3"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
 jsdom@16.2.2:
   version "16.2.2"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.2.2.tgz#76f2f7541646beb46a938f5dc476b88705bedf2b"
@@ -17697,7 +17971,7 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -18542,6 +18816,16 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+multimatch@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  integrity sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
+
 multimatch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-3.0.0.tgz#0e2534cc6bc238d9ab67e1b9cd5fcd85a6dbf70b"
@@ -18696,7 +18980,7 @@ node-ask@^1.0.1:
   resolved "https://registry.yarnpkg.com/node-ask/-/node-ask-1.0.1.tgz#caaa1076cc58e0364267a0903e3eadfac158396b"
   integrity sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=
 
-node-dir@^0.1.10:
+node-dir@^0.1.10, node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
@@ -19026,6 +19310,13 @@ npm-pick-manifest@^3.0.0:
     figgy-pudding "^3.5.1"
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
+
+npm-run-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+  integrity sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=
+  dependencies:
+    path-key "^1.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -19938,6 +20229,11 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
+  integrity sha1-XVPVeAGWRsDWiADbThRua9wqx68=
 
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
@@ -21868,6 +22164,16 @@ recast@^0.14.7:
     private "~0.1.5"
     source-map "~0.6.1"
 
+recast@^0.20.3:
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.20.4.tgz#db55983eac70c46b3fff96c8e467d65ffb4a7abc"
+  integrity sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==
+  dependencies:
+    ast-types "0.14.2"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tslib "^2.0.1"
+
 recast@~0.11.12:
   version "0.11.23"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
@@ -22539,7 +22845,7 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.
   dependencies:
     glob "^7.1.3"
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -24563,6 +24869,13 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
+temp@^0.8.1:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.4.tgz#8c97a33a4770072e0a05f919396c7665a7dd59f2"
+  integrity sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==
+  dependencies:
+    rimraf "~2.6.2"
+
 tempfile@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-2.0.0.tgz#6b0446856a9b1114d1856ffcbe509cccb0977265"
@@ -25065,6 +25378,11 @@ tslib@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tslib@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils@^3.17.1, tsutils@^3.7.0:
   version "3.17.1"
@@ -26413,7 +26731,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@1, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
## What changed (non-technical)

We have added a system to allow downstream teams to run automatic code updates, called "codemods". Learn more about them here https://github.com/facebook/codemod#background

## What changed (technical)

This PR creates a new `paste-codemods` folder in our monorepo that publishes the `@twilio-paste/codemods` package.

The package is structured to contain multiple "transforms", which are jscodeshift functions we can write to transform code.  The first and only transform included is the `barreled-to-unbarreled` transform, which converts imports from paste-core to the new unbarreled style (`@twilio-paste/core/button`).

The package also includes a `bin` field in the package json which points to a CLI nodejs script to make running this package easy and ergonomic for folks. This is heavily inspired (read: copied) from the [react-codemods](https://github.com/reactjs/react-codemod) repo.


## How to test it

I've published the code as the `@next` version, you can run it locally to watch it in action with:
```shell
npx @twilio-paste/codemods
```

We currently only have one codemod, generously contributed by @GiantRobots 