### PR TITLE
chore(website): add "click here" guidelines to anchor doc and update "New" banner

### DIFF
--- a/packages/paste-website/src/components/homepage/HomeHero.tsx
+++ b/packages/paste-website/src/components/homepage/HomeHero.tsx
@@ -70,18 +70,18 @@ const HomeHero: React.FC = () => {
             <Column span={5}>
               <NewComponentBanner>
                 <NewComponentBannerBadge>New!</NewComponentBannerBadge>
-                <NewComponentBannerText>You can now use an Icon inside an Avatar.</NewComponentBannerText>
+                <NewComponentBannerText>We're looking for a Product Designer!</NewComponentBannerText>
                 <NewComponentBannerLink
-                  to="/components/avatar#representing-an-entity-via-an-icon"
+                  to="https://boards.greenhouse.io/twilio/jobs/3133421"
                   onClick={() =>
                     trackCustomEvent({
                       category: 'Hero',
                       action: 'click-new-component-banner',
-                      label: 'Announcing Avatar Icon',
+                      label: 'Product Designer job opening',
                     })
                   }
                 >
-                  Check it out!
+                  Is it you?
                 </NewComponentBannerLink>
               </NewComponentBanner>
               <Text

--- a/packages/paste-website/src/components/homepage/HomeHero.tsx
+++ b/packages/paste-website/src/components/homepage/HomeHero.tsx
@@ -80,6 +80,7 @@ const HomeHero: React.FC = () => {
                       label: 'Product Designer job opening',
                     })
                   }
+                  showExternal
                 >
                   Is it you?
                 </NewComponentBannerLink>

--- a/packages/paste-website/src/components/homepage/HomeHero.tsx
+++ b/packages/paste-website/src/components/homepage/HomeHero.tsx
@@ -70,7 +70,7 @@ const HomeHero: React.FC = () => {
             <Column span={5}>
               <NewComponentBanner>
                 <NewComponentBannerBadge>New!</NewComponentBannerBadge>
-                <NewComponentBannerText>We're looking for a Product Designer!</NewComponentBannerText>
+                <NewComponentBannerText>We&apos;re looking for a Product Designer!</NewComponentBannerText>
                 <NewComponentBannerLink
                   to="https://boards.greenhouse.io/twilio/jobs/3133421"
                   onClick={() =>

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -87,7 +87,7 @@ The anchor is built with standard accessible practices in mind. Those include an
 
 The title attribute was not included because it’s not exposed to all browsers in an accessible way, meaning most screen readers and touch-only devices will likely never see that information.
 
-All anchor text should be written succinctly and make sense on its own (e.g., don't write "Click here"). This is especially important for users of assistive technology who often navigate through a list of all actions on a page, meaning they might not know about any contextual information surrounding a given action.
+All anchor text should be written succinctly and make sense on its own (e.g., [don't write "Click here"](https://paste.twilio.design/content/product-style-guide#be-inclusive-of-people-and-devices)). This is especially important for users of assistive technology who often navigate through a list of all actions on a page, meaning they might not know about any contextual information surrounding a given action.
 
 ## Examples
 

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -87,6 +87,8 @@ The anchor is built with standard accessible practices in mind. Those include an
 
 The title attribute was not included because it’s not exposed to all browsers in an accessible way, meaning most screen readers and touch-only devices will likely never see that information.
 
+All anchor text should be written succinctly and make sense on its own (e.g., don't write "Click here"). This is especially important for users of assistive technology who often navigate through a list of all actions on a page, meaning they might not know about any contextual information surrounding a given action.
+
 ## Examples
 
 ### Default Anchor

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -87,7 +87,7 @@ The anchor is built with standard accessible practices in mind. Those include an
 
 The title attribute was not included because it’s not exposed to all browsers in an accessible way, meaning most screen readers and touch-only devices will likely never see that information.
 
-All anchor text should be written succinctly and make sense on its own (e.g., [don't write "Click here"](https://paste.twilio.design/content/product-style-guide#be-inclusive-of-people-and-devices)). This is especially important for users of assistive technology who often navigate through a list of all actions on a page, meaning they might not know about any contextual information surrounding a given action.
+All anchor text should be written succinctly and make sense on its own (e.g., [don't write "Click here"](/content/product-style-guide#be-inclusive-of-people-and-devices)). This is especially important for users of assistive technology who often navigate through a list of all actions on a page, meaning they might not know about any contextual information surrounding a given action.
 
 ## Examples
 


### PR DESCRIPTION
Add a guideline about not using "click here" (from the Button vs. Anchor page) to the Anchor page.