### PR TITLE
feat(modal-dialog-primitive): replace reach dialog with reakit dialog

### DIFF
--- a/.changeset/dry-carrots-compare.md
+++ b/.changeset/dry-carrots-compare.md
@@ -1,0 +1,11 @@
+---
+'@twilio-paste/modal-dialog-primitive': major
+'@twilio-paste/core': major
+---
+
+BREAKING CHANGE: Modal Dialog Primitive is no longer using Reach Dialog. It now uses Reakit Dialog.
+
+- ModalDialogPrimitiveContent has been deprecated
+- ModalDialogPrimitiveOverlay has been deprecated
+
+useModalDialogPrimitiveState, ModalDialogPrimitive, and ModalDialogBackdropPrimitive should now be used to compose a modal dialog.

--- a/.changeset/tame-emus-hear.md
+++ b/.changeset/tame-emus-hear.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/reakit-library': patch
+'@twilio-paste/core': patch
+---
+
+Bumped to the latest Reakit version.

--- a/packages/paste-core/components/menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -401,7 +401,7 @@ exports[`Menu Render should render 1`] = `
     hidden=""
     id="menu-example"
     role="menu"
-    style="display: none;"
+    style="display: none; position: fixed; left: 100%; top: 100%;"
     tabindex="-1"
   >
     <a
@@ -473,7 +473,7 @@ exports[`Menu Render should render 1`] = `
       hidden=""
       id="sub-menu"
       role="menu"
-      style="display: none;"
+      style="display: none; position: fixed; left: 100%; top: 100%;"
       tabindex="-1"
     >
       <a

--- a/packages/paste-core/primitives/menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/primitives/menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`Menu Primitive Render should render 1`] = `
     hidden=""
     id="menu-example"
     role="menu"
-    style="display: none;"
+    style="display: none; position: fixed; left: 100%; top: 100%;"
     tabindex="-1"
   >
     <button
@@ -60,7 +60,7 @@ exports[`Menu Primitive Render should render 1`] = `
       hidden=""
       id="sub-menu"
       role="menu"
-      style="display: none;"
+      style="display: none; position: fixed; left: 100%; top: 100%;"
       tabindex="-1"
     >
       <button

