### PR TITLE
chore(website): remove code style from numeric Table examples

### DIFF
--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -211,21 +211,21 @@ The Fixed Table variant sets equal column widths for the table.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">35</Text>
+        35
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">28</Text>
+        28
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">7</Text>
+        7
       </Td>
     </Tr>
   </TBody>
@@ -234,7 +234,7 @@ The Fixed Table variant sets equal column widths for the table.
       <Td/>
       <Td/>
       <Td textAlign="right">
-        <Text as="span">70</Text>
+        70
       </Td>
     </Tr>
   </TFoot>
@@ -383,21 +383,21 @@ turned off by setting `variant="borderless"` on `Table`.
         <Th scope="row">Adam Brown</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span">35</Text>
+          35
         </Td>
       </Tr>
       <Tr>
         <Th scope="row">Adriana Lovelock</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span">28</Text>
+          28
         </Td>
       </Tr>
       <Tr>
         <Th scope="row">Amanda Cutlack</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span">7</Text>
+          7
         </Td>
       </Tr>
     </TBody>
@@ -406,7 +406,7 @@ turned off by setting `variant="borderless"` on `Table`.
         <Td/>
         <Td/>
         <Td textAlign="right">
-          <Text as="span">70</Text>
+          70
         </Td>
       </Tr>
     </TFoot>
@@ -490,21 +490,21 @@ rather than using the `TFoot`.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">35</Text>
+        35
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">28</Text>
+        28
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">7</Text>
+        7
       </Td>
     </Tr>
   </TBody>
@@ -513,7 +513,7 @@ rather than using the `TFoot`.
       <Th scope="row">Total tasks</Th>
       <Td/>
       <Td textAlign="right">
-        <Text as="span">70</Text>
+        70
       </Td>
     </Tr>
   </TFoot>
@@ -574,21 +574,21 @@ setting `striped` on `Table`.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">35</Text>
+        35
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">28</Text>
+        28
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">7</Text>
+        7
       </Td>
     </Tr>
   </TBody>
@@ -597,7 +597,7 @@ setting `striped` on `Table`.
       <Th scope="row">Total tasks</Th>
       <Td/>
       <Td textAlign="right">
-        <Text as="span">70</Text>
+        70
       </Td>
     </Tr>
   </TFoot>
@@ -638,7 +638,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">35</Text>
+        35
       </Td>
     </Tr>
     <Tr>
@@ -650,7 +650,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">28</Text>
+        28
       </Td>
     </Tr>
     <Tr>
@@ -662,7 +662,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">7</Text>
+        7
       </Td>
     </Tr>
   </TBody>
@@ -698,7 +698,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">35</Text>
+        35
       </Td>
     </Tr>
     <Tr>
@@ -715,7 +715,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">28</Text>
+        28
       </Td>
     </Tr>
     <Tr>
@@ -732,7 +732,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span">7</Text>
+        7</Text>
       </Td>
     </Tr>
   </TBody>

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -210,32 +210,24 @@ The Fixed Table variant sets equal column widths for the table.
     <Tr>
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        35
-      </Td>
+      <Td textAlign="right">35</Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        28
-      </Td>
+      <Td textAlign="right">28</Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        7
-      </Td>
+      <Td textAlign="right">7</Td>
     </Tr>
   </TBody>
   <TFoot>
     <Tr>
       <Td/>
       <Td/>
-      <Td textAlign="right">
-        70
-      </Td>
+      <Td textAlign="right">70</Td>
     </Tr>
   </TFoot>
 </Table>`}
@@ -382,32 +374,24 @@ turned off by setting `variant="borderless"` on `Table`.
       <Tr>
         <Th scope="row">Adam Brown</Th>
         <Td>English, French, Sales, Spanish</Td>
-        <Td textAlign="right">
-          35
-        </Td>
+        <Td textAlign="right">35</Td>
       </Tr>
       <Tr>
         <Th scope="row">Adriana Lovelock</Th>
         <Td>English, French, Sales, Spanish</Td>
-        <Td textAlign="right">
-          28
-        </Td>
+        <Td textAlign="right">28</Td>
       </Tr>
       <Tr>
         <Th scope="row">Amanda Cutlack</Th>
         <Td>English, French, Sales, Spanish</Td>
-        <Td textAlign="right">
-          7
-        </Td>
+        <Td textAlign="right">7</Td>
       </Tr>
     </TBody>
     <TFoot>
       <Tr>
         <Td/>
         <Td/>
-        <Td textAlign="right">
-          70
-        </Td>
+        <Td textAlign="right">70</Td>
       </Tr>
     </TFoot>
   </Table>
@@ -489,32 +473,24 @@ rather than using the `TFoot`.
     <Tr>
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        35
-      </Td>
+      <Td textAlign="right">35</Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        28
-      </Td>
+      <Td textAlign="right">28</Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        7
-      </Td>
+      <Td textAlign="right">7</Td>
     </Tr>
   </TBody>
   <TFoot>
     <Tr>
       <Th scope="row">Total tasks</Th>
       <Td/>
-      <Td textAlign="right">
-        70
-      </Td>
+      <Td textAlign="right">70</Td>
     </Tr>
   </TFoot>
 </Table>`}
@@ -573,32 +549,24 @@ setting `striped` on `Table`.
     <Tr>
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        35
-      </Td>
+      <Td textAlign="right">35</Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        28
-      </Td>
+      <Td textAlign="right">28</Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        7
-      </Td>
+      <Td textAlign="right">7</Td>
     </Tr>
   </TBody>
   <TFoot>
     <Tr>
       <Th scope="row">Total tasks</Th>
       <Td/>
