### PR TITLE
chore: first codeowners iteration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @twilio-labs/design-system-eng-leads
+
+# Paste core - round robin someone from the team and a lead for review
+/packages/ @twilio-labs/design-systems-eng @twilio-labs/design-system-eng-leads
+
+# Design tokens - ensure someone from design reviews to keep in sync with Figma
+/packages/paste-design-tokens @twilio-labs/design-systems-pd @twilio-labs/design-system-eng-leads


### PR DESCRIPTION
To set up PR auto assignment we need some teams and codeowners.

This should do the following:

- Any changes to design tokens gets a product designer and tech lead reviewer
- Any changes to any packages gets a engineer and a tech lead reviewer
- Anything else gets a tech lead reviewer