### PR TITLE
fix(combobox): ensure listbox optionn ids in groups are always unique

### DIFF
--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -105,7 +105,7 @@ const GroupedItems: React.FC<GroupItemsProps> = ({
               return (
                 <Item
                   item={item}
-                  index={index}
+                  index={UIDSeed(`${groupedItemKey}-${index}`)}
                   key={UIDSeed(`${groupedItemKey}-${index}`)}
                   getItemProps={getItemProps}
                   highlightedIndex={highlightedIndex}

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -30,7 +30,7 @@ export interface ComboboxProps extends Omit<InputProps, 'id' | 'type' | 'value'>
 
 export interface ItemProps extends Pick<ComboboxProps, 'optionTemplate'> {
   item: Item;
-  index: number;
+  index: number | string;
   getItemProps: any;
   highlightedIndex: UseComboboxPrimitiveState<Item>['highlightedIndex'];
   inGroup?: boolean;


### PR DESCRIPTION
Due to the way groups of options are rendered, that start at a fresh index meaning you get duplicate ids across groups.

Ensure that this doesn't happen and write a test to make sure it never happens again.