### PR TITLE
feat(grid): add ability to create equal height columns

### DIFF
--- a/packages/paste-core/layout/flex/src/index.tsx
+++ b/packages/paste-core/layout/flex/src/index.tsx
@@ -99,3 +99,5 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 export {Flex};
+
+export * from './types';

--- a/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/paste-core/layout/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Grid Utils render it should render a Column 1`] = `
+exports[`Grid render it should render a Column 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 8.333333333333332%;
@@ -15,18 +15,13 @@ exports[`Grid Utils render it should render a Column 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Grid Utils render it should render a Grid 1`] = `
+exports[`Grid render it should render a Grid 1`] = `
 <DocumentFragment>
   .emotion-0 {
   box-sizing: border-box;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -48,18 +43,13 @@ exports[`Grid Utils render it should render a Grid 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Grid Utils render it should render a Grid as any HTML element 1`] = `
+exports[`Grid render it should render a Grid as any HTML element 1`] = `
 <DocumentFragment>
   .emotion-0 {
   box-sizing: border-box;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -81,18 +71,10 @@ exports[`Grid Utils render it should render a Grid as any HTML element 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Grid Utils render it should render responsive css 1`] = `
+exports[`Grid render it should render responsive css 1`] = `
 <DocumentFragment>
   .emotion-2 {
   box-sizing: border-box;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;

--- a/packages/paste-core/layout/grid/__tests__/grid.test.tsx
+++ b/packages/paste-core/layout/grid/__tests__/grid.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {render} from '@testing-library/react';
 import {Grid, Column} from '../src';
 import {getOuterGutterPull, getStackedColumns, getColumnOffset, getColumnSpan} from '../src/utils';
+import {getColumnStyles} from '../src/Column';
 
 describe('Grid', () => {
   describe('Utils', () => {
@@ -95,32 +96,75 @@ describe('Grid', () => {
         ).toEqual(['25%', '50%', '25%']);
       });
     });
+  });
 
-    describe('render', () => {
-      it('it should render a Grid', () => {
-        const {asFragment} = render(<Grid>child</Grid>);
-        expect(asFragment()).toMatchSnapshot();
+  describe('Column', () => {
+    describe('getColumnStyles', () => {
+      it('should return column padding when passed a gutter', () => {
+        expect(getColumnStyles({gutter: 'space20'})).toEqual({
+          paddingLeft: 'space20',
+          paddingRight: 'space20',
+          width: '8.333333333333332%',
+        });
       });
 
-      it('it should render a Grid as any HTML element', () => {
-        const {asFragment} = render(<Grid as="section">child</Grid>);
-        expect(asFragment()).toMatchSnapshot();
+      it('should return column margin left when passed a column offset based on size of offset', () => {
+        expect(getColumnStyles({offset: 2})).toEqual({
+          marginLeft: '16.666666666666664%',
+          width: '8.333333333333332%',
+        });
+        expect(getColumnStyles({offset: 6})).toEqual({
+          marginLeft: '50%',
+          width: '8.333333333333332%',
+        });
       });
 
-      it('it should render a Column', () => {
-        const {asFragment} = render(<Column>child</Column>);
-        expect(asFragment()).toMatchSnapshot();
+      it('should set 100% width and zero offset when a column is vertical', () => {
+        expect(getColumnStyles({vertical: true, offset: 4})).toEqual({
+          marginLeft: '33.33333333333333%',
+          width: '8.333333333333332%',
+        });
+        expect(getColumnStyles({vertical: true})).toEqual({
+          marginLeft: 'space0',
+          minWidth: '100%',
+          width: '8.333333333333332%',
+        });
       });
 
-      it('it should render responsive css', () => {
-        const {asFragment} = render(
-          <Grid gutter={['space10', 'space20', 'space30']} vertical={[true, true, false]}>
-            <Column span={[2, 4, 2]} offset={[8, 6, 8]} />
-            <Column />
-          </Grid>
-        );
-        expect(asFragment()).toMatchSnapshot();
+      it('should set the column to stretch content and display flex when setting stretch column content', () => {
+        expect(getColumnStyles({stretchColumnContent: true})).toEqual({
+          alignContent: 'stretch',
+          display: 'flex',
+          width: '8.333333333333332%',
+        });
       });
+    });
+  });
+
+  describe('render', () => {
+    it('it should render a Grid', () => {
+      const {asFragment} = render(<Grid>child</Grid>);
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('it should render a Grid as any HTML element', () => {
+      const {asFragment} = render(<Grid as="section">child</Grid>);
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('it should render a Column', () => {
+      const {asFragment} = render(<Column>child</Column>);
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('it should render responsive css', () => {
+      const {asFragment} = render(
+        <Grid gutter={['space10', 'space20', 'space30']} vertical={[true, true, false]}>
+          <Column span={[2, 4, 2]} offset={[8, 6, 8]} />
+          <Column />
+        </Grid>
+      );
+      expect(asFragment()).toMatchSnapshot();
     });
   });
 });

--- a/packages/paste-core/layout/grid/package.json
+++ b/packages/paste-core/layout/grid/package.json
@@ -28,7 +28,6 @@
   "peerDependencies": {
     "@twilio-paste/box": "^2.11.9",
     "@twilio-paste/design-tokens": "^6.3.6",
-    "@twilio-paste/flex": "^0.3.69",
     "@twilio-paste/style-props": "^1.8.9",
     "@twilio-paste/styling-library": "^0.1.4",
     "@twilio-paste/theme": "^3.3.2",
@@ -40,7 +39,6 @@
   "devDependencies": {
     "@twilio-paste/box": "^2.11.9",
     "@twilio-paste/design-tokens": "^6.3.6",
-    "@twilio-paste/flex": "^0.3.69",
     "@twilio-paste/style-props": "^1.8.9",
     "@twilio-paste/styling-library": "^0.1.4",
     "@twilio-paste/theme": "^3.3.2",

--- a/packages/paste-core/layout/grid/src/Column.tsx
+++ b/packages/paste-core/layout/grid/src/Column.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {styled, compose, layout, space} from '@twilio-paste/styling-library';
+import {styled, compose, flexbox, layout, space} from '@twilio-paste/styling-library';
 import {ResponsiveProp} from '@twilio-paste/style-props';
 import {ColumnProps, ColumnStyleProps} from './types';
 import {getStackedColumns, getColumnOffset, getColumnSpan} from './utils';
 
-const getColumnStyles = (props: ColumnProps): ColumnStyleProps => {
+export const getColumnStyles = (props: ColumnProps): ColumnStyleProps => {
   const columnStyles: ColumnStyleProps = {
     width: getColumnSpan(props),
   };
@@ -24,24 +24,27 @@ const getColumnStyles = (props: ColumnProps): ColumnStyleProps => {
     columnStyles.marginLeft = 'space0';
   }
 
+  if (props.stretchColumnContent) {
+    columnStyles.alignContent = 'stretch';
+    columnStyles.display = 'flex';
+  }
+
   return columnStyles;
 };
 
 const StyledColumn = styled.div(
   compose(
     space,
+    flexbox,
     layout
   )
 ) as React.FC<ColumnProps>;
 
-const Column: React.FC<ColumnProps> = ({as, children, count, gutter, offset, span, vertical}) => {
-  const ColumnStyles = React.useMemo(() => getColumnStyles({count, gutter, offset, span, vertical}), [
-    count,
-    gutter,
-    offset,
-    span,
-    vertical,
-  ]);
+const Column: React.FC<ColumnProps> = ({as, children, count, gutter, offset, span, stretchColumnContent, vertical}) => {
+  const ColumnStyles = React.useMemo(
+    () => getColumnStyles({count, gutter, offset, span, stretchColumnContent, vertical}),
+    [count, gutter, offset, span, stretchColumnContent, vertical]
+  );
   return (
     <StyledColumn {...ColumnStyles} as={as}>
       {children}

--- a/packages/paste-core/layout/grid/src/types.ts
+++ b/packages/paste-core/layout/grid/src/types.ts
@@ -1,9 +1,10 @@
 import {ResponsiveValue} from '@twilio-paste/styling-library';
-import {LayoutProps, PaddingProps, Space, SpaceProps} from '@twilio-paste/style-props';
+import {LayoutProps, FlexboxProps, PaddingProps, Space, SpaceProps} from '@twilio-paste/style-props';
 
 export interface GridProps extends SpaceProps {
   as?: keyof JSX.IntrinsicElements;
   children: NonNullable<React.ReactNode>;
+  equalColumnHeights?: boolean;
   gutter?: Space;
   vertical?: ResponsiveValue<boolean>;
 }
@@ -16,6 +17,7 @@ export type ColumnSpanOptions = number;
 export type ColumnSpan = ResponsiveValue<ColumnSpanOptions>;
 
 export interface ColumnStyleProps extends Omit<LayoutProps, 'minWidth' | 'width'>, PaddingProps {
+  alignContent?: FlexboxProps['alignContent'];
   marginLeft?: ResponsiveValue<string>;
   minWidth?: ColumnMinWidth;
   width?: ColumnWidthSpan;
@@ -27,5 +29,6 @@ export interface ColumnProps extends ColumnStyleProps {
   gutter?: Space;
   offset?: ColumnOffset;
   span?: ColumnSpan;
+  stretchColumnContent?: boolean;
   vertical?: ResponsiveValue<boolean>;
 }

--- a/packages/paste-core/layout/grid/stories/index.stories.tsx
+++ b/packages/paste-core/layout/grid/stories/index.stories.tsx
@@ -550,19 +550,25 @@ storiesOf('Layout|Grid', module)
       <Grid gutter="space70" vertical={[true, false, false]}>
         <Column>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
         <Column>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
         <Column>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
@@ -574,20 +580,26 @@ storiesOf('Layout|Grid', module)
       <Grid gutter="space70" vertical={[true, false, false]}>
         <Column span={6}>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
         <Column span={6}>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
         <Column span={6}>
           <Box marginTop="space70">
             <Card padding="space70">
-              <Heading as="h2">Card Heading</Heading>
+              <Heading as="h2" variant="heading20">
+                Card Heading
+              </Heading>
               <Text as="p">Body</Text>
             </Card>
           </Box>
@@ -595,7 +607,9 @@ storiesOf('Layout|Grid', module)
         <Column span={6}>
           <Box marginTop="space70">
             <Card padding="space70">
-              <Heading as="h2">Card Heading</Heading>
+              <Heading as="h2" variant="heading20">
+                Card Heading
+              </Heading>
               <Text as="p">Body</Text>
             </Card>
           </Box>
@@ -607,7 +621,9 @@ storiesOf('Layout|Grid', module)
     return (
       <Grid gutter="space70" vertical={[true, false, false]}>
         <Column span={8}>
-          <Heading as="h2">Content Heading</Heading>
+          <Heading as="h2" variant="heading20">
+            Content Heading
+          </Heading>
           <Paragraph>
             Kale chips distillery authentic, portland etsy cloud bread vinyl gentrify drinking vinegar viral meh hot
             chicken bitters fashion axe palo santo. Chillwave fixie sustainable <i>helvetica</i> etsy.
@@ -620,11 +636,95 @@ storiesOf('Layout|Grid', module)
         </Column>
         <Column span={4}>
           <Card padding="space70">
-            <Heading as="h2">Card Heading</Heading>
+            <Heading as="h2" variant="heading20">
+              Card Heading
+            </Heading>
             <Text as="p">Body</Text>
           </Card>
         </Column>
       </Grid>
+    );
+  })
+  .add('Grid - Equal height columns', () => {
+    return (
+      <>
+        <Grid gutter="space30" vertical={[true, true, false]} equalColumnHeights>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Why use Paste?
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Paste helps you rapidly prototype, and ship great, inclusive customer experiences. It makes it easy to
+                do the right thing, cheaply.
+              </Paragraph>
+            </Card>
+          </Column>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Inclusive by default
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Paste meets WCAG 2.1 AA standards in the design and development of our components, making it even easier
+                to build accessibly.
+              </Paragraph>
+              <Paragraph marginBottom="space0">
+                Paste meets WCAG 2.1 AA standards in the design and development of our components, making it even easier
+                to build accessibly.
+              </Paragraph>
+            </Card>
+          </Column>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Get up and running
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Whether you’re a designer or developer, setting up Paste is easy and only takes a few minutes!
+              </Paragraph>
+            </Card>
+          </Column>
+        </Grid>
+        <Grid gutter="space30" equalColumnHeights>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Why use Paste?
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Paste helps you rapidly prototype, and ship great, inclusive customer experiences. It makes it easy to
+                do the right thing, cheaply.
+              </Paragraph>
+            </Card>
+          </Column>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Inclusive by default
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Paste meets WCAG 2.1 AA standards in the design and development of our components, making it even easier
+                to build accessibly.
+              </Paragraph>
+              <Paragraph marginBottom="space0">
+                Paste meets WCAG 2.1 AA standards in the design and development of our components, making it even easier
+                to build accessibly.
+              </Paragraph>
+            </Card>
+          </Column>
+          <Column span={4}>
+            <Card padding="space70">
+              <Heading as="h2" variant="heading20">
+                Get up and running
+              </Heading>
+              <Paragraph marginBottom="space0">
+                Whether you’re a designer or developer, setting up Paste is easy and only takes a few minutes!
+              </Paragraph>
+            </Card>
+          </Column>
+        </Grid>
+      </>
     );
   })
   .add('Grid - Containing long content', () => {

--- a/packages/paste-core/layout/grid/tsconfig.build.json
+++ b/packages/paste-core/layout/grid/tsconfig.build.json
@@ -15,9 +15,6 @@
       "path": "../../../paste-design-tokens"
     },
     {
-      "path": "../flex"
-    },
-    {
       "path": "../../../paste-style-props"
     },
     {

--- a/packages/paste-website/src/pages/layout/grid/index.mdx
+++ b/packages/paste-website/src/pages/layout/grid/index.mdx
@@ -164,6 +164,51 @@ Use `offset` to push a column to the right by a certain number of columns. For e
 </Grid>`}
 </LivePreview>
 
