### PR TITLE
fix(disclosure): add a background color to disclosure content

### DIFF
--- a/.changeset/poor-insects-repeat.md
+++ b/.changeset/poor-insects-repeat.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/disclosure': patch
+'@twilio-paste/core': patch
+---
+
+Add a background color to disclosure content for when it is placed on top of a background color that is not the body color

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -93,9 +93,23 @@ export const decorators = [
                   <Story />
                 </Box>
               </Theme.Provider>
+              <Theme.Provider theme="default">
+                <Box backgroundColor="colorBackgroundBody" color="colorText" padding="space20">
+                  <Box margin="space40" padding="space40" backgroundColor="colorBackground">
+                    <Story />
+                  </Box>
+                </Box>
+              </Theme.Provider>
               <Theme.Provider theme="dark">
                 <Box backgroundColor="colorBackgroundBody" color="colorText" padding="space80">
                   <Story />
+                </Box>
+              </Theme.Provider>
+              <Theme.Provider theme="dark">
+                <Box backgroundColor="colorBackgroundBody" color="colorText" padding="space20">
+                  <Box margin="space40" padding="space40" backgroundColor="colorBackground">
+                    <Story />
+                  </Box>
                 </Box>
               </Theme.Provider>
             </Stack>

--- a/packages/paste-core/components/disclosure/src/DisclosureContent.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureContent.tsx
@@ -27,6 +27,7 @@ const DisclosureContent = React.forwardRef<HTMLDivElement, DisclosureContentProp
         {...disclosure}
         {...safelySpreadBoxProps(props)}
         as={AnimatedDisclosureContent}
+        backgroundColor="colorBackgroundBody"
         padding="space50"
         ref={ref}
         style={{


### PR DESCRIPTION
To address this discussion topic https://github.com/twilio-labs/paste/discussions/1320

Add a background color to the disclosure content so that you can see it on a background that is not the body color.

Also add story layout for VRT to at least display each component of a background that is not the body.