### PR TITLE
chore: configure netlify next support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ packages/paste-website/public
 
 # next.js build output
 .next
+out/
 
 # Apple gunk
 .DS_Store

--- a/packages/paste-theme-designer/package.json
+++ b/packages/paste-theme-designer/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && next export",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
Netlify next build plugin requires next v10.0.6, but we use 10.0.4.

If I upgrade some weird error occurs on build and refresh of pages in dev mode. I've spent half a day trying to figure it out, but as we don't rely on SSR we can safely just statically export the site for hosting purposes.

We can address the build issues later when we start working on it again.