### PR TITLE
fix(website): typos on Table and Menu pages

### DIFF
--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -159,7 +159,7 @@ Add separators between MenuGroups and other menu items.
 
 ### Choosing a menu trigger
 
-The `MenuButton` is the standard Paste [Button](/component/button) with some extra functionality. As a result it takes all the usual props the Paste Button takes, meaning you have full access to all the variants and styling options.
+The `MenuButton` is the standard Paste [Button](/components/button) with some extra functionality. As a result it takes all the usual props the Paste Button takes, meaning you have full access to all the variants and styling options.
 
 For example, you can create an icon button menu trigger like so:
 

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -208,21 +208,21 @@ The Fixed Table variant sets equal column widths for the table.
   </THead>
   <TBody>
     <Tr>
-      <Th scrope="row">Adam Brown</Th>
+      <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
         <Text as="span" fontFamily="fontFamilyCode">35</Text>
       </Td>
     </Tr>
     <Tr>
-      <Th scrope="row">Adriana Lovelock</Th>
+      <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
         <Text as="span" fontFamily="fontFamilyCode">28</Text>
       </Td>
     </Tr>
     <Tr>
-      <Th scrope="row">Amanda Cutlack</Th>
+      <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
         <Text as="span" fontFamily="fontFamilyCode">7</Text>
@@ -343,19 +343,19 @@ Table rows (`Tr`) can be set with either top, middle, or bottom vertical alignme
   </THead>
   <TBody>
     <Tr verticalAlign="top">
-      <Th scrope="row">Chinua Achebe</Th>
+      <Th scope="row">Chinua Achebe</Th>
       <Td>The impatient idealist says: ‘Give me a place to stand and I shall move the earth.' But such a place does not exist. We all have to stand on the earth itself and go with her at her pace.</Td>
     </Tr>
     <Tr verticalAlign="middle">
-      <Th scrope="row">James Baldwin</Th>
+      <Th scope="row">James Baldwin</Th>
       <Td>Anyone who has ever struggled with poverty knows how extremely expensive it is to be poor.</Td>
     </Tr>
     <Tr verticalAlign="middle">
-      <Th scrope="row">Dorothy West</Th>
+      <Th scope="row">Dorothy West</Th>
       <Td>To know how much there is to know is the beginning of learning to live.</Td>
     </Tr>
     <Tr verticalAlign="bottom">
-      <Th scrope="row">W.E.B. Du Bois</Th>
+      <Th scope="row">W.E.B. Du Bois</Th>
       <Td>Herein lies the tragedy of the age: not that men are poor—all men know something of poverty; not that men are wicked—who is good? Not that men are ignorant—what is truth? Nay, but that men know so little of men.</Td>
     </Tr>
   </TBody>
@@ -380,21 +380,21 @@ turned off by setting `variant="borderless"` on `Table`.
     </THead>
     <TBody>
       <Tr>
-        <Th scrope="row">Adam Brown</Th>
+        <Th scope="row">Adam Brown</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
           <Text as="span" fontFamily="fontFamilyCode">35</Text>
         </Td>
       </Tr>
       <Tr>
-        <Th scrope="row">Adriana Lovelock</Th>
+        <Th scope="row">Adriana Lovelock</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
           <Text as="span" fontFamily="fontFamilyCode">28</Text>
         </Td>
       </Tr>
       <Tr>
-        <Th scrope="row">Amanda Cutlack</Th>
+        <Th scope="row">Amanda Cutlack</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
           <Text as="span" fontFamily="fontFamilyCode">7</Text>


### PR DESCRIPTION
- Table examples: `<Th scrope="row">` --> `<Th scope="row">`
- Menu: fix Button URL (closes #1199 )