### PR TITLE
fix(website): fix broken links

### DIFF
--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -100,8 +100,6 @@ Lists are a number of connected list items that are printed consecutively, typic
 - Lists should align with the font-size, font-weight, and line-height of paragraphs, but are styled with bullets or numbers
 - Lists can have similar children elements as paragraphs to provide emphasis on a certain word or phrase
 
-List is part of the [Typography package](/components/typography), which includes Header and Paragraph as well.
-
 ### Accessibility
 
 - List text should meet AA requirements (4.5:1) for color contrast from itself and the background color

--- a/packages/paste-website/src/pages/getting-started/design/index.mdx
+++ b/packages/paste-website/src/pages/getting-started/design/index.mdx
@@ -14,9 +14,9 @@ import {Tooltip} from '@twilio-paste/tooltip';
 import {Stack} from '@twilio-paste/stack';
 import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 
-import { SuccessIcon } from "@twilio-paste/icons/esm/SuccessIcon";
-import { WarningIcon } from "@twilio-paste/icons/esm/WarningIcon";
-import { ErrorIcon } from "@twilio-paste/icons/esm/ErrorIcon";
+import {SuccessIcon} from '@twilio-paste/icons/esm/SuccessIcon';
+import {WarningIcon} from '@twilio-paste/icons/esm/WarningIcon';
+import {ErrorIcon} from '@twilio-paste/icons/esm/ErrorIcon';
 
 export const pageQuery = graphql`
   {
@@ -61,14 +61,11 @@ their design files. We also use Abstract to link Paste Sketch libraries and mana
 that later). Connect with your design manager to get added to the Twilio team in Abstract.
 
 <Callout variant="information">
-  <CalloutTitle>
-    Getting familiar with Abstract
-  </CalloutTitle>
+  <CalloutTitle>Getting familiar with Abstract</CalloutTitle>
   <CalloutText>
-    If you are not yet familiar with Abstract, please take some time to learn
-    about <Anchor href="https://www.abstract.com/how-it-works">how it works</Anchor>,
-    and read through these resources
-    on <Anchor href="https://help.abstract.com/hc/en-us/categories/360004353732-Best-Practices">best practices</Anchor>.
+    If you are not yet familiar with Abstract, please take some time to learn about{' '}
+    <Anchor href="https://www.abstract.com/how-it-works">how it works</Anchor>, and read through these resources on{' '}
+    <Anchor href="https://help.abstract.com/hc/en-us/categories/360004353732-Best-Practices">best practices</Anchor>.
   </CalloutText>
 </Callout>
 
@@ -86,8 +83,9 @@ to [download and install Fira Mono](https://fonts.google.com/specimen/Fira+Mono?
 our monospace typeface for code. It’s a free Google font.
 
 #### SF Pro
+
 If you are using <strong>any theme</strong> in Paste, you will need to [download and install SF Pro](https://developer.apple.com/fonts/), the
-system font for Apple platforms. We represent native web element styles (like option lists in [Select](/form-elements/select/)) in
+system font for Apple platforms. We represent native web element styles (like option lists in [Select](/components/select/)) in
 our design assets in the macOS styles.
 
 #### Inter
@@ -109,15 +107,16 @@ will need to link the necessary Paste Sketch libraries in order to use the
 Sketch symbols, text styles, and layer styles.
 
 <Callout variant="information">
-  <CalloutTitle>
-    Tips on linking libraries in Abstract
-  </CalloutTitle>
+  <CalloutTitle>Tips on linking libraries in Abstract</CalloutTitle>
   <CalloutText>
-    If you haven’t linked libraries in Abstract before, follow <Anchor href="https://help.abstract.com/hc/en-us/articles/360050379891-Linking-Libraries">this guide</Anchor> to learn how.
+    If you haven’t linked libraries in Abstract before, follow{' '}
+    <Anchor href="https://help.abstract.com/hc/en-us/articles/360050379891-Linking-Libraries">this guide</Anchor> to
+    learn how.
   </CalloutText>
 </Callout>
 
 ### Paste components
+
 <Tooltip text="There is ongoing maintenance and net new work in this project. Libraries in this project are at parity with code.">
   <Box
     role="button"
@@ -134,12 +133,10 @@ Sketch symbols, text styles, and layer styles.
     borderStyle="solid"
     borderRadius="borderRadius20"
   >
-  <Stack as="span" orientation="horizontal" spacing="space20">
-    <SuccessIcon decorative={false} title="Success icon" color="colorTextSuccess"/>
-    <Text as="p">
-      Actively maintained
-    </Text>
-  </Stack>
+    <Stack as="span" orientation="horizontal" spacing="space20">
+      <SuccessIcon decorative={false} title="Success icon" color="colorTextSuccess" />
+      <Text as="p">Actively maintained</Text>
+    </Stack>
   </Box>
 </Tooltip>
 
@@ -166,11 +163,10 @@ Use the symbols that match the theme you are using in your project.
 ![Menu in Sketch where you can navigate through symbols from the Anchor Sketch library](../../../assets/images/design-guidelines/paste-components-symbol.png)
 
 <Callout variant="warning">
-  <CalloutTitle>
-    A note on SendGrid components
-  </CalloutTitle>
+  <CalloutTitle>A note on SendGrid components</CalloutTitle>
   <CalloutText>
-    You will see that some symbols are provided in the SendGrid theme. If you plan to use them, please reach out to us in #help-design-system.
+    You will see that some symbols are provided in the SendGrid theme. If you plan to use them, please reach out to us
+    in #help-design-system.
   </CalloutText>
 </Callout>
 
@@ -187,29 +183,33 @@ exceptions: `typography`, `forms`, and `grid and spacing`.
   </DisclosureHeading>
   <DisclosureContent>
 
-  This library contains symbols that represent multiple components.
+This library contains symbols that represent multiple components.
 
-  ###### Heading
-  The `heading` symbols represent our [Heading](/components/heading) component and include symbols for H1 through H6. You can find the
-  heading symbols in `typography > [your theme] > heading`.
+###### Heading
 
-  ###### Paragraph
-  The `paragraph` symbol represents our [Paragraph](/components/paragraph) component. You can find the paragraph symbol
-  in `typography > [your theme] > text`. You’ll see that there is another symbol there called `default text`. Use the `paragraph` symbol for any prose,
-  such as a page description, and use the `default text` symbol for any small piece of UI text, such as data within a table. The line heights of each
-  are optimized for those different use cases.
+The `heading` symbols represent our [Heading](/components/heading) component and include symbols for H1 through H6. You can find the
+heading symbols in `typography > [your theme] > heading`.
 
-  ###### List
-  The `list` symbols represent our [List](/components/list) component and should be used for ordered and unordered lists.
-  You can find the list symbols in `typography > [your theme] > list`.
+###### Paragraph
 
-  ###### Using symbols vs. text styles
-  All typography symbols are left-aligned and include the default bottom margin that you’ll get when using this component in code. The alignment
-  and margin can be overridden in code, but instead of creating separate symbols for every potential variant, we’ve created type styles that are
-  included in the `typography` library. You can use these text styles instead of the symbols when you need to center- or right-align your text, or
-  when you need to remove the default bottom margin. You will also find type styles for strong and emphasized paragraph text.
+The `paragraph` symbol represents our [Paragraph](/components/paragraph) component. You can find the paragraph symbol
+in `typography > [your theme] > text`. You’ll see that there is another symbol there called `default text`. Use the `paragraph` symbol for any prose,
+such as a page description, and use the `default text` symbol for any small piece of UI text, such as data within a table. The line heights of each
+are optimized for those different use cases.
 
-  ![Menu in Sketch where you can navigate through text styles from the Typography Sketch library](../../../assets/images/design-guidelines/theme-typography-styles.png)
+###### List
+
+The `list` symbols represent our [List](/components/list) component and should be used for ordered and unordered lists.
+You can find the list symbols in `typography > [your theme] > list`.
+
+###### Using symbols vs. text styles
+
+All typography symbols are left-aligned and include the default bottom margin that you’ll get when using this component in code. The alignment
+and margin can be overridden in code, but instead of creating separate symbols for every potential variant, we’ve created type styles that are
+included in the `typography` library. You can use these text styles instead of the symbols when you need to center- or right-align your text, or
+when you need to remove the default bottom margin. You will also find type styles for strong and emphasized paragraph text.
+
+![Menu in Sketch where you can navigate through text styles from the Typography Sketch library](../../../assets/images/design-guidelines/theme-typography-styles.png)
 
   </DisclosureContent>
 </Disclosure>
@@ -220,8 +220,8 @@ exceptions: `typography`, `forms`, and `grid and spacing`.
   </DisclosureHeading>
   <DisclosureContent>
 
-  This library contains all symbols related to composing forms. This library includes symbols for input, textarea, checkbox, radio, select, combobox,
-  and form key. Note that select and combobox use the same symbols for all states except the expanded state.
+This library contains all symbols related to composing forms. This library includes symbols for input, textarea, checkbox, radio, select, combobox,
+and form key. Note that select and combobox use the same symbols for all states except the expanded state.
 
   </DisclosureContent>
 </Disclosure>
@@ -232,7 +232,7 @@ exceptions: `typography`, `forms`, and `grid and spacing`.
   </DisclosureHeading>
   <DisclosureContent>
 
-  This library contains symbols for some common grid layouts, as well as the vertical and horizontal separator symbols.
+This library contains symbols for some common grid layouts, as well as the vertical and horizontal separator symbols.
 
   </DisclosureContent>
 </Disclosure>
@@ -257,12 +257,10 @@ exceptions: `typography`, `forms`, and `grid and spacing`.
     borderStyle="solid"
     borderRadius="borderRadius20"
   >
-  <Stack as="span" orientation="horizontal" spacing="space20">
-    <SuccessIcon decorative={false} title="Success icon" color="colorTextSuccess"/>
-    <Text as="p">
-      Actively maintained
-    </Text>
-  </Stack>
+    <Stack as="span" orientation="horizontal" spacing="space20">
+      <SuccessIcon decorative={false} title="Success icon" color="colorTextSuccess" />
+      <Text as="p">Actively maintained</Text>
+    </Stack>
   </Box>
 </Tooltip>
 
@@ -275,9 +273,9 @@ you can find layer styles for every background color token that is available for
 There are two libraries available in this project:
 
 - The `console theme` is the current theme you see in Console. Flip the toggle on the Paste docs site to "Current"
-to see this theme.
+  to see this theme.
 - The `default theme` is the new unified theme, formerly known as the "Unified Design Language" or "UDL". Flip the toggle
- on the Paste docs site to "Preview" to see this theme.
+  on the Paste docs site to "Preview" to see this theme.
 
 Link whichever library matches the theme you are using in your project. For example, if you are designing using the
 Default theme, link the `default theme` library to your project.
@@ -285,11 +283,10 @@ Default theme, link the `default theme` library to your project.
 ![Modal in Abstract where you can select libraries from the Paste design tokens project to link to your project](../../../assets/images/design-guidelines/link-theme-library-modal.png)
 
 <Callout variant="warning">
-  <CalloutTitle>
-    A note on the SendGrid theme
-  </CalloutTitle>
+  <CalloutTitle>A note on the SendGrid theme</CalloutTitle>
   <CalloutText>
-    You will also see the SendGrid theme in this project. If you plan to use this theme, please reach out to us in #help-design-system.
+    You will also see the SendGrid theme in this project. If you plan to use this theme, please reach out to us in
+    #help-design-system.
   </CalloutText>
 </Callout>
 
@@ -340,11 +337,11 @@ using these text and layer styles to create custom compositions in Sketch.
     </Box>
   </Tooltip>
 
-  For those of you working on Console UI, you are likely familiar with the old Console React components. The legacy components in this system and the design libraries associated with them (which are
-  housed in the `Console components` project in Abstract) are now Sunset or Deprecated.
+For those of you working on Console UI, you are likely familiar with the old Console React components. The legacy components in this system and the design libraries associated with them (which are
+housed in the `Console components` project in Abstract) are now Sunset or Deprecated.
 
-  Reference the [sunset/deprecation notice](https://docs.google.com/document/d/1qWSYhUuO0joG0Y8UslgLOCvCfl3ao1dTvHL2b20TB_c/edit?usp=sharing) for more details on what this means and
-  how it impacts your work.
+Reference the [sunset/deprecation notice](https://docs.google.com/document/d/1qWSYhUuO0joG0Y8UslgLOCvCfl3ao1dTvHL2b20TB_c/edit?usp=sharing) for more details on what this means and
+how it impacts your work.
 
   </DisclosureContent>
 </Disclosure>
@@ -379,7 +376,7 @@ using these text and layer styles to create custom compositions in Sketch.
       </Box>
     </Tooltip>
 
-  For those of you doing design work in the SendGrid app, you are likely using the `SendGrid-Symbol-Library` library. There is no ongoing work in this project.
+For those of you doing design work in the SendGrid app, you are likely using the `SendGrid-Symbol-Library` library. There is no ongoing work in this project.
 
   </DisclosureContent>
 </Disclosure>
@@ -414,9 +411,9 @@ using these text and layer styles to create custom compositions in Sketch.
     </Box>
   </Tooltip>
 
-  This project previously housed all icons available in Paste. For simplicity, we have pulled our icons into the `Paste components` project. If you are still using the `Paste icons` project in
-  your work, please transition to using the [`icons`](https://app.abstract.com/projects/3daed58b-10b9-4ade-9373-a837591fe3c8/branches/master/files/84f1514e-bf2c-4784-99d7-def6e0b6f33d) library
-  in the `Paste components` project.
+This project previously housed all icons available in Paste. For simplicity, we have pulled our icons into the `Paste components` project. If you are still using the `Paste icons` project in
+your work, please transition to using the [`icons`](https://app.abstract.com/projects/3daed58b-10b9-4ade-9373-a837591fe3c8/branches/master/files/84f1514e-bf2c-4784-99d7-def6e0b6f33d) library
+in the `Paste components` project.
 
   </DisclosureContent>
 </Disclosure>
@@ -427,7 +424,7 @@ using these text and layer styles to create custom compositions in Sketch.
   </DisclosureHeading>
   <DisclosureContent>
 
-  For any designers working in Flex, you will likely be using Flex design assets that are not owned or maintained by our team. Reach out to the Flex designers for more information.
+For any designers working in Flex, you will likely be using Flex design assets that are not owned or maintained by our team. Reach out to the Flex designers for more information.
 
   </DisclosureContent>
 </Disclosure>
@@ -447,12 +444,15 @@ callouts for any [major changes](#types-of-library-changes) and how to safely ac
 #### Types of library changes
 
 ##### Major
+
 Breaking changes that require work to incorporate into designs. For example, symbols changed size, requiring designers to realign design elements; or symbol overrides reset, requiring designers to reapply them.
 
 ##### Minor
+
 Non-breaking functionality was added that requires no work to incorporate. For example, a new button variant was added, or a token value was adjusted.
 
 ##### Patch
+
 Non-breaking bug fixes that require no work to incorporate. For example, the alignment of text in an input was fixed, or an incorrect border radius on small buttons was updated.
 
 ### Safely accepting library updates
@@ -463,32 +463,32 @@ We do our best to thoroughly test all library updates before merging them in, bu
 we <strong>strongly recommend</strong> following these steps when you want to move to the newest versions of the Paste libraries:
 
 1. Create a new branch within the project where you want to pull in the most recent library updates. <strong>Use this branch specifically for testing the library updates.</strong> You can create this branch directly
-off of master or off of another active branch in your project.
+   off of master or off of another active branch in your project.
 
-  <Callout variant="warning">
-    <CalloutTitle>
-      Do NOT accept library updates on a branch where you are actively doing other design work.
-    </CalloutTitle>
-    <CalloutText>
-      Doing so may break your current work. Either create a new branch to test the library updates, or just wait to use the updated libraries until you start your next project. If you wait, you can still work with your
-      engineering team to use the most recent component style, even if you don’t have that style represented in your designs.
-    </CalloutText>
-  </Callout>
+<Callout variant="warning">
+  <CalloutTitle>Do NOT accept library updates on a branch where you are actively doing other design work.</CalloutTitle>
+  <CalloutText>
+    Doing so may break your current work. Either create a new branch to test the library updates, or just wait to use
+    the updated libraries until you start your next project. If you wait, you can still work with your engineering team
+    to use the most recent component style, even if you don’t have that style represented in your designs.
+  </CalloutText>
+</Callout>
 
 2. Open your Sketch file(s) within that project. You will have the “Library Updates Available” badge in the header if there are library updates relevant to the symbols or styles used in your project.
 
-  ![Badge in Sketch that appears when you have library updates available](../../../assets/images/design-guidelines/library-updates-badge.png)
+![Badge in Sketch that appears when you have library updates available](../../../assets/images/design-guidelines/library-updates-badge.png)
 
 3. The badge will open a dialog that outlines all of the library updates that are available.
 
-  ![Modal in Sketch that allows you to select which library updates you want to accept into your file](../../../assets/images/design-guidelines/library-updates-confirmation-modal.png)
+![Modal in Sketch that allows you to select which library updates you want to accept into your file](../../../assets/images/design-guidelines/library-updates-confirmation-modal.png)
 
-  <strong>You do NOT have to accept all library updates at once.</strong> In fact, we strongly encourage that you accept one update or group of related updates at a time, so that if something breaks in your design, it is easy to
-isolate which library update caused the issue.
+<strong>You do NOT have to accept all library updates at once.</strong> In fact, we strongly encourage that you accept one
+update or group of related updates at a time, so that if something breaks in your design, it is easy to isolate which library
+update caused the issue.
 
 4. After applying the library updates, take a look through all of the artboards in your file. If everything looks good, you are safe to merge this branch back into the parent branch.
 
-  If the library updates broke anything in your design, identify which of the following issues you are seeing:
+If the library updates broke anything in your design, identify which of the following issues you are seeing:
 
     - <strong>A style change has been incorporated that impacted the alignment and/or spacing of your design.</strong> For example, the line height of paragraph text was reduced, so you now have extra spacing between your paragraph
     text and the elements around it. In this case, the resolution is to either adjust your designs to accommodate the changes or decline the library updates for now. We will communicate in our release notes if library updates will impact

--- a/packages/paste-website/src/pages/patterns/create/index.mdx
+++ b/packages/paste-website/src/pages/patterns/create/index.mdx
@@ -248,9 +248,9 @@ Bringing consistency to what happens after the user triggers the Create action i
 
 ## Post-creation
 
-After the user has created a new object, navigate them either back to the index page, where they can see a list of all objects, or to the individual object detail page (whichever makes most sense for the given user flow), and show a success [Toast](../components/toast) informing them that the object has successfully been created.
+After the user has created a new object, navigate them either back to the index page, where they can see a list of all objects, or to the individual object detail page (whichever makes most sense for the given user flow), and show a success [Toast](/components/toast) informing them that the object has successfully been created.
 
-If the create action fails, keep the user where they were and display an error [Toast](../components/toast) that explains what went wrong and how to try again.
+If the create action fails, keep the user where they were and display an error [Toast](/components/toast) that explains what went wrong and how to try again.
 
 For more information, check out our [Notifications and Feedback patterns](/patterns/notifications).
 

--- a/packages/paste-website/src/pages/patterns/delete/index.mdx
+++ b/packages/paste-website/src/pages/patterns/delete/index.mdx
@@ -76,28 +76,28 @@ export const pageQuery = graphql`
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/button">Button</Anchor>
+        <Anchor href="/components/button">Button</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/Modal">Modal</Anchor>
+        <Anchor href="/components/Modal">Modal</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/input">Input</Anchor>
+        <Anchor href="/components/input">Input</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/toast">Toast</Anchor>
+        <Anchor href="/components/toast">Toast</Anchor>
       </Heading>
     </Card>
   </Column>