-      <Td textAlign="right">
-        70
-      </Td>
+      <Td textAlign="right">70</Td>
     </Tr>
   </TFoot>
 </Table>`}
@@ -637,9 +605,7 @@ understand data in an individual row.
         <Text as="p" color="colorTextWeak" fontWeight="fontWeightNormal">adam@brown.com</Text>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        35
-      </Td>
+      <Td textAlign="right">35</Td>
     </Tr>
     <Tr>
       <Th scope="row">
@@ -649,9 +615,7 @@ understand data in an individual row.
         <Text as="p" color="colorTextWeak" fontWeight="fontWeightNormal">adriana@lovelock.com</Text>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        28
-      </Td>
+      <Td textAlign="right">28</Td>
     </Tr>
     <Tr>
       <Th scope="row">
@@ -661,9 +625,7 @@ understand data in an individual row.
         <Text as="p" color="colorTextWeak" fontWeight="fontWeightNormal">amanda@cutlack.com</Text>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        7
-      </Td>
+      <Td textAlign="right">7</Td>
     </Tr>
   </TBody>
 </Table>`}
@@ -697,9 +659,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
         </Stack>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        35
-      </Td>
+      <Td textAlign="right">35</Td>
     </Tr>
     <Tr>
       <Th scope="row">
@@ -714,9 +674,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
         </Stack>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        28
-      </Td>
+      <Td textAlign="right">28</Td>
     </Tr>
     <Tr>
       <Th scope="row">
@@ -731,9 +689,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
         </Stack>
       </Th>
       <Td>English, French, Sales, Spanish</Td>
-      <Td textAlign="right">
-        7</Text>
-      </Td>
+      <Td textAlign="right">7</Td>
     </Tr>
   </TBody>
 </Table>`}

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -211,21 +211,21 @@ The Fixed Table variant sets equal column widths for the table.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">35</Text>
+        <Text as="span">35</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">28</Text>
+        <Text as="span">28</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">7</Text>
+        <Text as="span">7</Text>
       </Td>
     </Tr>
   </TBody>
@@ -234,7 +234,7 @@ The Fixed Table variant sets equal column widths for the table.
       <Td/>
       <Td/>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">70</Text>
+        <Text as="span">70</Text>
       </Td>
     </Tr>
   </TFoot>
@@ -383,21 +383,21 @@ turned off by setting `variant="borderless"` on `Table`.
         <Th scope="row">Adam Brown</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span" fontFamily="fontFamilyCode">35</Text>
+          <Text as="span">35</Text>
         </Td>
       </Tr>
       <Tr>
         <Th scope="row">Adriana Lovelock</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span" fontFamily="fontFamilyCode">28</Text>
+          <Text as="span">28</Text>
         </Td>
       </Tr>
       <Tr>
         <Th scope="row">Amanda Cutlack</Th>
         <Td>English, French, Sales, Spanish</Td>
         <Td textAlign="right">
-          <Text as="span" fontFamily="fontFamilyCode">7</Text>
+          <Text as="span">7</Text>
         </Td>
       </Tr>
     </TBody>
@@ -406,7 +406,7 @@ turned off by setting `variant="borderless"` on `Table`.
         <Td/>
         <Td/>
         <Td textAlign="right">
-          <Text as="span" fontFamily="fontFamilyCode">70</Text>
+          <Text as="span">70</Text>
         </Td>
       </Tr>
     </TFoot>
@@ -490,21 +490,21 @@ rather than using the `TFoot`.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">35</Text>
+        <Text as="span">35</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">28</Text>
+        <Text as="span">28</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">7</Text>
+        <Text as="span">7</Text>
       </Td>
     </Tr>
   </TBody>
@@ -513,7 +513,7 @@ rather than using the `TFoot`.
       <Th scope="row">Total tasks</Th>
       <Td/>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">70</Text>
+        <Text as="span">70</Text>
       </Td>
     </Tr>
   </TFoot>
@@ -574,21 +574,21 @@ setting `striped` on `Table`.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">35</Text>
+        <Text as="span">35</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">28</Text>
+        <Text as="span">28</Text>
       </Td>
     </Tr>
     <Tr>
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">7</Text>
+        <Text as="span">7</Text>
       </Td>
     </Tr>
   </TBody>
@@ -597,7 +597,7 @@ setting `striped` on `Table`.
       <Th scope="row">Total tasks</Th>
       <Td/>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">70</Text>
+        <Text as="span">70</Text>
       </Td>
     </Tr>
   </TFoot>
@@ -638,7 +638,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">35</Text>
+        <Text as="span">35</Text>
       </Td>
     </Tr>
     <Tr>
@@ -650,7 +650,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">28</Text>
+        <Text as="span">28</Text>
       </Td>
     </Tr>
     <Tr>
@@ -662,7 +662,7 @@ understand data in an individual row.
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">7</Text>
+        <Text as="span">7</Text>
       </Td>
     </Tr>
   </TBody>
@@ -698,7 +698,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">35</Text>
+        <Text as="span">35</Text>
       </Td>
     </Tr>
     <Tr>
@@ -715,7 +715,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">28</Text>
+        <Text as="span">28</Text>
       </Td>
     </Tr>
     <Tr>
@@ -732,7 +732,7 @@ You can put an avatar next to a user's first and last name using `Stack` inside 
       </Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td textAlign="right">
-        <Text as="span" fontFamily="fontFamilyCode">7</Text>
+        <Text as="span">7</Text>
       </Td>
     </Tr>
   </TBody>


### PR DESCRIPTION
Removed font-family-code style from some Table examples so folks don't take that as the recommendation for showing numbers in a table (since Inter has monospace numbers already).