### PR TITLE
feat(website): add product suitability to the patterns header

### DIFF
--- a/packages/paste-website/src/components/ProductBadge.tsx
+++ b/packages/paste-website/src/components/ProductBadge.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+
+const ProductBadge: React.FC = ({children}) => {
+  return (
+    <Box backgroundColor="colorBackgroundStrong" paddingX="space20" borderRadius="borderRadius20">
+      {children}
+    </Box>
+  );
+};
+
+export {ProductBadge};

--- a/packages/paste-website/src/components/shortcodes/package-status-legend/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/package-status-legend/index.tsx
@@ -23,7 +23,7 @@ const PackageStatusLegend: React.FC<PackageStatusLegendProps> = ({packageStatus}
   } = packageStatus[0].node.data;
 
   return (
-    <Box marginBottom="space100">
+    <Box marginBottom="space70">
       <Stack orientation="horizontal" spacing="space60">
         <Box display="flex" alignItems="center">
           <Text as="span" marginRight="space20">

--- a/packages/paste-website/src/components/shortcodes/pattern-header/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/pattern-header/index.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
 import {Heading} from '@twilio-paste/heading';
+import {Stack} from '@twilio-paste/stack';
 import {PackageLabel, PackageValue} from '../component-header';
 import {PackageStatusLegend} from '../package-status-legend';
 import {P} from '../../Typography';
 import {Breadcrumb, BreadcrumbItem} from '../../breadcrumb';
 import {sentenceCase} from '../../../utils/SentenceCase';
 import type {PackageStatusObject} from '../../../utils/types';
+import {ProductBadge} from '../../ProductBadge';
 
 const PatternHeaderBasic: React.FC<{
   name: string;
@@ -43,6 +45,18 @@ const PatternHeader: React.FC<PatternHeaderProps> = ({description, name, package
           <Box marginBottom="space20">
             <PackageLabel>Status</PackageLabel>
             <PackageValue>{sentenceCase(packageStatus[0].node.data.status)}</PackageValue>
+          </Box>
+        )}
+        {packageStatus[0].node.data.Product_suitability && (
+          <Box marginBottom="space20">
+            <PackageLabel>Products</PackageLabel>
+            <PackageValue>
+              <Stack orientation="horizontal" spacing="space20">
+                {packageStatus[0].node.data.Product_suitability.map((product) => (
+                  <ProductBadge>{product}</ProductBadge>
+                ))}
+              </Stack>
+            </PackageValue>
           </Box>
         )}
       </Box>

--- a/packages/paste-website/src/pages/patterns/button-vs-anchor/index.mdx
+++ b/packages/paste-website/src/pages/patterns/button-vs-anchor/index.mdx
@@ -41,6 +41,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/pages/patterns/create/index.mdx
+++ b/packages/paste-website/src/pages/patterns/create/index.mdx
@@ -39,6 +39,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/pages/patterns/delete/index.mdx
+++ b/packages/paste-website/src/pages/patterns/delete/index.mdx
@@ -39,6 +39,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/pages/patterns/empty-states/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-states/index.mdx
@@ -40,6 +40,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/pages/patterns/notifications-and-feedback/index.mdx
+++ b/packages/paste-website/src/pages/patterns/notifications-and-feedback/index.mdx
@@ -46,6 +46,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/pages/patterns/object-details/index.mdx
+++ b/packages/paste-website/src/pages/patterns/object-details/index.mdx
@@ -42,6 +42,7 @@ export const pageQuery = graphql`
             Engineer_committee_review
             Code
             status
+            Product_suitability
           }
         }
       }

--- a/packages/paste-website/src/utils/types.ts
+++ b/packages/paste-website/src/utils/types.ts
@@ -8,6 +8,7 @@ export type PackageStatusObject = [
         Engineer_committee_review: string;
         Code: string;
         status: string;
+        Product_suitability: ['Console' | 'SendGrid' | 'Flex'];
       };
     };
   }


### PR DESCRIPTION
Using the system Airtable, define product suitability for certain patterns. 

Which products are a pattern suitable to be used in? Not all patterns are created equally. Not all products should use all patterns. 

This PR adds a small products callout to the patterns header to clearly indicate where a Pattern could be leveraged.

Added a 'pattern' option to the System Hierarchy column, and added a "Product Suitability" column with a multi select to the Airtable

![image](https://user-images.githubusercontent.com/368249/123888635-c4d21480-d908-11eb-90f8-8c4355216369.png)