@@ -171,9 +171,9 @@ For high-severity deletions, show a confirmation modal that explains what is bei
 
 ## Post-deletion
 
-After the user has deleted the object, navigate them to the index page, where they can see a list of all remaining objects, and show a success [Toast](../components/toast) informing them that the object has successfully been deleted. If it is possible to undo the deletion, give the user the option to do so, and tell them how long they have to undo the deletion if it is time-bound.
+After the user has deleted the object, navigate them to the index page, where they can see a list of all remaining objects, and show a success [Toast](/components/toast) informing them that the object has successfully been deleted. If it is possible to undo the deletion, give the user the option to do so, and tell them how long they have to undo the deletion if it is time-bound.
 
-If the delete action fails, keep the modal open and display an error [Toast](../components/toast) that explains what went wrong and how to try again.
+If the delete action fails, keep the modal open and display an error [Toast](/components/toast) that explains what went wrong and how to try again.
 
 For more information, check out our [Notifications and Feedback patterns](/patterns/notifications).
 

--- a/packages/paste-website/src/pages/patterns/empty-states/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-states/index.mdx
@@ -68,21 +68,21 @@ export const pageQuery = graphql`
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/card">Card</Anchor>
+        <Anchor href="/components/card">Card</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/heading">Heading</Anchor>
+        <Anchor href="/components/heading">Heading</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/paragraph">Paragraph</Anchor>
+        <Anchor href="/components/paragraph">Paragraph</Anchor>
       </Heading>
     </Card>
   </Column>
@@ -91,21 +91,21 @@ export const pageQuery = graphql`
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/button">Button (optional)</Anchor>
+        <Anchor href="/components/button">Button (optional)</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../components/anchor">Anchor (optional)</Anchor>
+        <Anchor href="/components/anchor">Anchor (optional)</Anchor>
       </Heading>
     </Card>
   </Column>
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="../illustrations">Illustrations (optional)</Anchor>
+        <Anchor href="/illustrations">Illustrations (optional)</Anchor>
       </Heading>
     </Card>
   </Column>

