### PR TITLE
fix(button): improve Button handling of link behavior

### DIFF
--- a/.changeset/moody-pianos-poke.md
+++ b/.changeset/moody-pianos-poke.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/button': major
+---
+
+Button components used as links (as="a" and href="") now automatically add an arrow icon if children is a string. This change also adds additional validation to throw an error if the `disabled` or `loading` props are set to `true` for a Button as link.

--- a/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -304,6 +304,8 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
           fontFamily="fontFamilyText"
           fontWeight="fontWeightSemibold"
           onClick={[MockFunction]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           textDecoration="none"
           type="button"
           width="auto"
@@ -653,6 +655,8 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
           fontFamily="fontFamilyText"
           fontWeight="fontWeightSemibold"
           onClick={[MockFunction]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           textDecoration="none"
           type="button"
           width="auto"
@@ -1002,6 +1006,8 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
           fontFamily="fontFamilyText"
           fontWeight="fontWeightSemibold"
           onClick={[MockFunction]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           textDecoration="none"
           type="button"
           width="auto"

--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -160,6 +160,55 @@ describe('Button Errors', () => {
         </Button>
       )
     ).toThrow();
+    expect(() =>
+      shallow(
+        <Button as="a" variant="inverse_link" href={HREF}>
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
+  });
+
+  it('Throws an error when an "a" tag is passed but not using correct variant', () => {
+    expect(() =>
+      shallow(
+        <Button as="a" href="#" variant="destructive">
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
+    expect(() =>
+      shallow(
+        <Button as="a" href="#" variant="destructive_secondary">
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
+    expect(() =>
+      shallow(
+        <Button as="a" href="#" variant="inverse">
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
+  });
+
+  it('Throws an error when an "a" tag is passed with disabled or loading state', () => {
+    expect(() =>
+      shallow(
+        <Button as="a" href="#" variant="primary" disabled>
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
+
+    expect(() =>
+      shallow(
+        <Button as="a" href="#" variant="primary" loading>
+          Go to Paste
+        </Button>
+      )
+    ).toThrow();
   });
 
   it('Throws an error when size=reset is not applied to variant=reset', () => {

--- a/packages/paste-core/components/button/package.json
+++ b/packages/paste-core/components/button/package.json
@@ -28,6 +28,8 @@
     "lodash.merge": "^4.6.2"
   },
   "peerDependencies": {
+    "@twilio-paste/anchor": "^5.0.1",
+    "@twilio-paste/animation-library": "^0.3.1",
     "@twilio-paste/box": "4.0.2",
     "@twilio-paste/design-tokens": "6.6.0",
     "@twilio-paste/icons": "5.1.1",
@@ -43,6 +45,8 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@twilio-paste/anchor": "^5.0.1",
+    "@twilio-paste/animation-library": "^0.3.1",
     "@twilio-paste/box": "4.0.2",
     "@twilio-paste/design-tokens": "6.6.0",
     "@twilio-paste/icons": "5.1.1",

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -128,3 +128,33 @@ export const Reset = (): React.ReactNode => (
     </Heading>
   </>
 );
+export const ButtonAsAnchor = (): React.ReactNode => {
+  return (
+    <>
+      <Box padding="space30">
+        <Button as="a" href="https://twilio.com" variant="primary">
+          Automatically adds link icon
+        </Button>
+      </Box>
+      <Box padding="space30">
+        <Button as="a" href="https://twilio.com" variant="secondary">
+          Automatically adds link icon
+        </Button>
+      </Box>
+      <Box padding="space30">
+        <Button as="a" href="https://twilio.com" variant="reset">
+          Not added on reset variant
+        </Button>
+      </Box>
+
+      <Box padding="space30">
+        <Button as="a" href="https://twilio.com" variant="primary">
+          Not added when children{' '}
+          <em>
+            <u>is not string type</u>
+          </em>
+        </Button>
+      </Box>
+    </>
+  );
+};


### PR DESCRIPTION
- [x] The Button component now displays an animated arrow icon by default for Buttons with props `as="a" href="string"` where `children` is a string. It doesn't add an icon if `children` is not a string type.
  - [x] Only adds icon to  variant `primary` `secondary`. Not to `reset`
- [x] Added similar functionality to Anchor component to handle external links correctly. 
- [x] Added more validation errors and tests for these throws.
  - [x] Throws if link button is disabled or loading
  - [x] Throws if link button isnt of variant `primary` `secondary` or `reset`
  - [x] Throws to inform to use anchor component if `as="a"` and `variant="link"` or `variant="inverse_link`   
- [x] Added stories  