--- a/packages/paste-core/primitives/modal-dialog/__tests__/index.spec.tsx
+++ b/packages/paste-core/primitives/modal-dialog/__tests__/index.spec.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import {render, fireEvent, screen} from '@testing-library/react';
+// @ts-ignore
+import axe from '../../../../../.jest/axe-helper';
+import {ModalPrimitiveExample} from '../stories/index.stories';
+
+describe('Modal Primitive', () => {
+  describe('Render', () => {
+    it('should render a button with aria attributes', () => {
+      render(<ModalPrimitiveExample />);
+      const renderedModalButton = screen.getByRole('button');
+      expect(renderedModalButton.getAttribute('aria-haspopup')).toEqual('dialog');
+      expect(renderedModalButton.getAttribute('aria-controls')).toEqual('modal-primitive-example');
+      expect(renderedModalButton.getAttribute('aria-expanded')).toEqual('false');
+    });
+
+    it('should render a modal with aria attributes', () => {
+      render(<ModalPrimitiveExample />);
+      const renderedModal = screen.getByLabelText('Welcome');
+      expect(renderedModal.getAttribute('role')).toEqual('dialog');
+      expect(renderedModal.getAttribute('aria-modal')).toEqual('true');
+      expect(renderedModal.getAttribute('data-dialog')).toEqual('true');
+    });
+  });
+
+  describe('Interaction', () => {
+    it('should control expanded attribute on the button', () => {
+      render(<ModalPrimitiveExample />);
+      const renderedModalButton = screen.getByRole('button');
+      expect(renderedModalButton.getAttribute('aria-expanded')).toEqual('false');
+      fireEvent.click(renderedModalButton);
+      expect(renderedModalButton.getAttribute('aria-expanded')).toEqual('true');
+      if (document.activeElement != null) {
+        fireEvent.keyDown(document.activeElement, {key: 'Escape', code: 'Escape'});
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(renderedModalButton.getAttribute('aria-expanded')).toEqual('false');
+      }
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should have no accessibility violations', async () => {
+      const {container} = render(<ModalPrimitiveExample />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/paste-core/primitives/modal-dialog/package.json
+++ b/packages/paste-core/primitives/modal-dialog/package.json
@@ -28,10 +28,12 @@
     "@reach/dialog": "0.11.2"
   },
   "peerDependencies": {
+    "@twilio-paste/reakit-library": "^0.8.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@twilio-paste/reakit-library": "^0.8.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/paste-core/primitives/modal-dialog/src/index.tsx
+++ b/packages/paste-core/primitives/modal-dialog/src/index.tsx
@@ -1,22 +1,20 @@
-/**
- * If you’re wondering why we wrapped that package into our own, we reasoned that it
- * would be best for our consumers’ DX, with reasons such as:
- *
- * - If we want to migrate the underlying nuts and bolts in the future, Twilio products
- *   that depend on this primitive would need to replace all occurrences of
- *   `import … from ‘@reach/dialog’` to `import … from ‘@some-new/package’`.
- *   By wrapping it in `@twilio-paste/modal-dialog-primitive`, this refactor can be avoided.
- *   The only change would be a version bump in the package.json file.
- * - We can more strictly enforce semver and backwards compatibility than some of
- *   our dependencies.
- * - We can control when to provide an update and which versions we allow, to
- *   help reduce potential bugs our consumers may face.
- * - We can control which APIs we expose. For example, we may chose to enable or
- *   disable usage of certain undocumented APIs.
- */
+/* Keeping the Reach export until we transition Modal to use Reakit */
 import {
   DialogContent as ModalDialogPrimitiveContent,
   DialogOverlay as ModalDialogPrimitiveOverlay,
 } from '@reach/dialog';
 
 export {ModalDialogPrimitiveContent, ModalDialogPrimitiveOverlay};
+
+export type {
+  DialogState as ModalDialogPrimitiveState,
+  DialogInitialState as ModalDialogPrimitiveInitialState,
+  DialogProps as ModalDialogPrimitiveProps,
+  DialogBackdropProps as ModalDialogBackdropPrimitiveProps,
+} from 'reakit/Dialog';
+
+export {
+  useDialogState as useModalDialogPrimitiveState,
+  Dialog as ModalDialogPrimitive,
+  DialogBackdrop as ModalDialogBackdropPrimitive,
+} from 'reakit/Dialog';

--- a/packages/paste-libraries/reakit/package.json
+++ b/packages/paste-libraries/reakit/package.json
@@ -25,7 +25,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "reakit": "1.3.4",
+    "reakit": "1.3.8",
     "reakit-system": "0.15.1",
     "reakit-utils": "0.15.1"
   },

--- a/packages/paste-website/src/component-examples/ModalDialogPrimitiveExample.tsx
+++ b/packages/paste-website/src/component-examples/ModalDialogPrimitiveExample.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 import {styled} from '@twilio-paste/styling-library';
 import {Text} from '@twilio-paste/text';
 import {Button} from '@twilio-paste/button';
-import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '@twilio-paste/modal-dialog-primitive';
+import {
+  useModalDialogPrimitiveState,
+  ModalDialogPrimitive,
+  ModalDialogBackdropPrimitive,
+} from '@twilio-paste/modal-dialog-primitive';
 
-const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
+const StyledModalDialogOverlay = styled(ModalDialogBackdropPrimitive)({
   position: 'fixed',
   top: 0,
   right: 0,
@@ -16,7 +20,7 @@ const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
   background: 'rgba(0, 0, 0, 0.7)',
 });
 
-const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
+const StyledModalDialogContent = styled(ModalDialogPrimitive)({
   width: '100%',
   maxWidth: '560px',
   maxHeight: 'calc(100% - 60px)',
@@ -25,38 +29,38 @@ const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
   padding: '20px',
 });
 
-interface BasicModalDialogProps {
-  isOpen: boolean;
-  handleClose: () => void;
-}
-
-const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}) => {
-  const inputRef = React.useRef(null);
-
-  return (
-    <StyledModalDialogOverlay isOpen={isOpen} onDismiss={handleClose} allowPinchZoom initialFocusRef={inputRef}>
-      <StyledModalDialogContent>
-        <input type="text" value="first" />
-        <br />
-        <input ref={inputRef} type="text" value="second (initial focused)" />
-        <Text as="p" color="colorText">
-          Roll your own dialog!
-        </Text>
-      </StyledModalDialogContent>
-    </StyledModalDialogOverlay>
-  );
-};
-
 export const ModalDialogPrimitiveExample: React.FC = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const handleOpen = (): void => setIsOpen(true);
-  const handleClose = (): void => setIsOpen(false);
+  const dialog = useModalDialogPrimitiveState({baseId: 'modal-primitive-example'});
+  const handleOpen = (): void => dialog.show();
+  const initialFocusRef = React.useRef() as React.MutableRefObject<HTMLInputElement>;
+
+  React.useEffect(() => {
+    if (dialog.visible) {
+      initialFocusRef.current.focus();
+    }
+  }, [dialog.visible]);
+
   return (
-    <div>
-      <Button variant="primary" onClick={handleOpen}>
-        Open Sample Modal
+    <>
+      <Button
+        variant="primary"
+        onClick={handleOpen}
+        aria-controls={dialog.baseId}
+        aria-expanded={!!dialog.visible}
+        aria-haspopup="dialog"
+      >
+        Open Modal
       </Button>
-      <BasicModalDialog isOpen={isOpen} handleClose={handleClose} />
-    </div>
+      <StyledModalDialogOverlay {...dialog}>
+        <StyledModalDialogContent {...dialog} aria-label="Welcome">
+          <input type="text" defaultValue="first" />
+          <br />
+          <input ref={initialFocusRef} type="text" defaultValue="second (initial focused)" />
+          <Text as="p" color="colorText">
+            Roll your own dialog!
+          </Text>
+        </StyledModalDialogContent>
+      </StyledModalDialogOverlay>
+    </>
   );
 };

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -78,14 +78,14 @@ and accessibility issues in our products.
 
 ## Usage Guide
 
-This package is a wrapper around [`@reach/dialog`](https://reacttraining.com/reach-ui/dialog). If
+This package is a wrapper around [`Reakit Dialog`](https://reakit.io/docs/dialog/). If
 you’re wondering why we wrapped that package into our own, we reasoned that it would be best
 for our consumers’ developer experience. With reasons such as:
 
 - We can control which APIs we expose and how to expose them. For example, in this package we rename
   and export only some of the source package's exports.
 - If we want to migrate the underlying nuts and bolts in the future, Twilio products that
-  depend on this primitive would need to replace all occurrences of `import … from ‘@reach/dialog’`
+  depend on this primitive would need to replace all occurrences of `import … from ‘reakit’`
   to `import … from ‘@some-new/package’`. By wrapping it in `@twilio-paste/modal-dialog-primitive`,
   this refactor can be avoided. The only change would be a version bump in the package.json file.
 - We can more strictly enforce semver and backwards compatibility than some of our dependencies.
@@ -111,9 +111,9 @@ import * as React from 'react';
 import {styled} from '@twilio-paste/styling-library';
 import {Text} from '@twilio-paste/text';
 import {Button} from '@twilio-paste/button';
-import {ModalDialogPrimitiveOverlay, ModalDialogPrimitiveContent} from '@twilio-paste/modal-dialog-primitive';
+import {useModalDialogPrimitiveState, ModalDialogPrimitive, ModalDialogBackdropPrimitive} from '@twilio-paste/modal-dialog-primitive';
 
-const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
+const StyledModalDialogOverlay = styled(ModalDialogBackdropPrimitive)({
   position: 'fixed',
   top: 0,
   right: 0,
@@ -125,7 +125,7 @@ const StyledModalDialogOverlay = styled(ModalDialogPrimitiveOverlay)({
   background: 'rgba(0, 0, 0, 0.7)',
 });
 
-const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
+const StyledModalDialogContent = styled(ModalDialogPrimitive)({
   width: '100%',
   maxWidth: '560px',
   maxHeight: 'calc(100% - 60px)',
@@ -134,193 +134,96 @@ const StyledModalDialogContent = styled(ModalDialogPrimitiveContent)({
   padding: '20px',
 });
 
-interface BasicModalDialogProps {
-  isOpen: boolean;
-  handleClose: () => void;
-}
+xport const ModalDialogPrimitiveExample: React.FC = () => {
+  const dialog = useModalDialogPrimitiveState({baseId: 'modal-primitive-example'});
+  const handleOpen = (): void => dialog.show();
+  const initialFocusRef = React.useRef() as React.MutableRefObject<HTMLInputElement>;
 
-const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}) => {
-  const inputRef = React.useRef();
-
-  return (
-    <StyledModalDialogOverlay
-      isOpen={isOpen}
-      onDismiss={handleClose}
-      allowPinchZoom={true}
-      initialFocusRef={inputRef}
-    >
-      <StyledModalDialogContent>
-        <input type="text" value="first" />
-        <br />
-        <input ref={inputRef} type="text" value="second (initial focused)" />
-        <Text as="p" color="colorText">
-          Roll your own dialog!
-        </Text>
-      </StyledModalDialogContent>
-    </StyledModalDialogOverlay>
-  );
-};
-
-export const ModalActivator: React.FC = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const handleOpen = (): void => setIsOpen(true);
-  const handleClose = (): void => setIsOpen(false);
+  React.useEffect(() => {
+    if (dialog.visible) {
+      initialFocusRef.current.focus();
+    }
+  }, [dialog.visible]);
 
   return (
-    <div>
-      <Button variant="primary" onClick={handleOpen}>
-        Open Sample Modal
+    <>
+      <Button
+        variant="primary"
+        onClick={handleOpen}
+        aria-controls={dialog.baseId}
+        aria-expanded={!!dialog.visible}
+        aria-haspopup="dialog"
+      >
+        Open Modal
       </Button>
-      <BasicModalDialog isOpen={isOpen} handleClose={handleClose} />
-    </div>
+      <StyledModalDialogOverlay {...dialog}>
+        <StyledModalDialogContent {...dialog} aria-label="Welcome">
+          <input type="text" defaultValue="first" />
+          <br />
+          <input ref={initialFocusRef} type="text" defaultValue="second (initial focused)" />
+          <Text as="p" color="colorText">
+            Roll your own dialog!
+          </Text>
+        </StyledModalDialogContent>
+      </StyledModalDialogOverlay>
+    </>
   );
 };
 ```
 
 ### API
 
+#### Installation
+
+```bash
+yarn add @twilio-paste/modal-dialog-primitive - or - yarn add @twilio-paste/core
+```
+
 <Callout>
   <CalloutText>
-    Much of the following is copied directly from{' '}
-    <Anchor href="https://reacttraining.com/reach-ui/dialog/">reach-ui's docs</Anchor>. Because we may update at a
-    different cadence, we're duplicating the docs here to prevent inconsistent behaviors.
+    Much of the following is copied directly from <Anchor href="https://reakit.io/docs/dialog/">Reakit's docs</Anchor>.
+    Because we may update at a different cadence, we're duplicating the docs here to prevent inconsistent behaviors.
   </CalloutText>
 </Callout>
 
-#### ModalDialogPrimitiveOverlay Props
+#### Props
 
-All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
+This props list is a scoped version of the properties available from the [Reakit Dialog](https://reakit.io/docs/dialog/) package.
 
-| Prop             | Type            | Default |
-| ---------------- | --------------- | ------- |
-| isOpen           | bool            | false   |
-| allowPinchZoom?  | bool            | false   |
-| onDismiss?       | (event) => void | noop    |
-| initialFocusRef? | ref             | null    |
-| children         | node            | null    |
+##### useModalDialogPrimitiveState
 
-##### `isOpen` prop
+##### `baseId?: string`
 
-Controls whether the dialog is open or not.
+Sets the ID that will serve as a base for all the items IDs.
 
-```
-<ModalDialogPrimitiveOverlay isOpen={true}>
-  <p>I will be open</p>
-</ModalDialogPrimitiveOverlay>
+##### `visible?: boolean`
 
-<ModalDialogPrimitiveOverlay isOpen={false}>
-  <p>I will be closed</p>
-</ModalDialogPrimitiveOverlay>
-```
+Whether the modal dialog is visible or not.
 
-##### `allowPinchZoom` prop
+##### `animated?: number | boolean`
 
-Controls whether the dialog should allow zoom/pinch gestures on iOS devices.
+If true, animating will be set to true when visible is updated. It'll wait for stopAnimation to be called or a CSS transition ends. If animated is set to a number, stopAnimation will be called only after the same number of milliseconds have passed.
 
-##### `onDismiss` prop
+##### `modal?: boolean`
 
-This function is called whenever the user hits "Escape" or clicks outside the dialog.
-It's important to close the dialog when onDismiss is fired, as seen in all the demos on this page.
+Sets the modal state.
 
-The only time you _shouldn't_ close the dialog onDismiss is when the dialog requires a
-choice and none of them are "cancel". For example, perhaps two records need to be merged
-and the user needs to pick the surviving record. Neither choice is less destructive than
-the other, in these cases you may want to alert the user they need to a make a choice
-onDismiss instead of closing the dialog.
+- Non-modal: preventBodyScroll doesn't work and focus is free.
+- Modal: preventBodyScroll is automatically enabled, focus is trapped within the modal dialog and the modal dialog is rendered within a Portal.
 
-```
-function Example(props) {
-  const [showDialog, setShowDialog] = React.useState(false);
-  const open = () => setShowDialog(true);
-  const close = () => setShowDialog(false);
+##### ModalDialogPrimitive
 
-  return (
-    <div>
-      <button onClick={open}>Show Dialog</button>
-      <ModalDialogPrimitiveOverlay isOpen={showDialog} onDismiss={close}>
-        <ModalDialogPrimitiveContent>
-          <Text as="p">
-            It is your job to close this with state when the user clicks outside
-            or presses escape.
-          </Text>
-          <button onClick={close}>Okay</button>
-        </ModalDialogPrimitiveContent>
-      </ModalDialogPrimitiveOverlay>
-    </div>
-  );
-}
-```
+##### `hideOnEsc?: boolean | undefined`
 
-```
-function Example(props) {
-  const [showDialog, setShowDialog] = React.useState(false);
-  const [showWarning, setShowWarning] = React.useState(false);
-  const open = () => {
-    setShowDialog(true);
-    setShowWarning(false);
-  };
-  const close = () => setShowDialog(false);
-  const dismiss = () => setShowWarning(true);
+If enabled, the user can hide the modal dialog by pressing Escape.
 
-  return (
-    <div>
-      <button onClick={open}>Show Dialog</button>
-      <ModalDialogPrimitiveOverlay isOpen={showDialog} onDismiss={close}>
-        <ModalDialogPrimitiveContent>
-          {showWarning && (
-            <p style={{ color: "red" }}>You must make a choice, sorry :(</p>
-          )}
-          <p>Which router should survive the merge?</p>
-          <button onClick={close}>React Router</button>{" "}
-          <button onClick={close}>@reach/router</button>
-        </ModalDialogPrimitiveContent>
-      </ModalDialogPrimitiveOverlay>
-    </div>
-  );
-}
-```
+##### `hideOnClickOutside?: boolean | undefined`
 
-##### `initialFocusRef` prop
+If enabled, the user can hide the modal dialog by clicking outside it.
 
-By default the first focusable element will receive focus when the dialog opens but you
-can provide a ref to focus instead.
+##### `preventBodyaScroll?: boolean | undefined`
 
-```
-function Example(props) {
-  const [showDialog, setShowDialog] = React.useState(false);
-  const buttonRef = React.useRef();
-  const open = () => setShowDialog(true);
-  const close = () => setShowDialog(false);
-
-  return (
-    <div>
-      <button onClick={open}>Show Dialog</button>
-      {showDialog && (
-        <ModalDialogPrimitiveOverlay initialFocusRef={buttonRef} onDismiss={close}>
-          <ModalDialogPrimitiveContent>
-            <p>Pass the button ref to DialogOverlay and the button.</p>
-            <button onClick={close}>Not me</button>
-            <button
-              ref={buttonRef}
-              onClick={close}
-            >
-              Got me!
-            </button>
-          </ModalDialogPrimitiveContent>
-        </ModalDialogPrimitiveOverlay>
-      )}
-    </div>
-  );
-}
-```
-
-#### ModalDialogPrimitiveContent Props
-
-All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
-
-| Prop     | Type | Default |
-| -------- | ---- | ------- |
-| children | node | null    |
+If enabled, the user can't scroll on body when the modal dialog is visible. This option doesn't work if the dialog isn't a modal.
 
 <ChangelogRevealer>
   <Changelog />
@@ -329,4 +232,3 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 </content>
 
 </contentwrapper>
-```

--- a/yarn.lock
+++ b/yarn.lock
@@ -25434,10 +25434,10 @@ reakit-warning@^0.6.1:
   dependencies:
     reakit-utils "^0.15.1"
 
-reakit@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.4.tgz#1c83614130fbcee624ba510547db79c90b3435a4"
-  integrity sha512-aLR0GBOc9vELTk4PKK/zndBbIs4RSw4B7GSGY6yoMHQ/vna0iLNd5BMhjtXspD/B7hhkYERlT6di8pIyD3HSPw==
+reakit@1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.8.tgz#717e1a3b7cc6da803362a0edc2c55d2b6a001baf"
+  integrity sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==
   dependencies:
     "@popperjs/core" "^2.5.4"
     body-scroll-lock "^3.1.5"


### PR DESCRIPTION
- [x] Modal Dialog Primitive now uses Reakit Dialog
- [x] Updated Modal Dialog Primitive doc page with new api
- [x] Bumped Reakit version in Reakit-Library
- [x] Updated snapshots for Menu and Menu Primitive