### PR TITLE
chore: don't publish on *.md file changes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "useWorkspaces": true,
   "command": {
     "publish": {
-      "ignoreChanges": ["**/stories/**", "**/__tests__/**"],
+      "ignoreChanges": ["**/stories/**", "**/__tests__/**", "**/*.md"],
       "npmClient": "npm"
     }
   }


### PR DESCRIPTION
We merged a tiny change in a *.md file and our CI published a bunch of packages (:lol:). This will prevent publishing on MD file changes.