### PR TITLE
fix: missing publish access settings for npm

### DIFF
--- a/packages/paste-customization/package.json
+++ b/packages/paste-customization/package.json
@@ -9,6 +9,9 @@
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],

--- a/packages/paste-theme/package.json
+++ b/packages/paste-theme/package.json
@@ -9,6 +9,9 @@
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
I have no idea how the Theme package was publishing without this. The build broke for customization package publishing.

- fix(customization): add public access for npm publish
- fix(theme): add public access for npm publish
