### PR TITLE
chore(avatar): allow for only icon OR src prop

### DIFF
--- a/.changeset/fifty-roses-brake.md
+++ b/.changeset/fifty-roses-brake.md
@@ -1,0 +1,7 @@
+---
+'@twilio-paste/avatar': patch
+'@twilio-paste/website': patch
+'@twilio-paste/core': patch
+---
+
+Restricted Avatar propTypes so that users cannot add both `src` and `icon` props to Avatar, only one or the other.

--- a/.changeset/fifty-roses-brake.md
+++ b/.changeset/fifty-roses-brake.md
@@ -1,6 +1,5 @@
 ---
 '@twilio-paste/avatar': patch
-'@twilio-paste/website': patch
 '@twilio-paste/core': patch
 ---
 

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -44,6 +44,11 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
     if (name === undefined) {
       console.error('[Paste Avatar]: name prop is required');
     }
+    if (src && icon) {
+      console.error('[Paste Avatar]: do not set both src and icon on Avatar');
+      return null;
+    }
+    console.log(src, icon);
 
     return (
       <Box
@@ -55,18 +60,31 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         ref={ref}
         size={size}
       >
-        <AvatarContents name={name} size={size} src={src} icon={icon} {...props} />
+        {src ? (
+          <AvatarContents name={name} size={size} src={src} {...props} />
+        ) : (
+          <AvatarContents name={name} size={size} icon={icon} {...props} />
+        )}
       </Box>
     );
   }
 );
 
 Avatar.displayName = 'Avatar';
+
 Avatar.propTypes = {
   size: isIconSizeTokenProp,
-  src: PropTypes.string,
   name: PropTypes.string.isRequired,
-  icon: PropTypes.func,
+  src: function (props) {
+    if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
+    if (typeof props.src !== 'string') new Error('[Paste Avatar]: src prop must be a string');
+    return props.src;
+  },
+  icon: function (props) {
+    if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
+    if (typeof props.icon !== 'function') new Error('[Paste Avatar]: icon prop must be a Paste Icon');
+    return props.icon;
+  },
 };
 
 export {Avatar};

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -48,7 +48,6 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       console.error('[Paste Avatar]: do not set both src and icon on Avatar');
       return null;
     }
-    console.log(src, icon);
 
     return (
       <Box
@@ -75,15 +74,19 @@ Avatar.displayName = 'Avatar';
 Avatar.propTypes = {
   size: isIconSizeTokenProp,
   name: PropTypes.string.isRequired,
-  src: function (props) {
+  src: (props) => {
+    // eslint-disable-next-line no-new
     if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
+    // eslint-disable-next-line no-new
     if (typeof props.src !== 'string') new Error('[Paste Avatar]: src prop must be a string');
-    return props.src;
+    return null;
   },
-  icon: function (props) {
+  icon: (props) => {
+    // eslint-disable-next-line no-new
     if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
+    // eslint-disable-next-line no-new
     if (typeof props.icon !== 'function') new Error('[Paste Avatar]: icon prop must be a Paste Icon');
-    return props.icon;
+    return null;
   },
 };
 

--- a/packages/paste-core/components/avatar/src/types.ts
+++ b/packages/paste-core/components/avatar/src/types.ts
@@ -1,9 +1,17 @@
 import type {IconSize} from '@twilio-paste/style-props';
 import type {GenericIconProps} from '@twilio-paste/icons/esm/types';
 
-export interface AvatarProps extends React.HTMLAttributes<'div'> {
-  name: string;
-  size?: IconSize;
+type AvatarImage = {
   src?: string;
+  icon?: never;
+};
+type AvatarIcon = {
+  src?: never;
   icon?: React.FC<GenericIconProps>;
-}
+};
+
+export type AvatarProps = React.HTMLAttributes<'div'> &
+  (AvatarImage | AvatarIcon) & {
+    name: string;
+    size?: IconSize;
+  };

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -115,6 +115,11 @@ Provide the Avatar with a `name` and the component will render the initials as t
 
 Provide the Avatar with a source path via the `src` prop to render the Avatar as an image. The `src` prop acts just like an `img` tag. You **must** still provide a `name` prop.
 
+<Callout>
+  <CalloutTitle>A note about Avatar contents</CalloutTitle>
+  <CalloutText>The Avatar component can either display an image or an icon, but not both.</CalloutText>
+</Callout>
+
 <LivePreview
   scope={{
     Avatar,
@@ -137,6 +142,11 @@ Provide the Avatar with a source path via the `src` prop to render the Avatar as
 ### Representing an entity via an icon
 
 Provide the Avatar with an `icon` prop to display an icon. You must import the icon before passing it to the `icon` prop. You **must** still provide a `name` prop. The icon must be a <a href="https://paste.twilio.design/icons/">Paste Icon</a>.
+
+<Callout>
+  <CalloutTitle>A note about Avatar contents</CalloutTitle>
+  <CalloutText>The Avatar component can either display an image or an icon, but not both.</CalloutText>
+</Callout>
 
 <LivePreview
   scope={{
@@ -232,8 +242,6 @@ const AvatarExample = () => {
   return <Avatar size="sizeIcon10" name="Aayush Iyer" />;
 };
 ```
-
-**Note:** The Avatar component will display the `icon` if both the `icon` and `src` props are passed.
 
 #### Props
 


### PR DESCRIPTION
- Added union type to AvatarProps to only allow for either `src` OR `icon` prop
- Added check for presence of both `src` AND `icon` to catch javascript users
- Fixed Avatar.propTypes and <AvatarContents /> to satisfy typescript
- Updated docs to reflect changes

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
