### PR TITLE
chore(truncate): add required title prop to Truncate

### DIFF
--- a/.changeset/tricky-spiders-matter.md
+++ b/.changeset/tricky-spiders-matter.md
@@ -1,0 +1,7 @@
+---
+'@twilio-paste/truncate': major
+'@twilio-paste/core': major
+---
+
+[Truncate] Added the title prop to show full non-truncated text
+BREAKING CHANGE: `title` prop is now required for the Truncate component.

--- a/packages/paste-core/components/alert/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert/stories/index.stories.tsx
@@ -52,7 +52,9 @@ export const Neutral = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Alert>
       </Box>
@@ -126,7 +128,9 @@ export const Warning = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Alert>
       </Box>

--- a/packages/paste-core/components/alert/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert/stories/index.stories.tsx
@@ -91,7 +91,9 @@ export const Error = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Alert>
       </Box>

--- a/packages/paste-core/components/disclosure/stories/index.stories.tsx
+++ b/packages/paste-core/components/disclosure/stories/index.stories.tsx
@@ -163,7 +163,9 @@ export const TruncatedHeader = (): React.ReactNode => {
     <Box width="size40">
       <Disclosure variant="contained">
         <DisclosureHeading as="h3" variant="heading30">
-          <Truncate>This is a really long header with truncation</Truncate>
+          <Truncate title="This is a really long header with truncation">
+            This is a really long header with truncation
+          </Truncate>
         </DisclosureHeading>
         <DisclosureContent>
           Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac cursus

--- a/packages/paste-core/components/table/stories/index.stories.tsx
+++ b/packages/paste-core/components/table/stories/index.stories.tsx
@@ -952,7 +952,7 @@ export const Truncation = (): React.ReactNode => {
       <TBody>
         <Tr>
           <Td>
-            <Truncate>Some very long text to truncate</Truncate>
+            <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
           </Td>
           <Td>Empty</Td>
           <Td>Cell</Td>
@@ -965,7 +965,7 @@ export const Truncation = (): React.ReactNode => {
         </Tr>
         <Tr>
           <Td>
-            <Truncate>Some very long text to truncate</Truncate>
+            <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
           </Td>
           <Td>Empty</Td>
           <Td>Cell</Td>
@@ -978,7 +978,7 @@ export const Truncation = (): React.ReactNode => {
         </Tr>
         <Tr>
           <Td>
-            <Truncate>Some very long text to truncate</Truncate>
+            <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
           </Td>
           <Td>Empty</Td>
           <Td>Cell</Td>

--- a/packages/paste-core/components/toast/stories/index.stories.tsx
+++ b/packages/paste-core/components/toast/stories/index.stories.tsx
@@ -49,7 +49,9 @@ export const Neutral = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Toast>
       </ToastContainer>
@@ -86,7 +88,9 @@ export const Success = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Toast>
       </ToastContainer>
@@ -123,7 +127,9 @@ export const Error = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Toast>
       </ToastContainer>
@@ -160,7 +166,9 @@ export const Warning = (): React.ReactNode => {
             ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
           </Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </Toast>
       </ToastContainer>

--- a/packages/paste-core/components/truncate/src/index.tsx
+++ b/packages/paste-core/components/truncate/src/index.tsx
@@ -4,6 +4,7 @@ import {Box, BoxProps} from '@twilio-paste/box';
 
 export interface TruncateProps extends Omit<React.HtmlHTMLAttributes<HTMLSpanElement>, 'color'>, Pick<BoxProps, 'as'> {
   children: NonNullable<React.ReactNode>;
+  title: NonNullable<string>;
 }
 
 const Truncate = React.forwardRef<HTMLSpanElement, TruncateProps>(({children, ...props}, ref) => {
@@ -27,6 +28,7 @@ Truncate.displayName = 'Truncate';
 if (process.env.NODE_ENV === 'development') {
   Truncate.propTypes = {
     children: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired,
   };
 }
 

--- a/packages/paste-core/components/truncate/src/index.tsx
+++ b/packages/paste-core/components/truncate/src/index.tsx
@@ -4,7 +4,7 @@ import {Box, BoxProps} from '@twilio-paste/box';
 
 export interface TruncateProps extends Omit<React.HtmlHTMLAttributes<HTMLSpanElement>, 'color'>, Pick<BoxProps, 'as'> {
   children: NonNullable<React.ReactNode>;
-  title: NonNullable<string>;
+  title: string;
 }
 
 const Truncate = React.forwardRef<HTMLSpanElement, TruncateProps>(({children, ...props}, ref) => {

--- a/packages/paste-core/components/truncate/stories/index.stories.tsx
+++ b/packages/paste-core/components/truncate/stories/index.stories.tsx
@@ -13,7 +13,7 @@ export const Default = (): React.ReactNode => {
   return (
     <Box maxWidth="size20">
       <Text as="p">
-        <Truncate>Some very long text to truncate</Truncate>
+        <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
       </Text>
     </Box>
   );

--- a/packages/paste-core/layout/flex/stories/index.stories.tsx
+++ b/packages/paste-core/layout/flex/stories/index.stories.tsx
@@ -384,10 +384,14 @@ export const ContainedWidth = (): React.ReactNode => {
       <Paragraph>Text should not cause the flex boxes to break out of their containers when too long.</Paragraph>
       <Flex>
         <Flex>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Flex>
         <Flex>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Flex>
       </Flex>
     </Box>

--- a/packages/paste-core/layout/grid/stories/index.stories.tsx
+++ b/packages/paste-core/layout/grid/stories/index.stories.tsx
@@ -875,18 +875,26 @@ export const GridContainingLongContent = (): React.ReactNode => {
       </Text>
       <Grid gutter="space70">
         <Column span={8}>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Column>
         <Column span={4}>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Column>
       </Grid>
       <Grid gutter="space70">
         <Column>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Column>
         <Column>
-          <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+          <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+            http://www.extremelylongurlthatmightbreakthelayout.com
+          </Truncate>
         </Column>
       </Grid>
     </Box>

--- a/packages/paste-core/layout/media-object/stories/index.stories.tsx
+++ b/packages/paste-core/layout/media-object/stories/index.stories.tsx
@@ -82,7 +82,9 @@ export const ConstrainedWidth = (): React.ReactNode => {
         <MediaBody as="div">
           <Text as="p">Some media Object body text</Text>
           <Text as="p">
-            <Truncate>http://www.extremelylongurlthatmightbreakthelayout.com</Truncate>
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
           </Text>
         </MediaBody>
         <MediaFigure as="div" align="end" spacing="space70">

--- a/packages/paste-website/src/components/icons-list/IconTile.tsx
+++ b/packages/paste-website/src/components/icons-list/IconTile.tsx
@@ -50,7 +50,7 @@ const IconTile = React.forwardRef<HTMLButtonElement, IconTileProps>(({children, 
       {children}
       <Box as="div" display="flex" color="colorTextWeak" marginTop="space30" maxWidth="100%">
         <ScreenReaderOnly>Show details for:</ScreenReaderOnly>
-        <Truncate>{icon.name.replace('Icon', '')}</Truncate>
+        <Truncate title={icon.name}>{icon.name.replace('Icon', '')}</Truncate>
       </Box>
     </Box>
   );

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -859,7 +859,7 @@ long URLs, and the user does not need to read the full URL.
       <Th scope="row">Adam Brown</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td>
-        <Truncate>
+        <Truncate title="Learn more about Paste">
           <Anchor href="/getting-started/about-paste">
             https://paste.twilio.design/getting-started/about-paste
           </Anchor>
@@ -870,7 +870,7 @@ long URLs, and the user does not need to read the full URL.
       <Th scope="row">Adriana Lovelock</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td>
-        <Truncate>
+        <Truncate title="Learn more about Paste">
           <Anchor href="/getting-started/about-paste">
             https://paste.twilio.design/getting-started/about-paste
           </Anchor>
@@ -881,7 +881,7 @@ long URLs, and the user does not need to read the full URL.
       <Th scope="row">Amanda Cutlack</Th>
       <Td>English, French, Sales, Spanish</Td>
       <Td>
-        <Truncate>
+        <Truncate title="Learn more about Paste">
           <Anchor href="/getting-started/about-paste">
             https://paste.twilio.design/getting-started/about-paste
           </Anchor>

--- a/packages/paste-website/src/pages/components/truncate/index.mdx
+++ b/packages/paste-website/src/pages/components/truncate/index.mdx
@@ -116,7 +116,7 @@ spans the full width of a container.
 >
   {`<Box maxWidth="size30">
   <Text as="p">
-    <Truncate>Black Lives Matter. We stand with the Black community.</Truncate>
+    <Truncate title="Black Lives Matter. We stand with the Black community.">Black Lives Matter. We stand with the Black community.</Truncate>
   </Text>
 </Box>`}
 </LivePreview>
@@ -132,7 +132,7 @@ spans the full width of a container.
 >
   {`<Box maxWidth="size30">
   <Anchor href="/getting-started/about-paste">
-    <Truncate>https://paste.twilio.design/getting-started/about-paste</Truncate>
+    <Truncate title="Learn more about Paste">https://paste.twilio.design/getting-started/about-paste</Truncate>
   </Anchor>
 </Box>`}
 </LivePreview>
@@ -153,7 +153,7 @@ spans the full width of a container.
     <Alert variant="error">
       <Box maxWidth="size20">
         <Text as="span">
-          <Truncate>
+          <Truncate title="Your account balance is low and your credit card has expired. As a result we have suspended your account">
             Your account balance is low and your credit card has expired. As a result we have suspended your account
           </Truncate>
         </Text>
@@ -183,7 +183,7 @@ const Component: React.FC = () => {
   return (
     <Box maxWidth="size20">
       <Text as="p">
-        <Truncate>Some very long text to truncate</Truncate>
+        <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
       </Text>
     </Box>
   );
@@ -195,6 +195,7 @@ const Component: React.FC = () => {
 | Prop     | Type        | Description | Default |
 | -------- | ----------- | ----------- | ------- |
 | children | `ReactNode` |             | null    |
+| title    | `string`    |             | null    |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/truncate/index.mdx
+++ b/packages/paste-website/src/pages/components/truncate/index.mdx
@@ -141,7 +141,7 @@ spans the full width of a container.
   <Do title="Do" body="Use Truncate to shorten text that doesn't fit in its parent container">
     <Box maxWidth="size20" padding="space60">
       <Text as="p">
-        <Truncate>Some very long text to truncate</Truncate>
+        <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
       </Text>
     </Box>
   </Do>


### PR DESCRIPTION
Added a required title `prop` to the `Truncate` component API, intended to represent the full truncated text.