### PR TITLE
chore: escape component from changelog using markdown backticks

### DIFF
--- a/.changeset/happy-phones-bow.md
+++ b/.changeset/happy-phones-bow.md
@@ -3,4 +3,4 @@
 '@twilio-paste/core': patch
 ---
 
-Buttons that behave as links (<Button as="a" href="">) now correctly use the external link icon for external links.
+Buttons that behave as links (`<Button as="a" href="">`) now correctly use the external link icon for external links.


### PR DESCRIPTION
Having an unescaped component in markdown means it doesn't render in the GitHub UI and breaks our website when we try to render it.

Escaping it with backticks should solve for this.
