### PR TITLE
chore: only build preview deploys when we change website files

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[context.deploy-preview]
+  # only do a preview deply when there is a website change
+  ignore = "git diff --quiet HEAD^ HEAD -- packages/paste-website packages/paste-theme-designer || echo changed"

--- a/packages/paste-theme-designer/netlify.toml
+++ b/packages/paste-theme-designer/netlify.toml
@@ -1,0 +1,3 @@
+[context.deploy-preview]
+  # only do a preview deply when there is a website change
+  ignore = "git diff --quiet HEAD^ HEAD -- packages/paste-theme-designer || echo changed"

--- a/packages/paste-website/netlify.toml
+++ b/packages/paste-website/netlify.toml
@@ -1,0 +1,3 @@
+[context.deploy-preview]
+  # only do a preview deply when there is a website change
+  ignore = "git diff --quiet HEAD^ HEAD -- packages/paste-website || echo changed"


### PR DESCRIPTION
We run a lot of website build minutes necessarily.

If we want to see the affects of a component we can in chromatic. We can probably get away with not deploying if we don't change anything in the website or theme designer for PRs.

This still deploys on merge to main though as we need to for changelogs being published to the site.