### PR TITLE
fix(avatar): make size optional and have default size

### DIFF
--- a/.changeset/twenty-parrots-care.md
+++ b/.changeset/twenty-parrots-care.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/avatar': patch
+'@twilio-paste/core': patch
+---
+
+Avatar: fixed size prop to make it optional and have a default of icon-size-70.

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -6,7 +6,9 @@ import {isIconSizeTokenProp} from '@twilio-paste/style-props';
 import {getComputedTokenNames, getInitialsFromName} from './utils';
 import type {AvatarProps} from './types';
 
-const AvatarContents: React.FC<AvatarProps> = ({name, size, src, icon: Icon}) => {
+const DEFAULT_SIZE = 'sizeIcon70';
+
+const AvatarContents: React.FC<AvatarProps> = ({name, size = DEFAULT_SIZE, src, icon: Icon}) => {
   const computedTokenNames = getComputedTokenNames(size);
   if (Icon != null) {
     if (typeof Icon !== 'function' || typeof Icon.displayName !== 'string' || !Icon.displayName.includes('Icon')) {
@@ -38,7 +40,7 @@ const AvatarContents: React.FC<AvatarProps> = ({name, size, src, icon: Icon}) =>
 };
 
 const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
-  ({name, children, size = 'sizeIcon70', src, icon, ...props}, ref) => {
+  ({name, children, size = DEFAULT_SIZE, src, icon, ...props}, ref) => {
     if (name === undefined) {
       console.error('[Paste Avatar]: name prop is required');
     }

--- a/packages/paste-core/components/avatar/src/types.ts
+++ b/packages/paste-core/components/avatar/src/types.ts
@@ -3,7 +3,7 @@ import type {GenericIconProps} from '@twilio-paste/icons/esm/types';
 
 export interface AvatarProps extends React.HTMLAttributes<'div'> {
   name: string;
-  size: IconSize;
+  size?: IconSize;
   src?: string;
   icon?: React.FC<GenericIconProps>;
 }


### PR DESCRIPTION
- Fixed the size prop to make it optional
- Created a default variable for the size's default value to use in Avatar and AvatarContents components.