### PR TITLE
chore: set up mergify and PR labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+# https://github.com/actions/labeler
+
+# Add 'repo' label to any root file changes
+"Area: Repo":
+  - "*"
+
+"Area: Components":
+  - packages/paste-core/components/**/*
+
+"Area: Doc Site":
+  - packages/paste-website/**/*
+
+"Area: Theme":
+  - packages/paste-theme/**/*
+
+"Area: Tokens":
+  - packages/paste-design-tokens/**/*
+
+"Area: Storybook":
+  - .storybook/**/*
+
+"Area: Infrastructure":
+  - .eslint/**/*
+  - .github/**/*
+  - .jest/**/*
+  - .vscode/**/*
+  - tools/**/*
+
+"Type: Documentation":
+  - packages/paste-website/src/pages/**/*
+
+"Type: Tests":
+  - "**/__tests__/**/*"
+  - cypress/**/*

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,26 @@
+queue_rules:
+  # once on the merge queue, mergify always makes sure the pr is up to date with the target branch before merging.
+  - name: default
+    conditions:
+      - base=main
+
+pull_request_rules:
+  # mergify always respects branch protection rules, which includes required CI checks
+  - name: automatic merge for main when labelled ready to merge
+    # when against main, labelled "ready-to-merge" and approved by 2 reviewers, PR is added to the merge queue
+    conditions:
+      - base=main
+      # must be approved and have no out standing change requests
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      # must be labelled ready-to-merge and not do-not-merge
+      - "label=Status: Ready to merge"
+      - "label!=Status: Do Not Merge"
+    actions:
+      queue:
+        # name of queue to add to
+        name: default
+        # rebase onto main as the primary method of merging the PR
+        method: rebase
+        # if rebase can't happen, squash the commits onto main
+        rebase_fallback: squash

--- a/.github/opened-pr-labeler.yml
+++ b/.github/opened-pr-labeler.yml
@@ -1,0 +1,5 @@
+# https://github.com/actions/labeler
+
+# Add 'Status: Do Not Merge' label to any newly opened PR
+"Status: Do Not Merge":
+  - "**/*"

--- a/.github/workflows/opened-pr-labeler.yml
+++ b/.github/workflows/opened-pr-labeler.yml
@@ -1,0 +1,14 @@
+name: Opened Pull Request Labeler
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/opened-pr-labeler.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: Pull Request Categorizer
+
+on: pull_request
+
+jobs:
+  pr-categorizer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
Set up Mergify for handling our merge queue better.

Merging will be based on a "ready to merge" label. For some extra protection if it's labelled with "do not merge" it will be ignored regardless of checks and approvals.

Also set up auto labeling to help manage labelling of PRs. New ones get do not merge by default.