### PR TITLE
feat(website): add illustration library access instructions

### DIFF
--- a/packages/paste-website/src/pages/illustrations/index.mdx
+++ b/packages/paste-website/src/pages/illustrations/index.mdx
@@ -50,7 +50,7 @@ Our illustration style is carefully curated by the Twilio Brand team. While addi
 
 [Read the brand illustration guidelines](https://www.twilio.com/brand/guidelines/illustration-guidelines)
 
-[Browse the illustration library](https://library.twilio.com/web/2f44a10496e4c83b/shared-illustrations). To login to the library with your Twilio credentials, you'll have to first request application access through IT via [ServiceNow](https://twilio.service-now.com) to "The Library (Bynder)".
+[Browse the illustration library](https://library.twilio.com). To login to the library with your Twilio credentials, you'll have to first request application access through IT via [ServiceNow](https://twilio.service-now.com) to "The Library (Bynder)".
 
 ### General guidelines for product UIs
 
@@ -66,13 +66,8 @@ Our illustration style is carefully curated by the Twilio Brand team. While addi
 
 ### Request new illustrations
 
-<Paragraph>
-  The best way to request new illustrations is to file a request with the Brand team. You can create a new{' '}
-  <Flex display="inline-flex" as="span" vAlignContent="center">
-    <Anchor href="https://issues.corp.twilio.com/projects/MARK/issues/"> request on JIRA</Anchor>
-    <LinkExternalIcon display="inline-block" decorative={false} title="Opens an external resource" /> (VPN required)
-  </Flex>
-</Paragraph>
+The best way to request new illustrations is to file a request with the Brand team. You can create a new 
+[request on Jira](https://issues.corp.twilio.com/projects/MARK/issues) (VPN required).
 
 </content>
 

--- a/packages/paste-website/src/pages/illustrations/index.mdx
+++ b/packages/paste-website/src/pages/illustrations/index.mdx
@@ -50,7 +50,7 @@ Our illustration style is carefully curated by the Twilio Brand team. While addi
 
 [Read the brand illustration guidelines](https://www.twilio.com/brand/guidelines/illustration-guidelines)
 
-[Browse the illustration library](https://library.twilio.com). To login to the library with your Twilio credentials, you'll have to first request application access through IT via [ServiceNow](https://twilio.service-now.com) to "The Library (Bynder)".
+[Browse the illustration library](https://library.twilio.com). To log in to the library with your Twilio credentials, request application access through IT via [ServiceNow](https://twilio.service-now.com) for "The Library (Bynder)".
 
 ### General guidelines for product UIs
 

--- a/packages/paste-website/src/pages/illustrations/index.mdx
+++ b/packages/paste-website/src/pages/illustrations/index.mdx
@@ -48,21 +48,9 @@ Illustration helps breathe life into our brand. It can take a complex idea and m
 
 Our illustration style is carefully curated by the Twilio Brand team. While adding these elements to your UI, ensure that you are reviewing your work with them. A good place to start is by posting in #mkg-brand.
 
-<Box as="div" marginBottom="space60"><Stack orientation="vertical" spacing="space60">
-<Flex display="inline-flex" vAlignContent="center">
-<Anchor href="https://www.twilio.com/brand/guidelines/illustration-guidelines">
-Read the brand illustration guidelines
-</Anchor>
-<LinkExternalIcon decorative={false} title="Opens an external resource" />
-</Flex>
+[Read the brand illustration guidelines](https://www.twilio.com/brand/guidelines/illustration-guidelines)
 
-<Flex display="inline-flex" vAlignContent="center">
-<Anchor href="https://library.twilio.com/web/2f44a10496e4c83b/shared-illustrations/">
-Browse the illustration repository
-</Anchor>
-<LinkExternalIcon decorative={false} title="Opens an external resource" />
-</Flex>
-</Stack></Box>
+[Browse the illustration library](https://library.twilio.com/web/2f44a10496e4c83b/shared-illustrations). To login to the library with your Twilio credentials, you'll have to first request application access through IT via [ServiceNow](https://twilio.service-now.com) to "The Library (Bynder)".
 
 ### General guidelines for product UIs
 


### PR DESCRIPTION
- Add IT request instructions next to the link to the illustration library.
- Update external anchors to use showExternal prop

closes #1182 