### PR TITLE
chore(website): filter out deprecated design tokens from list

### DIFF
--- a/.changeset/rich-poems-worry.md
+++ b/.changeset/rich-poems-worry.md
@@ -1,0 +1,8 @@
+---
+'@twilio-paste/box': patch
+'@twilio-paste/text': patch
+'@twilio-paste/style-props': patch
+'@twilio-paste/core': patch
+---
+
+Add the ability to warn consumers that they are using a deprecated Design Token using prop type validation on the Box and Text component

--- a/packages/paste-core/primitives/box/src/index.tsx
+++ b/packages/paste-core/primitives/box/src/index.tsx
@@ -22,6 +22,12 @@ import type {
   FlexboxProps,
   TypographyProps,
 } from '@twilio-paste/style-props';
+import {
+  isDeprecatedBackgroundColorTokenProp,
+  isDeprecatedBorderColorTokenProp,
+  isDeprecatedBoxShadowTokenProp,
+  isDeprecatedTextColorTokenProp,
+} from '@twilio-paste/style-props';
 import type {
   CursorProperty,
   AppearanceProperty,
@@ -216,5 +222,11 @@ export const Box = styled.div(
 ) as React.FC<BoxProps>;
 
 Box.displayName = 'Box';
+Box.propTypes = {
+  backgroundColor: isDeprecatedBackgroundColorTokenProp,
+  borderColor: isDeprecatedBorderColorTokenProp,
+  boxShadow: isDeprecatedBoxShadowTokenProp,
+  color: isDeprecatedTextColorTokenProp,
+};
 
 export * from './SafelySpreadProps';

--- a/packages/paste-core/primitives/text/src/index.tsx
+++ b/packages/paste-core/primitives/text/src/index.tsx
@@ -11,8 +11,8 @@ import {
   typography,
   verticalAlign,
 } from '@twilio-paste/styling-library';
-import {CursorProperty, OutlineProperty, TextTransformProperty, TransitionProperty} from 'csstype';
-import {
+import type {CursorProperty, OutlineProperty, TextTransformProperty, TransitionProperty} from 'csstype';
+import type {
   Display,
   OverflowProps,
   PositionProps,
@@ -21,6 +21,7 @@ import {
   TypographyProps,
   VerticalAlign,
 } from '@twilio-paste/style-props';
+import {isDeprecatedBoxShadowTokenProp, isDeprecatedTextColorTokenProp} from '@twilio-paste/style-props';
 import {PseudoPropStyles} from './PseudoPropStyles';
 
 export interface TextStyleProps extends OverflowProps, PositionProps, ShadowProps, SpaceProps, TypographyProps {
@@ -126,6 +127,11 @@ Text.defaultProps = {
   color: 'colorText',
   fontSize: 'fontSize30',
   lineHeight: 'lineHeight30',
+};
+
+Text.propTypes = {
+  boxShadow: isDeprecatedBoxShadowTokenProp,
+  color: isDeprecatedTextColorTokenProp,
 };
 
 export * from './SafelySpreadProps';

--- a/packages/paste-style-props/package.json
+++ b/packages/paste-style-props/package.json
@@ -23,7 +23,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "csstype": "^2.6.10"
+    "csstype": "^2.6.10",
+    "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {
     "@twilio-paste/design-tokens": "^6.6.0",

--- a/packages/paste-style-props/src/constants.ts
+++ b/packages/paste-style-props/src/constants.ts
@@ -1,0 +1,8 @@
+import * as RawJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
+
+const camelCase = require('lodash.camelcase');
+
+export const DEPRECATE_TOKENS = Object.values(RawJSON.props)
+  // @ts-ignore deprecated most definitely exists
+  .filter((token) => token.deprecated)
+  .map((deprecatedToken) => camelCase(deprecatedToken.name));

--- a/packages/paste-style-props/src/proptypes/background.ts
+++ b/packages/paste-style-props/src/proptypes/background.ts
@@ -1,7 +1,16 @@
 import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
+import {DEPRECATE_TOKENS} from '../constants';
 
 // Tokens
 const BackgroundColorOptions = ['none', 'transparent', ...Object.keys(DefaultTheme.backgroundColors)];
 
 export const isBackgroundColorTokenProp = propValidator(BackgroundColorOptions);
+export const isDeprecatedBackgroundColorTokenProp = (props: Record<string, unknown>): Error | null => {
+  if (props.backgroundColor != null && DEPRECATE_TOKENS.indexOf(props.backgroundColor) > 0) {
+    console.error(
+      `Paste: "${props.backgroundColor}" is a deprecated design token. It will be removed in the 2021.11.16 release of Paste`
+    );
+  }
+  return null;
+};

--- a/packages/paste-style-props/src/proptypes/border.ts
+++ b/packages/paste-style-props/src/proptypes/border.ts
@@ -1,5 +1,6 @@
 import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
+import {DEPRECATE_TOKENS} from '../constants';
 
 // Tokens
 const BorderRadiusOptions = Object.keys(DefaultTheme.radii);
@@ -9,3 +10,11 @@ const BorderColorOptions = ['transparent', ...Object.keys(DefaultTheme.borderCol
 export const isBorderRadiusTokenProp = propValidator(BorderRadiusOptions);
 export const isBorderWidthTokenProp = propValidator(BorderWidthOptions);
 export const isBorderColorTokenProp = propValidator(BorderColorOptions);
+export const isDeprecatedBorderColorTokenProp = (props: Record<string, unknown>): Error | null => {
+  if (props.borderColor != null && DEPRECATE_TOKENS.indexOf(props.borderColor) > 0) {
+    console.error(
+      `Paste: "${props.borderColor}" is a deprecated design token. It will be removed in the 2021.11.16 release of Paste`
+    );
+  }
+  return null;
+};

--- a/packages/paste-style-props/src/proptypes/index.ts
+++ b/packages/paste-style-props/src/proptypes/index.ts
@@ -1,5 +1,10 @@
-export {isBackgroundColorTokenProp} from './background';
-export {isBorderColorTokenProp, isBorderRadiusTokenProp, isBorderWidthTokenProp} from './border';
+export {isBackgroundColorTokenProp, isDeprecatedBackgroundColorTokenProp} from './background';
+export {
+  isBorderColorTokenProp,
+  isDeprecatedBorderColorTokenProp,
+  isBorderRadiusTokenProp,
+  isBorderWidthTokenProp,
+} from './border';
 export {
   isHeightTokenProp,
   isMaxHeightTokenProp,
@@ -10,7 +15,7 @@ export {
   isIconSizeTokenProp,
 } from './layout';
 export {isZIndexTokenProp} from './position';
-export {isBoxShadowTokenProp} from './shadow';
+export {isBoxShadowTokenProp, isDeprecatedBoxShadowTokenProp} from './shadow';
 export {isSpaceTokenProp, isMarginTokenProp, isPaddingTokenProp} from './space';
 export {
   isFontFamilyTokenProp,
@@ -18,6 +23,7 @@ export {
   isFontWeightTokenProp,
   isLineHeightTokenProp,
   isTextColorTokenProp,
+  isDeprecatedTextColorTokenProp,
 } from './typography';
 export {StyleResetProp} from './helpers';
 export {ResponsiveProp} from './utils/responsivePropValidator';

--- a/packages/paste-style-props/src/proptypes/shadow.ts
+++ b/packages/paste-style-props/src/proptypes/shadow.ts
@@ -1,7 +1,16 @@
 import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
+import {DEPRECATE_TOKENS} from '../constants';
 
 // Tokens
 const BoxShadowOptions = ['none', ...Object.keys(DefaultTheme.shadows)];
 
 export const isBoxShadowTokenProp = propValidator(BoxShadowOptions);
+export const isDeprecatedBoxShadowTokenProp = (props: Record<string, unknown>): Error | null => {
+  if (props.boxShadow != null && DEPRECATE_TOKENS.indexOf(props.boxShadow) > 0) {
+    console.error(
+      `Paste: "${props.boxShadow}" is a deprecated design token. It will be removed in the 2021.11.16 release of Paste`
+    );
+  }
+  return null;
+};

--- a/packages/paste-style-props/src/proptypes/typography.ts
+++ b/packages/paste-style-props/src/proptypes/typography.ts
@@ -1,5 +1,6 @@
 import {DefaultTheme} from '@twilio-paste/theme';
 import {propValidator} from './utils/propValidator';
+import {DEPRECATE_TOKENS} from '../constants';
 
 // Tokens
 const FontFamilyOptions = ['inherit', ...Object.keys(DefaultTheme.fonts)];
@@ -13,3 +14,11 @@ export const isFontSizeTokenProp = propValidator(FontSizeOptions);
 export const isFontWeightTokenProp = propValidator(FontWeightOptions);
 export const isLineHeightTokenProp = propValidator(LineHeightOptions);
 export const isTextColorTokenProp = propValidator(TextColorOptions);
+export const isDeprecatedTextColorTokenProp = (props: Record<string, unknown>): Error | null => {
+  if (props.color != null && DEPRECATE_TOKENS.indexOf(props.color) > 0) {
+    console.error(
+      `Paste: "${props.color}" is a deprecated design token. It will be removed in the 2021.11.16 release of Paste`
+    );
+  }
+  return null;
+};

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -8,7 +8,6 @@ import {useUID} from '@twilio-paste/uid-library';
 import {InlineCode} from '../Typography';
 import {AnchoredHeading} from '../Heading';
 import {Callout, CalloutTitle, CalloutText} from '../callout';
-import {SiteLink} from '../SiteLink';
 import {TokenExample} from './TokensExample';
 import {getTokenValue} from './getTokenValue';
 
@@ -27,6 +26,7 @@ interface Token {
   comment: string;
   category: string;
   type: string;
+  deprecated: boolean;
 }
 
 interface TokenCategory {
@@ -43,27 +43,16 @@ interface TokensShape {
 
 interface TokensListProps {
   children?: React.ReactElement;
-  consoleTokens: TokensShape[];
-  sendgridTokens: TokensShape[];
   defaultTokens: TokensShape[];
 }
 
-const getTokensByTheme = (props: TokensListProps): TokenCategory[] => {
-  const font = props.defaultTokens[0].node.tokens.find((ele) => ele.categoryName === 'fonts');
-  if (font) {
-    font.info = (
-      <Callout>
-        <CalloutTitle as="h4">Heads up about fonts in Paste!</CalloutTitle>
-        <CalloutText>
-          Paste leaves it up to you to load the fonts needed for the theme you&apos;ve selected. Console uses Whitney
-          ScreenSmart and SendGrid uses Colfax. Checkout the{' '}
-          <SiteLink to="/getting-started/engineering/#how-to-load-the-right-font">font section</SiteLink> in the getting
-          started guide for more details.
-        </CalloutText>
-      </Callout>
-    );
-  }
+const filterDeprecatedTokens = (tokens: TokenCategory[]): TokenCategory[] => {
+  return tokens.map((category) => {
+    return {...category, tokens: [...category.tokens.filter((token) => !token.deprecated)]};
+  });
+};
 
+const getTokensByTheme = (props: TokensListProps): TokenCategory[] => {
   const fontSize = props.defaultTokens[0].node.tokens.find((ele) => ele.categoryName === 'font-sizes');
   if (fontSize) {
     fontSize.info = (
@@ -81,8 +70,7 @@ const getTokensByTheme = (props: TokensListProps): TokenCategory[] => {
   let tokens = [] as TokenCategory[];
 
   if (props.defaultTokens != null) {
-    // eslint-disable-next-line prefer-destructuring
-    tokens = props.defaultTokens[0].node.tokens;
+    tokens = filterDeprecatedTokens(props.defaultTokens[0].node.tokens);
   }
 
   return tokens;

--- a/packages/paste-website/src/pages/tokens/index.mdx
+++ b/packages/paste-website/src/pages/tokens/index.mdx
@@ -41,11 +41,7 @@ In Paste, **1 rem unit = 16 pixels**.
   </Paragraph>
 </Box>
 
-<TokensList
-  defaultTokens={props.data.allPasteTokenDefault.edges}
-  consoleTokens={props.data.allPasteTokenConsole.edges}
-  sendgridTokens={props.data.allPasteTokenSendGrid.edges}
-/>
+<TokensList defaultTokens={props.data.allPasteTokenDefault.edges} />
 
 export const pageQuery = graphql`
   {
@@ -62,42 +58,7 @@ export const pageQuery = graphql`
               originalValue
               type
               value
-            }
-          }
-        }
-      }
-    }
-    allPasteTokenSendGrid {
-      edges {
-        node {
-          id
-          tokens {
-            categoryName
-            tokens {
-              category
-              comment
-              name
-              originalValue
-              type
-              value
-            }
-          }
-        }
-      }
-    }
-    allPasteTokenConsole {
-      edges {
-        node {
-          id
-          tokens {
-            categoryName
-            tokens {
-              category
-              comment
-              name
-              originalValue
-              type
-              value
+              deprecated
             }
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "newLine": "lf",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true
   },
   "include": ["packages/**/*"],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -20218,6 +20218,11 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.clonedeep@4.5.0, lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"


### PR DESCRIPTION
Filter out the deprecated design tokens from the list page.

- I tried doing this by filtering the GraphQL so I wouldn't have to do this, but for whatever reason I just can't get it to filter the date

In terms of trying to add autocomplete annotations, we can deprecate methods, arguments or props, but not specific values of those things. I even tried with a conditional  type using JSDoc syntax but it just wouldn't infer the annotation based on value.