### PR TITLE
fix: pull request codesandboxes need their own tsconfig

### DIFF
--- a/.changeset/strong-schools-draw.md
+++ b/.changeset/strong-schools-draw.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/nextjs-template': patch
+---
+
+As the NextJs template is used as a standalone application in a Codesandbox, it cannot inherit the base tsconfig from the the root of the monorepo. This is because it does not exist when deployed to Codesandbox

--- a/packages/paste-nextjs-template/tsconfig.json
+++ b/packages/paste-nextjs-template/tsconfig.json
@@ -1,10 +1,15 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly":  false,
+    "emitDecoratorMetadata": true,
     "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
     "incremental": false,
+    "isolatedModules": true,
     "jsx": "preserve",
     "lib": [
       "dom",
@@ -12,8 +17,23 @@
       "esnext"
     ],
     "module": "esnext",
+    "moduleResolution": "node",
+    "newLine": "lf",
     "noEmit": true,
-    "resolveJsonModule": true
+    "noEmitOnError": false,
+    "noImplicitAny": true,
+    "noResolve": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "paths": {
+      "*": ["./@types/*"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es6",
+    "typeRoots": ["./@types", "node_modules/@types"]
   },
   "include": [
     "next-env.d.ts",

--- a/packages/paste-nextjs-template/tsconfig.json
+++ b/packages/paste-nextjs-template/tsconfig.json
@@ -25,15 +25,11 @@
     "noResolve": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "paths": {
-      "*": ["./@types/*"]
-    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "es6",
-    "typeRoots": ["./@types", "node_modules/@types"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
When we use the NextJs template for the PR codesandbox build, the tsconfig was trying to inherit from the monorepo root tsconfig which didn't exist. So it broke.

This provides it's own isolated tsconfig for Codesandbox purposes