+### Equal column heights
+
+Set `equalColumnHeights` on a grid container and all columns in a single row will share the height of the tallest column.
+
+This can be useful when trying to visually align Cards where their content is variable.
+
+When columns have equal heights, a single child element will stretch to the height of the column. You may still need to control the width of that child though.
+
+<LivePreview scope={{Grid, Column, Card, Button, Heading, Paragraph, Box}} language="jsx">
+  {`<Grid gutter="space30" equalColumnHeights>
+  <Column span={4}>
+    <Card padding="space70">
+      <Heading as="h2" variant="heading20">
+        Why use Paste?
+      </Heading>
+      <Paragraph marginBottom="space0">
+        Paste helps you rapidly prototype, and ship great, inclusive customer experiences. It makes it easy to
+        do the right thing, cheaply.
+      </Paragraph>
+    </Card>
+  </Column>
+  <Column span={4}>
+    <Card padding="space70">
+      <Heading as="h2" variant="heading20">
+        Inclusive by default
+      </Heading>
+      <Paragraph marginBottom="space0">
+        Paste meets WCAG 2.1 AA standards in the design and development of our components, making it even easier
+        to build accessibly.
+      </Paragraph>
+    </Card>
+  </Column>
+  <Column span={4}>
+    <Card padding="space70">
+      <Heading as="h2" variant="heading20">
+        Get up and running
+      </Heading>
+      <Paragraph marginBottom="space0">
+        Whether you’re a designer or developer, setting up Paste is easy and only takes a few minutes!
+      </Paragraph>
+    </Card>
+  </Column>
+</Grid>`}
+</LivePreview>
+
 ### Stacked columns in a vertical layout
 
 Use the `vertical` prop to stack columns vertically instead of horizontally. The `vertical` prop can work along with theme breakpoints,
@@ -559,10 +604,11 @@ const Component = () => (
 
 #### Grid Props
 
-| Prop      | Type                                         | Description                                                                                                                         | Default |
-| --------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| gutter?   | `ResponsiveValue<keyof ThemeShape['space']>` | Sets the spacing on both sides of a Column. Use a spacing token that represents half of the total space you need between 2 Columns. |         |
-| vertical? | `boolean, ResponsiveValue<boolean>`          | Stacks the Columns                                                                                                                  |         |
+| Prop                | Type                                         | Description                                                                                                                         | Default |
+| ------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| equalColumnHeights? | `boolean`                                    | Sets the height of columns in a row to be equal.                                                                                    |         |
+| gutter?             | `ResponsiveValue<keyof ThemeShape['space']>` | Sets the spacing on both sides of a Column. Use a spacing token that represents half of the total space you need between 2 Columns. |         |
+| vertical?           | `boolean, ResponsiveValue<boolean>`          | Stacks the Columns                                                                                                                  |         |
 
 #### Column Props
 


### PR DESCRIPTION
Pass `equalColumnHeight` to grid to use Flexbox to stretch align content it's columns, and the columns content.

Has limitations that only a single child will work in a column, and `display: flex` collapses the child's width.

