### PR TITLE
docs(website): add uid-library docs

### DIFF
--- a/packages/paste-website/gatsby-config.js
+++ b/packages/paste-website/gatsby-config.js
@@ -57,7 +57,7 @@ const gatsbyConfig = {
       options: {
         name: 'pages',
         path: `${__dirname}/src/pages`,
-        ignore: ['**/components/**/*', '**/primitives/**/*', '**/layout/**/*'],
+        ignore: ['**/components/**/*', '**/primitives/**/*', '**/layout/**/*', '**/libraries/**/*'],
       },
     },
     {
@@ -79,6 +79,13 @@ const gatsbyConfig = {
       options: {
         name: 'layout',
         path: `${__dirname}/src/pages/layout`,
+      },
+    },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'libraries',
+        path: `${__dirname}/src/pages/libraries`,
       },
     },
     {
@@ -139,6 +146,10 @@ const gatsbyConfig = {
 
           if (node.relativePath.startsWith('paste-core/layout') && node.relativePath.endsWith('package.json')) {
             return 'PasteLayout';
+          }
+
+          if (node.relativePath.startsWith('paste-libraries') && node.relativePath.endsWith('package.json')) {
+            return 'PasteLibraries';
           }
 
           if (node.relativePath.startsWith('paste-theme') && node.relativePath.endsWith('package.json')) {

--- a/packages/paste-website/gatsby-config.js
+++ b/packages/paste-website/gatsby-config.js
@@ -31,8 +31,10 @@ const gatsbyConfig = {
     {
       resolve: 'gatsby-source-filesystem',
       options: {
+        // grab stuff in packages for indexing like changelogs, package.json, design token compiled files
         name: 'packages',
         path: `${__dirname}/../../packages/`,
+        // but ignore all the build artifacts that we don't need so we don't fill graphql with a bunch of random stuff
         ignore: [
           '**/.*',
           '**/.cache/**',
@@ -42,6 +44,12 @@ const gatsbyConfig = {
           '**/__tests__/**',
           '**/paste-website/**/*',
           '**/README.md',
+          '**/*.js',
+          '**/*.ts',
+          '**/*.tsx',
+          '**/*.d.ts.map',
+          '**/*.build.json',
+          '**/tsconfig.json',
         ],
       },
     },
@@ -57,35 +65,6 @@ const gatsbyConfig = {
       options: {
         name: 'pages',
         path: `${__dirname}/src/pages`,
-        ignore: ['**/components/**/*', '**/primitives/**/*', '**/layout/**/*', '**/libraries/**/*'],
-      },
-    },
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        name: 'components',
-        path: `${__dirname}/src/pages/components`,
-      },
-    },
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        name: 'primitives',
-        path: `${__dirname}/src/pages/primitives`,
-      },
-    },
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        name: 'layout',
-        path: `${__dirname}/src/pages/layout`,
-      },
-    },
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        name: 'libraries',
-        path: `${__dirname}/src/pages/libraries`,
       },
     },
     {

--- a/packages/paste-website/src/components/shortcodes/component-header/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/component-header/index.tsx
@@ -18,6 +18,8 @@ const getCategoryNameFromRoute = (categoryRoute: string): string => {
       return 'Layout';
     case SidebarCategoryRoutes.TOKENS:
       return 'Tokens';
+    case SidebarCategoryRoutes.LIBRARIES:
+      return 'Libraries';
     default:
       return 'Layout';
   }

--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarAnchor.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarAnchor.tsx
@@ -8,7 +8,7 @@ interface SidebarAnchorProps {
   to: string;
 }
 
-const StyledSidbarAnchor = styled(Link)<SidebarAnchorProps>`
+const StyledSidebarAnchor = styled(Link)<SidebarAnchorProps>`
   position: relative;
   display: block;
   width: 100%;
@@ -39,9 +39,9 @@ const StyledSidbarAnchor = styled(Link)<SidebarAnchorProps>`
 `;
 
 const SidebarAnchor: React.FC<SidebarAnchorProps> = ({children, nested, to}) => (
-  <StyledSidbarAnchor nested={nested} to={to}>
+  <StyledSidebarAnchor nested={nested} to={to}>
     {children}
-  </StyledSidbarAnchor>
+  </StyledSidebarAnchor>
 );
 
 export {SidebarAnchor};

--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarNavigation.tsx
@@ -125,6 +125,10 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
     visible: getCurrentPathname().startsWith(SidebarCategoryRoutes.CONTENT),
   });
 
