### PR TITLE
fix(help-text): align error icon to top of text

### DIFF
--- a/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/combobox/__tests__/__snapshots__/index.spec.tsx.snap
@@ -220,10 +220,10 @@ exports[`Combobox Render should render 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/paste-core/components/help-text/src/HelpText.tsx
+++ b/packages/paste-core/components/help-text/src/HelpText.tsx
@@ -53,7 +53,7 @@ const HelpText = React.forwardRef<HTMLDivElement, HelpTextProps>(({marginTop, ch
   }
 
   return (
-    <Flex vAlignContent="center" marginTop={marginTop || 'space30'} ref={ref}>
+    <Flex marginTop={marginTop || 'space30'} ref={ref}>
       {icon}
       <Text
         {...safelySpreadTextProps(props)}


### PR DESCRIPTION
- [x] Changed help text icon to be top aligned. Fixes https://github.com/twilio-labs/paste/discussions/1062