### PR TITLE
chore(website): anonymize data sent to GA and respect DNT

### DIFF
--- a/packages/paste-website/gatsby-config.js
+++ b/packages/paste-website/gatsby-config.js
@@ -19,6 +19,10 @@ const gatsbyConfig = {
       resolve: 'gatsby-plugin-google-analytics',
       options: {
         trackingId: 'UA-145457417-1',
+        // Anonymizes data sent to google
+        anonymize: true,
+        // Respects browser do not track (why isn't this default lol)
+        respectDNT: true,
       },
     },
     `gatsby-plugin-typescript`,


### PR DESCRIPTION
Anonymizes data sent to Google analytics and doesn't load it at all if browser has the Do Not Track flag on.
https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#anonymize