### PR TITLE
chore: extend the tooltip story timeouts

### DIFF
--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -39,12 +39,14 @@ storiesOf('Components|Tooltip', module)
     'Default',
     () => {
       return (
-        <Tooltip visible text={text('text', 'Welcome to Paste!')}>
-          <Button variant="primary">Open tooltip</Button>
-        </Tooltip>
+        <Box as="div" minHeight="400px">
+          <Tooltip visible text={text('text', 'Welcome to Paste!')}>
+            <Button variant="primary">Open tooltip</Button>
+          </Tooltip>
+        </Box>
       );
     },
-    {chromatic: {delay: 300}}
+    {chromatic: {delay: 800}}
   )
   .add(
     'Tooltip Placements',
@@ -68,7 +70,7 @@ storiesOf('Components|Tooltip', module)
         </Box>
       );
     },
-    {chromatic: {delay: 300}}
+    {chromatic: {delay: 800}}
   )
   .add('Automatic edge placement', () => {
     return (


### PR DESCRIPTION
These two tooltip stories diff everytime in chromatic. The default doesn't even include a screenshot of the tooltip, and extending the timeout before the capture to hopefully iron out the positioning differences.