--- a/packages/paste-website/src/pages/patterns/index.mdx
+++ b/packages/paste-website/src/pages/patterns/index.mdx
@@ -126,7 +126,7 @@ There are two primary goals of patterns:
             </Tr>
             <Tr>
               <Td>
-                <Anchor href="/patterns/empty-state">Empty states</Anchor>
+                <Anchor href="/patterns/empty-states">Empty states</Anchor>
               </Td>
               <Td>How to inform a user that there is no data to display on a page or section.</Td>
               <Td>Beta</Td>

--- a/packages/paste-website/src/pages/patterns/notifications/index.mdx
+++ b/packages/paste-website/src/pages/patterns/notifications/index.mdx
@@ -100,7 +100,7 @@ Each notification or feedback pattern uses one or more of these components.
     <Stack orientation="vertical" spacing="space50">
       <Card>
         <Heading as="h3" variant="heading40" marginBottom="space0">
-          <Anchor href="/form-elements/input/#input-with-inline-error">Inline error on form fields</Anchor>
+          <Anchor href="/components/input/#input-with-inline-error">Inline error on form fields</Anchor>
         </Heading>
       </Card>
       <Card>
@@ -116,9 +116,9 @@ Each notification or feedback pattern uses one or more of these components.
         Component composition
       </Heading>
       <Paragraph marginBottom="space0">