+  const librariesDisclosure = useDisclosurePrimitiveState({
+    visible: getCurrentPathname().startsWith(SidebarCategoryRoutes.LIBRARIES),
+  });
+
   const tokensDisclosure = useDisclosurePrimitiveState({
     visible: getCurrentPathname().startsWith(SidebarCategoryRoutes.TOKENS),
   });
@@ -349,7 +353,23 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = () => {
           </DisclosurePrimitiveContent>
         </SidebarItem>
         <SidebarItem>
-          <SidebarAnchor to="/libraries">Libraries</SidebarAnchor>
+          <DisclosurePrimitive as={SidebarDisclosureButton} {...librariesDisclosure} data-cy="libraries-button">
+            Libraries
+          </DisclosurePrimitive>
+          <DisclosurePrimitiveContent {...librariesDisclosure}>
+            <SidebarNestedList>
+              <SidebarNestedItem>
+                <SidebarAnchor nested to={SidebarCategoryRoutes.LIBRARIES}>
+                  Overview
+                </SidebarAnchor>
+              </SidebarNestedItem>
+              <SidebarNestedItem>
+                <SidebarAnchor nested to={`${SidebarCategoryRoutes.LIBRARIES}/uid-library`}>
+                  UID
+                </SidebarAnchor>
+              </SidebarNestedItem>
+            </SidebarNestedList>
+          </DisclosurePrimitiveContent>
         </SidebarItem>
         <SidebarItem>
           <SidebarAnchor to="/roadmap">Roadmap</SidebarAnchor>

--- a/packages/paste-website/src/constants.ts
+++ b/packages/paste-website/src/constants.ts
@@ -15,6 +15,7 @@ export const SidebarCategoryRoutes = {
   LAYOUT: '/layout',
   ICON_SYSTEM: '/icons',
   CONTENT: '/content',
+  LIBRARIES: '/libraries',
   GETTING_STARTED: '/getting-started',
   TOKENS: '/tokens',
 };

--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -34,7 +34,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/alert/"}}) {
+    mdx(fields: {slug: {eq: "/components/alert/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/anchor/"}}) {
+    mdx(fields: {slug: {eq: "/components/anchor/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -27,7 +27,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/avatar/"}}) {
+    mdx(fields: {slug: {eq: "/components/avatar/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/button/"}}) {
+    mdx(fields: {slug: {eq: "/components/button/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/card/index.mdx
+++ b/packages/paste-website/src/pages/components/card/index.mdx
@@ -62,7 +62,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/card/"}}) {
+    mdx(fields: {slug: {eq: "/components/card/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/checkbox/index.mdx
+++ b/packages/paste-website/src/pages/components/checkbox/index.mdx
@@ -36,7 +36,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/checkbox/"}}) {
+    mdx(fields: {slug: {eq: "/components/checkbox/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -49,7 +49,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/combobox/"}}) {
+    mdx(fields: {slug: {eq: "/components/combobox/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -30,7 +30,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/disclosure/"}}) {
+    mdx(fields: {slug: {eq: "/components/disclosure/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/heading/"}}) {
+    mdx(fields: {slug: {eq: "/components/heading/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/input/index.mdx
+++ b/packages/paste-website/src/pages/components/input/index.mdx
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/input/"}}) {
+    mdx(fields: {slug: {eq: "/components/input/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -28,7 +28,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/list/"}}) {
+    mdx(fields: {slug: {eq: "/components/list/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -39,7 +39,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/menu/"}}) {
+    mdx(fields: {slug: {eq: "/components/menu/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -35,7 +35,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/modal/"}}) {
+    mdx(fields: {slug: {eq: "/components/modal/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -27,7 +27,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/paragraph/"}}) {
+    mdx(fields: {slug: {eq: "/components/paragraph/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/popover/index.mdx
+++ b/packages/paste-website/src/pages/components/popover/index.mdx
@@ -27,7 +27,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/popover/"}}) {
+    mdx(fields: {slug: {eq: "/components/popover/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/radio-group/index.mdx
+++ b/packages/paste-website/src/pages/components/radio-group/index.mdx
@@ -34,7 +34,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/radio-group/"}}) {
+    mdx(fields: {slug: {eq: "/components/radio-group/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
+++ b/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/screen-reader-only/"}}) {
+    mdx(fields: {slug: {eq: "/components/screen-reader-only/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/select/index.mdx
+++ b/packages/paste-website/src/pages/components/select/index.mdx
@@ -36,7 +36,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/select/"}}) {
+    mdx(fields: {slug: {eq: "/components/select/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/separator/index.mdx
+++ b/packages/paste-website/src/pages/components/separator/index.mdx
@@ -25,7 +25,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/separator/"}}) {
+    mdx(fields: {slug: {eq: "/components/separator/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/spinner/"}}) {
+    mdx(fields: {slug: {eq: "/components/spinner/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -27,7 +27,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/table/"}}) {
+    mdx(fields: {slug: {eq: "/components/table/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -35,7 +35,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/tabs/"}}) {
+    mdx(fields: {slug: {eq: "/components/tabs/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/textarea/"}}) {
+    mdx(fields: {slug: {eq: "/components/textarea/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/toast/index.mdx
+++ b/packages/paste-website/src/pages/components/toast/index.mdx
@@ -39,7 +39,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/toast/"}}) {
+    mdx(fields: {slug: {eq: "/components/toast/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/tooltip/index.mdx
+++ b/packages/paste-website/src/pages/components/tooltip/index.mdx
@@ -30,7 +30,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/tooltip/"}}) {
+    mdx(fields: {slug: {eq: "/components/tooltip/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/components/truncate/index.mdx
+++ b/packages/paste-website/src/pages/components/truncate/index.mdx
@@ -29,7 +29,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/truncate/"}}) {
+    mdx(fields: {slug: {eq: "/components/truncate/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/layout/aspect-ratio/index.mdx
+++ b/packages/paste-website/src/pages/layout/aspect-ratio/index.mdx
@@ -34,7 +34,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/aspect-ratio/"}}) {
+    mdx(fields: {slug: {eq: "/layout/aspect-ratio/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/layout/flex/index.mdx
+++ b/packages/paste-website/src/pages/layout/flex/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/flex/"}}) {
+    mdx(fields: {slug: {eq: "/layout/flex/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/layout/grid/index.mdx
+++ b/packages/paste-website/src/pages/layout/grid/index.mdx
@@ -33,7 +33,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/grid/"}}) {
+    mdx(fields: {slug: {eq: "/layout/grid/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/layout/media-object/index.mdx
+++ b/packages/paste-website/src/pages/layout/media-object/index.mdx
@@ -31,7 +31,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/media-object/"}}) {
+    mdx(fields: {slug: {eq: "/layout/media-object/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/layout/stack/index.mdx
+++ b/packages/paste-website/src/pages/layout/stack/index.mdx
@@ -28,7 +28,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/stack/"}}) {
+    mdx(fields: {slug: {eq: "/layout/stack/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/libraries/index.mdx
+++ b/packages/paste-website/src/pages/libraries/index.mdx
@@ -38,6 +38,12 @@ All of these libraries are first-party; we actively support them and hope they p
 
 ## Libraries
 
+### [uid-library](/libraries/uid-library)
+
+This is used to generate unique `id` values throughout React applications. This is most commonly used for
+mapping form labels to form inputs, or mapping titles for accessibility. This library works when SSR and dyanmically importing
+application code.
+
 ### [SVG-to-React](https://github.com/twilio-labs/svg-to-react)
 
 SVG-to-React allows users to generate fully-formed and accessible React components from an SVG input.

--- a/packages/paste-website/src/pages/libraries/uid-library/index.mdx
+++ b/packages/paste-website/src/pages/libraries/uid-library/index.mdx
@@ -1,0 +1,170 @@
+---
+title: UID Library
+description: Generates unique identifiers for HTML and JS
+slug: /libraries/uid-library/
+---
+
+import {graphql} from 'gatsby';
+import {Box} from '@twilio-paste/box';
+import {SidebarCategoryRoutes} from '../../../constants';
+import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
+
+export const pageQuery = graphql`
+  {
+    allPasteLibraries(filter: {name: {eq: "@twilio-paste/uid-library"}}) {
+      edges {
+        node {
+          name
+          description
+          status
+          version
+        }
+      }
+    }
+    mdx(fields: {slug: {eq: "/libraries/uid-library/"}}) {
+      fileAbsolutePath
+      frontmatter {
+        slug
+        title
+      }
+    }
+  }
+`;
+
+<ComponentHeader
+  name="UID Library"
+  categoryRoute={SidebarCategoryRoutes.LIBRARIES}
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-libraries/uid"
+  storybookUrl="https://twilio-labs.github.io/paste/?path=/story/libraries-uid"
+  data={props.data.allPasteLibraries.edges}
+/>
+
+---
+
+<contentwrapper>
+<PageAside data={props.data.mdx} />
+<content>
+
+## Guidelines
+
+### Why do we need unique IDs
+
+Unique IDs are important because:
+
+- The [HTML spec says they should be unique](https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute) and strange bugs might occur otherwise.
+- You need them to correctly pair form elements together for better UX.
+- You need them to provide additional information for screenreaders, such as to provide a text hint to icons.
+
+Here's what could happen without unique IDs:
+
+<iframe
+  src="https://codesandbox.io/embed/blue-http-xqqo4?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  title="blue-http-xqqo4"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+<br />
+<br />
+<br />
+
+### Why do we need a library?
+
+Anytime a software product needs unique identifiers, the likelyhood of `id` collisions increases the larger the project and team becomes.
+Furthermore, the way React has transformed the traditional process of page-based development to componened-based development leads to more situations where an `id` can clash.
+For example, if one page renders the same `DeleteIcon` component twice and that icon has `id="delete-icon"` hardcoded, then we now have an `id` collision.
+It is very difficult to predict the exact circumstances where a component will be used, so any time a component needs an `id` the risk of a collision is present.
+
+### How does this library work?
+
+This library maintains a sequential count, so that everytime a component mounts and needs an ID, it will fetch the next value (`count += 1`).
+
+---
+
+## Usage Guide
+
+This package is a wrapper around [react-uid](https://github.com/thearnica/react-uid).
+If you’re wondering why we wrapped that package into our own, we reasoned that
+it would be best for our consumers’ developer experience. For example:
+
+- We can control which APIs we expose and how to expose them. For example, in this package
+  export only some of the source package's exports.
+- If we want to migrate the underlying nuts and bolts in the future, Twilio products that
+  depend on this primitive would need to replace all occurrences of `import … from ‘@react-uid’`
+  to `import … from ‘@some-new/package’`. By wrapping it in `@twilio-paste/uid-library`,
+  this refactor can be avoided. The only change would be a version bump in the package.json file.
+- We can more strictly enforce semver and backwards compatibility than some of our dependencies.
+- We can control when to provide an update and which versions we allow, to help reduce
+  potential bugs our consumers may face.
+
+This package has 4 exports, described below.
+
+### API
+
+#### useUID()
+
+This is a React Hook to generate a UID.
+
+<iframe
+  src="https://codesandbox.io/embed/happy-bush-ued0c?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  title="useUID example"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+<Box marginTop="space100" />
+
+#### useUIDSeed()
+
+This React Hook creates a seed from which you can generate several UIDs. It's handy for when you need multiple `id`s in a single component.
+
+<iframe
+  src="https://codesandbox.io/embed/useuidseed-example-p0sxb?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  title="useUIDSeed example"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+<Box marginTop="space100" />
+
+#### UIDFork Component
+
+<Callout variant="primary">
+  <CalloutText>This is only needed for lazy-loaded or code-split chunks.</CalloutText>
+</Callout>
+
+This React Component pivots the global singleton `count` to read a counter from React Context.
+If your app has code-splitting or lazy-loading, you want to wrap every entrypoint with `<UIDFork>` in order
+to garantee there isn't any collisions.
+
+<Box marginTop="space100" />
+
+#### uid(item, index)
+
+<Callout variant="warning">
+  <CalloutTitle>Don't use this API in React Components</CalloutTitle>
+  <CalloutText>
+    Prefer using the other React Hooks (useUID or useUIDSeed) in React components. They are Server Side Rendering (SSR)
+    compatible and the recommended future-proof API.
+  </CalloutText>
+</Callout>
+
+A plain Javascript function to return a UID. `item` should be an object (in JS, this could mean a function, an array, etc.). If `item` isn't an object
+, provide the second argument `index`. This API is not SSR friendly.
+
+We provide this export for quick UID generation in utility files.
+
+<iframe
+  src="https://codesandbox.io/embed/uid-example-s35fo?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="uid Example"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+</content>
+
+</contentwrapper>

--- a/packages/paste-website/src/pages/libraries/uid-library/index.mdx
+++ b/packages/paste-website/src/pages/libraries/uid-library/index.mdx
@@ -27,6 +27,10 @@ export const pageQuery = graphql`
         slug
         title
       }
+      headings {
+        depth
+        value
+      }
     }
   }
 `;

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -23,7 +23,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/box/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/box/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -28,7 +28,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/combobox-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/combobox-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
@@ -34,7 +34,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/disclosure-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/disclosure-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
@@ -45,7 +45,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/menu-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/menu-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/modal-dialog-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/modal-dialog-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
@@ -37,7 +37,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/non-modal-dialog-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/non-modal-dialog-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/tabs-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tabs-primitive/index.mdx
@@ -34,7 +34,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/tabs-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/tabs-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug

--- a/packages/paste-website/src/pages/primitives/text/index.mdx
+++ b/packages/paste-website/src/pages/primitives/text/index.mdx
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/text/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/text/"}}) {
       fileAbsolutePath
       frontmatter {
         slug
@@ -257,7 +257,7 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 | color?          | `ResponsiveValue<keyof ThemeShape['textColors']>`                             |                           |         |
 | textDecoration? | `ResponsiveValue<CSS.TextDecorationProperty<CSS.TextDecorationLineProperty>>` |                           |         |
 | textOverflow?   | `ResponsiveValue<CSS.TextOverflowProperty>`                                   |                           |         |
-| whitespace?      | `ResponsiveValue<CSS.WhiteSpaceProperty>`                                     |                           |         |
+| whitespace?     | `ResponsiveValue<CSS.WhiteSpaceProperty>`                                     |                           |         |
 | \_after?        | TextProps                                                                     |                           |         |
 | \_before?       | TextProps                                                                     |                           |         |
 | \_focus?        | TextProps                                                                     |                           |         |

--- a/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
@@ -32,7 +32,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: {slug: {eq: "/tooltip-primitive/"}}) {
+    mdx(fields: {slug: {eq: "/primitives/tooltip-primitive/"}}) {
       fileAbsolutePath
       frontmatter {
         slug


### PR DESCRIPTION
Adds documentation for the uid-library package. This is the first library we document on the website, so it required some additional scaffolding.