### PR TITLE
fix(combobox): pass required prop to textbox

### DIFF
--- a/.changeset/cool-actors-itch.md
+++ b/.changeset/cool-actors-itch.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/combobox': patch
+'@twilio-paste/core': patch
+---
+
+Fixed the `required` prop not being passed to the `textbox` inside Combobox.

--- a/packages/paste-core/components/combobox/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/combobox/__tests__/index.spec.tsx
@@ -8,7 +8,7 @@ import {Box} from '@twilio-paste/box';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {useCombobox, Combobox} from '../src';
-import {ComboboxProps} from '../src/types';
+import type {ComboboxProps} from '../src/types';
 import {getIndexedItems, getGroupedItems} from '../src/helpers';
 
 const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
@@ -59,6 +59,7 @@ const ComboboxMock: React.FC = () => {
         initialIsOpen
         helpText="This is the help text"
         labelText="Choose a component:"
+        required
         onInputValueChange={({inputValue}) => {
           if (inputValue !== undefined) {
             setInputItems(items.filter((item) => item.toLowerCase().startsWith(inputValue.toLowerCase())));
@@ -197,6 +198,12 @@ describe('Combobox', () => {
       const renderedLabel = document.querySelector('label');
       const renderedTextbox = screen.getByRole('textbox');
       expect(renderedLabel!.getAttribute('for')).toEqual(renderedTextbox.getAttribute('id'));
+    });
+
+    it('should render a required combobox', () => {
+      render(<ComboboxMock />);
+      const renderedTextbox = screen.getByRole('textbox');
+      expect(renderedTextbox.getAttribute('required')).toEqual('');
     });
   });
 

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -151,7 +151,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
           <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
             <ComboboxInputSelect
               {...getToggleButtonProps({tabIndex: 0})}
-              {...getInputProps({disabled, ref})}
+              {...getInputProps({disabled, required, ref})}
               {...(!autocomplete ? {onChange: (event: React.ChangeEvent) => event.preventDefault()} : undefined)}
               autocomplete={autocomplete}
               aria-describedby={helpTextId}


### PR DESCRIPTION
Fixes: https://github.com/twilio-labs/paste/issues/1472

- [x] Passes the required prop to the textbox inside combobox.
- [x] Test to verify required is being passed.