-        Create a composition with <Anchor href="/components/card">Card</Anchor>, <Anchor href="/components/heading">
-          Heading
-        </Anchor>, and <Anchor href="/components/paragraph">Paragraph</Anchor> for in-page messaging.
+        Create a composition with <Anchor href="/components/card">Card</Anchor>,{' '}
+        <Anchor href="/components/heading">Heading</Anchor>, and <Anchor href="/components/paragraph">Paragraph</Anchor>{' '}
+        for in-page messaging.
       </Paragraph>
     </Card>
   </Column>
@@ -182,7 +182,7 @@ Notifications and feedback can come in 4 variants:
 
 Give users enough time to read a notification message, make a decision, and act on their decision. Users’ reading speeds, vision levels, literacy levels, dexterity, and familiarity with Twilio products can all affect how much time they’ll need to interact with a notification.
 
-Visit the [Alert](/components/alert), [Modal](/components/modal), [Form element](/form-elements/input), and [Toast](/components/toast) pages for more specific guidelines on how to implement each component accessibly.
+Visit the [Alert](/components/alert), [Modal](/components/modal), [Form element](/components/input), and [Toast](/components/toast) pages for more specific guidelines on how to implement each component accessibly.
 
 ## Notification and feedback levels
 

--- a/packages/paste-website/src/pages/patterns/object-details/index.mdx
+++ b/packages/paste-website/src/pages/patterns/object-details/index.mdx
@@ -175,8 +175,9 @@ The most common way to structure an object details page is to first show an over
       </Text>
       , <Text as="span" fontFamily="fontFamilyCode">
         Text as="dd"
