### PR TITLE
fix(disclosure): remove wrapping box around heading content

### DIFF
--- a/.changeset/beige-icons-think.md
+++ b/.changeset/beige-icons-think.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/disclosure': patch
+'@twilio-paste/core': patch
+---
+
+DisclosureHeading now gracefully handles children and doesn't impose flex behavior. This makes it easier to pass MediaObjects and Truncate as children.

--- a/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
@@ -66,9 +66,7 @@ const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosur
               size={IconSizeFromHeading[variant] || 'sizeIcon20'}
             />
           </Box>
-          <Box display="flex" flexGrow={1} minWidth="0px">
-            {children}
-          </Box>
+          {children}
         </Box>
       </Heading>
     );

--- a/packages/paste-core/components/disclosure/stories/index.stories.tsx
+++ b/packages/paste-core/components/disclosure/stories/index.stories.tsx
@@ -3,6 +3,8 @@ import {Box} from '@twilio-paste/box';
 import {Stack} from '@twilio-paste/stack';
 import {Truncate} from '@twilio-paste/truncate';
 import {Paragraph} from '@twilio-paste/paragraph';
+import {ProductInternetOfThingsIcon} from '@twilio-paste/icons/esm/ProductInternetOfThingsIcon';
+import {MediaObject, MediaBody, MediaFigure} from '@twilio-paste/media-object';
 import {Disclosure, DisclosureContent, DisclosureHeading, useDisclosureState} from '../src';
 import type {DisclosureHeadingProps, DisclosureInitialState, DisclosureStateReturn, DisclosureVariants} from '../src';
 
@@ -176,6 +178,33 @@ export const TruncatedHeader = (): React.ReactNode => {
 
 TruncatedHeader.story = {
   name: 'Truncated Header',
+};
+
+export const MediaObjectHeading = (): React.ReactNode => {
+  return (
+    <Disclosure variant="contained">
+      <DisclosureHeading as="h2" variant="heading30">
+        <Box width="100%">
+          <MediaObject verticalAlign="center">
+            <MediaFigure spacing="space10">
+              <ProductInternetOfThingsIcon decorative={false} title="phone numbers" size="sizeIcon40" />
+            </MediaFigure>
+            <MediaBody as="div">
+              <Box display="flex" justifyContent="space-between" flexWrap="wrap">
+                <Box>Internet of Things</Box>
+                <Box>$808</Box>
+              </Box>
+            </MediaBody>
+          </MediaObject>
+        </Box>
+      </DisclosureHeading>
+      <DisclosureContent>It works!</DisclosureContent>
+    </Disclosure>
+  );
+};
+
+MediaObjectHeading.story = {
+  name: 'MediaObject in Heading',
 };
 
 export const ContainedHeadingVariant10 = (): React.ReactNode => {


### PR DESCRIPTION
This PR removes the wrapper around the `{children}` in the DisclosureHeading. Generally speaking, having `flexGrow=1` on a `display block` element leads to all kinds of wacky behavior. We generally shouldn't be trying to position the children either, because developers may be attempting all kinds of things and we end up in a game of whack a mole with CSS. 
This change _should_ not have any breaking changes and makes it possible to position/layout the children any which way the developers want.