### PR TITLE
fix: applitools batches

### DIFF
--- a/.github/workflows/vrt_main.yml
+++ b/.github/workflows/vrt_main.yml
@@ -54,4 +54,5 @@ jobs:
         run: yarn test:vrt
         env:
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+          APPLITOOLS_BATCH_NAME: "twilio-labs/paste: main"
           GITHUB_HEAD_SHA: ${{ github.sha }}

--- a/.github/workflows/vrt_pull_request.yml
+++ b/.github/workflows/vrt_pull_request.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  chromatic:
+  vrt:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
@@ -53,4 +53,5 @@ jobs:
         run: yarn test:vrt
         env:
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+          APPLITOOLS_BATCH_NAME: "${{ github.event.pull_request.head.repo.full_name }}: pull request from ${{ github.event.pull_request.head.ref }} - ${{ github.event.pull_request.title }} (${{ github.event.pull_request.head.sha }})"
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/applitools.config.js
+++ b/applitools.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   serverUrl: 'https://twilioeyesapi.applitools.com',
   batchId: process.env.GITHUB_HEAD_SHA,
+  batchName: process.env.APPLITOOLS_BATCH_NAME,
   exitcode: 0,
 };


### PR DESCRIPTION
At some point applitools stopped naming batches based on branches. I wondered if it was due to the job being moved to it's own workflow, but they have also pushed out a change to how batches work. Trying to debug which broke it.

![image](https://user-images.githubusercontent.com/368249/99571711-85157880-2988-11eb-99cb-48e2676fbfb7.png)
