### PR TITLE
feat(website): update status on the displaying progress pattern

### DIFF
--- a/packages/paste-website/src/pages/patterns/index.mdx
+++ b/packages/paste-website/src/pages/patterns/index.mdx
@@ -244,9 +244,9 @@ There are two primary goals of patterns:
               <Td>Open for contribution</Td>
             </Tr>
             <Tr>
-              <Td>Display progress</Td>
+              <Td>Displaying progress</Td>
               <Td>How to display progress through a multi-step flow.</Td>
-              <Td>Open for contribution</Td>
+              <Td><strong>In progress</strong></Td>
             </Tr>
             <Tr>
               <Td>Country flags</Td>
@@ -297,8 +297,8 @@ There are two primary goals of patterns:
               <Td>Open for contribution</Td>
             </Tr>
             <Tr>
-              <Td>Export/Import/Download/Upload</Td>
-              <Td>how to move a file into or out of Twilio.</Td>
+              <Td>Data export</Td>
+              <Td>How to move a file or dataset out of Twilio.</Td>
               <Td><strong>In progress</strong></Td>
             </Tr>
           </TBody>


### PR DESCRIPTION
- Updated the status on the "Displaying progress" pattern to "In progress". @ishah-twilio, @ang-twilio, @mindytom, @charleneyjh1, and @mjanssen2021 have started taking on this work.
- Made the data download/upload pattern name a bit more concise ("Data export"). We'll update it if the pattern eventually includes importing/uploading actions, too.