### PR TITLE
fix(tabs): adjust TabPanel focus state

### DIFF
--- a/.changeset/cold-impalas-decide.md
+++ b/.changeset/cold-impalas-decide.md
@@ -1,0 +1,9 @@
+---
+'@twilio-paste/tabs': patch
+'@twilio-paste/core': patch
+---
+
+[Tabs]
+
+- Added `:focus-visible` styles to TabPanel in order to override the default browser style.
+- Added a `borderRadius20` border-radius to TabPanel to make the focus not so harsh.

--- a/.changeset/gold-mugs-float.md
+++ b/.changeset/gold-mugs-float.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/box': patch
+'@twilio-paste/core': patch
+---
+
+[Box] Added `focusVisble` to `PseudoPropStyles`.

--- a/packages/paste-core/components/tabs/src/TabPanel.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanel.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import {Box} from '@twilio-paste/box';
+import type {BoxStyleProps} from '@twilio-paste/box';
 import {TabPrimitivePanel} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
+
+export const tabPanelStyles = {
+  borderRadius: 'borderRadius20',
+  _focusVisible: {
+    boxShadow: 'shadowFocus',
+    outline: 'none',
+  },
+} as Partial<BoxStyleProps>;
 
 export interface TabPanelProps {
   id?: string | undefined;
@@ -12,7 +22,7 @@ export interface TabPanelProps {
 const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, ...props}, ref) => {
   const tab = React.useContext(TabsContext);
   return (
-    <TabPrimitivePanel {...(tab as any)} {...props} ref={ref}>
+    <TabPrimitivePanel {...(tab as any)} {...tabPanelStyles} {...props} as={Box} ref={ref}>
       {children}
     </TabPrimitivePanel>
   );

--- a/packages/paste-core/primitives/box/__tests__/box.test.tsx
+++ b/packages/paste-core/primitives/box/__tests__/box.test.tsx
@@ -439,6 +439,7 @@ describe('ZIndex', () => {
             _before={{padding: 'space10'}}
             _after={{padding: 'space10'}}
             _focusWithin={{padding: 'space10'}}
+            _focusVisible={{padding: 'space10'}}
             _placeholder={{padding: 'space10'}}
             data-testid="box"
           >
@@ -470,6 +471,7 @@ describe('ZIndex', () => {
       expect(renderedBox).toHaveStyleRule('padding', '0.125rem', {target: ':before'});
       expect(renderedBox).toHaveStyleRule('padding', '0.125rem', {target: ':after'});
       expect(renderedBox).toHaveStyleRule('padding', '0.125rem', {target: ':focus-within'});
+      expect(renderedBox).toHaveStyleRule('padding', '0.125rem', {target: ':focus-visible'});
       expect(renderedBox).toHaveStyleRule('padding', '0.125rem', {target: '::placeholder'});
     });
   });

--- a/packages/paste-core/primitives/box/src/PseudoPropStyles.ts
+++ b/packages/paste-core/primitives/box/src/PseudoPropStyles.ts
@@ -27,6 +27,7 @@ export const PseudoPropStyles = {
   _before: '&:before',
   _after: '&:after',
   _focusWithin: '&:focus-within',
+  _focusVisible: '&:focus-visible',
   _placeholder: '&::placeholder',
   __moz_focus_inner: '&::-moz-focus-inner',
 };


### PR DESCRIPTION
- [x] Changed TabPanel focus state to use `focus-visible` and match the standard Paste focus styles
- [x] Added `focus-visible` to Box pseudo-styles