### PR TITLE
fix(input): fixed the color of disabled input values

### DIFF
--- a/.changeset/itchy-countries-attend.md
+++ b/.changeset/itchy-countries-attend.md
@@ -1,0 +1,7 @@
+---
+'@twilio-paste/input': patch
+'@twilio-paste/textarea': patch
+'@twilio-paste/core': patch
+---
+
+Fix disabled value color in Safari.

--- a/.changeset/many-flowers-jump.md
+++ b/.changeset/many-flowers-jump.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/styling-library': patch
+'@twilio-paste/core': patch
+---
+
+Added `-webkit-text-fill-color` and enable it to use Paste textColor token values.

--- a/packages/paste-core/components/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/index.stories.tsx
@@ -237,7 +237,15 @@ ComboboxErrorInverse.story = {
 };
 
 export const ComboboxDisabled = (): React.ReactNode => {
-  return <Combobox items={items} labelText="Choose a component:" helpText="This is the help text" disabled />;
+  return (
+    <Combobox
+      items={items}
+      labelText="Choose a component:"
+      helpText="This is the help text"
+      initialSelectedItem={items[2]}
+      disabled
+    />
+  );
 };
 
 ComboboxDisabled.story = {
@@ -251,6 +259,7 @@ export const ComboboxDisabledInverse = (): React.ReactNode => {
         items={items}
         labelText="Choose a component:"
         helpText="This is the help text"
+        initialSelectedItem={items[2]}
         disabled
         variant="inverse"
       />

--- a/packages/paste-core/components/input/__tests__/__snapshots__/input.test.tsx.snap
+++ b/packages/paste-core/components/input/__tests__/__snapshots__/input.test.tsx.snap
@@ -98,6 +98,8 @@ exports[`Input render should render 1`] = `
 .emotion-0:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 <div
@@ -193,6 +195,8 @@ exports[`Input render should render with disabled 1`] = `
 .emotion-0:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 .emotion-1 {
@@ -314,6 +318,8 @@ exports[`Input render should render with hasError 1`] = `
 .emotion-0:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 .emotion-1 {
@@ -460,6 +466,8 @@ exports[`Input render should render with prefix 1`] = `
 .emotion-1:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 .emotion-0 {
@@ -580,6 +588,8 @@ exports[`Input render should render with readOnly 1`] = `
 .emotion-0:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 .emotion-1 {
@@ -727,6 +737,8 @@ exports[`Input render should render with suffix 1`] = `
 .emotion-0:disabled {
   color: rgb(200,204,207);
   cursor: not-allowed;
+  -webkit-text-fill-color: rgb(200,204,207);
+  -webkit-opacity: 1;
 }
 
 .emotion-1 {

--- a/packages/paste-core/components/input/__tests__/input.test.tsx
+++ b/packages/paste-core/components/input/__tests__/input.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {matchers} from 'jest-emotion';
 import {render} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {Label} from '@twilio-paste/label';
@@ -7,6 +8,8 @@ import {HelpText} from '@twilio-paste/help-text';
 import axe from '../../../../../.jest/axe-helper';
 import {Input} from '../src';
 import type {InputTypes} from '../src';
+
+expect.extend(matchers);
 
 const NOOP = (): void => {};
 
@@ -124,6 +127,7 @@ describe('Input inner input props', () => {
 
   it('should set disabled correctly', () => {
     expect(InnerInput.getAttribute('disabled')).toEqual('');
+    expect(InnerInput).toHaveStyleRule('-webkit-text-fill-color', 'colorTextWeaker', {target: ':disabled'});
   });
 
   it('should set readOnly correctly', () => {

--- a/packages/paste-core/components/input/src/Input.tsx
+++ b/packages/paste-core/components/input/src/Input.tsx
@@ -67,6 +67,9 @@ export const InputElement = styled.input<InputProps>((props) =>
     '&:disabled': {
       color: props.variant === 'inverse' ? 'colorTextInverseWeaker' : 'colorTextWeaker',
       cursor: 'not-allowed',
+      // Fixes value color in Safari
+      '-webkit-text-fill-color': props.variant === 'inverse' ? 'colorTextInverseWeaker' : 'colorTextWeaker',
+      '-webkit-opacity': '1',
     },
   })
 );

--- a/packages/paste-core/components/input/stories/input.stories.tsx
+++ b/packages/paste-core/components/input/stories/input.stories.tsx
@@ -334,7 +334,7 @@ InputDisabled.story = {
 
 export const InputDisabledInverse = (): React.ReactNode => {
   const uid = useUID();
-  const [value, setValue] = React.useState('Input');
+  const [value, setValue] = React.useState('Input - Disabled');
   return (
     <Box backgroundColor="colorBackgroundBodyInverse" padding="space60">
       <Label htmlFor={uid} variant="inverse" disabled>

--- a/packages/paste-core/components/textarea/__tests__/textarea.test.tsx
+++ b/packages/paste-core/components/textarea/__tests__/textarea.test.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import {render} from 'react-dom';
+import {matchers} from 'jest-emotion';
 import {render as testRender, fireEvent} from '@testing-library/react';
 import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {TextArea} from '../src';
+
+expect.extend(matchers);
 
 const NOOP = (): void => {};
 
@@ -35,6 +38,7 @@ describe('TextArea render', () => {
   it('should render as disabled', () => {
     const {getByRole} = testRender(<TextArea {...initialProps} disabled />);
     expect(getByRole('textbox').getAttribute('disabled')).toEqual('');
+    expect(getByRole('textbox')).toHaveStyleRule('-webkit-text-fill-color', 'colorTextWeaker', {target: ':disabled'});
   });
 
   it('should render an id', () => {

--- a/packages/paste-core/components/textarea/src/TextArea.tsx
+++ b/packages/paste-core/components/textarea/src/TextArea.tsx
@@ -60,6 +60,9 @@ const TextAreaElement = styled(TextareaAutosize)<TextAreaProps>((props) =>
     '&:disabled': {
       color: props.variant === 'inverse' ? 'colorTextInverseWeaker' : 'colorTextWeaker',
       cursor: 'not-allowed',
+      // Fixes value color in Safari
+      '-webkit-text-fill-color': props.variant === 'inverse' ? 'colorTextInverseWeaker' : 'colorTextWeaker',
+      '-webkit-opacity': '1',
     },
   })
 );

--- a/packages/paste-core/components/textarea/stories/textarea.stories.tsx
+++ b/packages/paste-core/components/textarea/stories/textarea.stories.tsx
@@ -197,6 +197,7 @@ export const TextareaDisabled = (): React.ReactNode => {
       <TextArea
         id={uid}
         placeholder="Placeholder"
+        value="Disabled text content..."
         disabled
         onChange={action('handleFocus')}
         onFocus={action('handleFocus')}
@@ -221,6 +222,7 @@ export const TextareaDisabledInverse = (): React.ReactNode => {
       <TextArea
         id={uid}
         placeholder="Placeholder"
+        value="Disabled text content..."
         disabled
         onChange={action('handleFocus')}
         onFocus={action('handleFocus')}

--- a/packages/paste-libraries/styling/src/css-function/css.ts
+++ b/packages/paste-libraries/styling/src/css-function/css.ts
@@ -121,6 +121,8 @@ const scales = {
   maxHeight: 'sizes',
   flexBasis: 'sizes',
   size: 'sizes',
+  // safari overrides
+  '-webkit-text-fill-color': 'textColors',
   // svg
   fill: 'fillColors',
   stroke: 'strokeColors',


### PR DESCRIPTION
Fixes: https://github.com/twilio-labs/paste/issues/1305

- [x] Added `-webkit-text-fill-color` to css scales and enabled it to use `textColor` tokens
- [x] Fixed disabled `Input` value color
- [x] Fixed disabled `TextArea` value color
- [x] Adjusted disabled `Combobox` story to have an initial value for VRT