### PR TITLE
fix(box): add datetime typing

### DIFF
--- a/.changeset/brave-starfishes-agree.md
+++ b/.changeset/brave-starfishes-agree.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/box': patch
+---
+
+Added 'datetime' prop Typescript typing to Box

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -109,6 +109,7 @@ export interface BoxElementProps extends Omit<React.HTMLAttributes<HTMLElement>,
   multiple?: boolean;
   // optgroup props
   label?: string;
+  datetime?: string;
 }
 
 export interface BoxProps extends BoxElementProps, BoxStyleProps {}


### PR DESCRIPTION
Adds missing datetime prop typing to box as per https://github.com/twilio-labs/paste/discussions/661