-      </Text>) to help define the relationship between a property and its label, and spaced with the{' '}
-      <Anchor href="/layout/stack">Stack</Anchor> component.
+      </Text>) to help define the relationship between a property and its label, and spaced with the <Anchor href="/layout/stack">
+        Stack
+      </Anchor> component.
     </Paragraph>
     <Paragraph>
       In the future, this composition will be replaced with a Description List component.{' '}
@@ -220,7 +221,7 @@ For example, when viewing the details of a sent email campaign, a customer may w
 
 ### Tabbed details
 
-When you find that customers want to see multiple, top-level content sections, separate them with [Tabs](../components/tabs).
+When you find that customers want to see multiple, top-level content sections, separate them with [Tabs](/components/tabs).
 
 ![Screen of call details with tabs and list of properties](../../../assets/images/patterns/object-details-tabbed@3x.png)
 

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -62,7 +62,7 @@ export const pageQuery = graphql`
 
 The modal dialog primitive is an unstyled and barebones version of a [Modal dialog](https://www.w3.org/TR/wai-aria-practices/#dialog_modal).
 It handles the implementation details around accessibility and provides a robust API to
-build upon. For example, our [Modal component](../components/modal) is built on top of this primitive.
+build upon. For example, our [Modal component](/components/modal) is built on top of this primitive.
 If you find that our designed Modal component can’t work for your particular use case,
 we suggest falling back to this component to roll your own solution. We encourage
 using this code as a basis for all modal dialogs in order to avoid code fragmentation


### PR DESCRIPTION
There were a few broken links on the website, this PR fixes them to point to the correct paths.

Hide whitespace changes in Github to remove prettier lines:
![image](https://user-images.githubusercontent.com/1592327/121957977-d27b7d80-ccfe-11eb-8971-14c4351964ca.png)
