### PR TITLE
fix(tooltip): prevent child props being overridden/swallowed by tooltip

### DIFF
--- a/.changeset/seven-moons-shop.md
+++ b/.changeset/seven-moons-shop.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/tooltip': patch
+---
+
+[Tooltip] Fix a bug where the Tooltip component was swallowing the event handlers of the child component it was wrapping

--- a/packages/paste-core/components/tooltip/__test__/index.spec.tsx
+++ b/packages/paste-core/components/tooltip/__test__/index.spec.tsx
@@ -70,8 +70,13 @@ describe('Tooltip', () => {
           </Tooltip>
         </Theme.Provider>
       );
-      await act(async () => screen.getByRole('button').focus());
-      await act(async () => fireEvent.click(document.activeElement));
+      await act(async () => {
+        await screen.getByRole('button').focus();
+      });
+      await act(async () => {
+        // @ts-expect-error yes, I know activeElement MIGHT be null, but it's not, OK?
+        await fireEvent.click(document.activeElement);
+      });
       expect(focusHandlerMock).toHaveBeenCalled();
       expect(clickHandlerMock).toHaveBeenCalled();
     });

--- a/packages/paste-core/components/tooltip/__test__/index.spec.tsx
+++ b/packages/paste-core/components/tooltip/__test__/index.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {render, screen} from '@testing-library/react';
+import {act, fireEvent, render, screen} from '@testing-library/react';
 import {Button} from '@twilio-paste/button';
 import {Theme} from '@twilio-paste/theme';
 // @ts-ignore typescript doesn't like js imports
@@ -54,6 +54,26 @@ describe('Tooltip', () => {
         return;
       }
       expect(tooltip.getAttribute('hidden')).toBeDefined();
+    });
+  });
+
+  describe('Children', () => {
+    it('should not override child provided events such as onBlur or onFocus', async () => {
+      const focusHandlerMock: jest.Mock = jest.fn();
+      const clickHandlerMock: jest.Mock = jest.fn();
+      render(
+        <Theme.Provider theme="console">
+          <Tooltip text="Welcome to Paste!" data-testid="tooltip-children-example">
+            <Button variant="primary" onFocus={focusHandlerMock} onClick={clickHandlerMock}>
+              Open Tooltip
+            </Button>
+          </Tooltip>
+        </Theme.Provider>
+      );
+      await act(async () => screen.getByRole('button').focus());
+      await act(async () => fireEvent.click(document.activeElement));
+      expect(focusHandlerMock).toHaveBeenCalled();
+      expect(clickHandlerMock).toHaveBeenCalled();
     });
   });
 

--- a/packages/paste-core/components/tooltip/__test__/index.spec.tsx
+++ b/packages/paste-core/components/tooltip/__test__/index.spec.tsx
@@ -39,7 +39,7 @@ describe('Tooltip', () => {
       if (ButtonOne === null || ButtonTwo === null || tooltip === null) {
         return;
       }
-      expect(tooltip.getAttribute('hidden')).toBeDefined();
+      expect(tooltip.getAttribute('hidden')).not.toBeNull();
 
       ButtonOne.click();
       tooltip = screen.queryByTestId('state-hook-tooltip');
@@ -53,7 +53,7 @@ describe('Tooltip', () => {
       if (tooltip === null) {
         return;
       }
-      expect(tooltip.getAttribute('hidden')).toBeDefined();
+      expect(tooltip.getAttribute('hidden')).not.toBeNull();
     });
   });
 
@@ -72,7 +72,7 @@ describe('Tooltip', () => {
       );
       const tooltip = screen.getByTestId('tooltip-children-example');
 
-      expect(tooltip.getAttribute('hidden')).toBeDefined();
+      expect(tooltip.getAttribute('hidden')).not.toBeNull();
 
       await act(async () => {
         await screen.getByRole('button').focus();
@@ -85,7 +85,6 @@ describe('Tooltip', () => {
         await fireEvent.click(document.activeElement);
       });
 
-      expect(tooltip.getAttribute('hidden')).toBeDefined();
       expect(focusHandlerMock).toHaveBeenCalled();
       expect(clickHandlerMock).toHaveBeenCalled();
     });

--- a/packages/paste-core/components/tooltip/__test__/index.spec.tsx
+++ b/packages/paste-core/components/tooltip/__test__/index.spec.tsx
@@ -70,13 +70,22 @@ describe('Tooltip', () => {
           </Tooltip>
         </Theme.Provider>
       );
+      const tooltip = screen.getByTestId('tooltip-children-example');
+
+      expect(tooltip.getAttribute('hidden')).toBeDefined();
+
       await act(async () => {
         await screen.getByRole('button').focus();
       });
+
+      expect(tooltip.getAttribute('hidden')).toBeNull();
+
       await act(async () => {
         // @ts-expect-error yes, I know activeElement MIGHT be null, but it's not, OK?
         await fireEvent.click(document.activeElement);
       });
+
+      expect(tooltip.getAttribute('hidden')).toBeDefined();
       expect(focusHandlerMock).toHaveBeenCalled();
       expect(clickHandlerMock).toHaveBeenCalled();
     });

--- a/packages/paste-core/components/tooltip/src/index.tsx
+++ b/packages/paste-core/components/tooltip/src/index.tsx
@@ -49,7 +49,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(({baseId, childre
   return (
     <>
       {React.Children.only(
-        <TooltipPrimitiveReference {...tooltip} ref={ref}>
+        <TooltipPrimitiveReference {...tooltip} ref={ref} {...children.props}>
           {(referenceProps) => React.cloneElement(children, referenceProps)}
         </TooltipPrimitiveReference>
       )}


### PR DESCRIPTION
When cloning the child wrapped by the tooltip, we are not mixing in the child props that are provided by the consumer.

This means there can be cases where provided props are not called on the trigger element when wrapped in a tooltip as
they no longer exist when we clone it.

Spreading the children props on the tooltip before we clone means they are present when we clone using the referenceProps
