### PR TITLE
fix(alert-dialog): added missing date-fns dependency

### DIFF
--- a/.changeset/orange-jeans-destroy.md
+++ b/.changeset/orange-jeans-destroy.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/alert-dialog': patch
+'@twilio-paste/core': patch
+---
+
+[AlertDialog]: added missing `@twilio-paste/uid-library` dependency.

--- a/.changeset/short-taxis-shout.md
+++ b/.changeset/short-taxis-shout.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/time-picker': patch
+'@twilio-paste/core': patch
+---
+
+[TimePicker]: added missing `date-fns` dependency.

--- a/packages/paste-core/components/alert-dialog/package.json
+++ b/packages/paste-core/components/alert-dialog/package.json
@@ -35,6 +35,7 @@
     "@twilio-paste/styling-library": "^0.3.1",
     "@twilio-paste/theme": "^5.0.1",
     "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
@@ -50,6 +51,7 @@
     "@twilio-paste/styling-library": "^0.3.3",
     "@twilio-paste/theme": "^5.2.0",
     "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/packages/paste-core/components/time-picker/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/time-picker/__tests__/index.spec.tsx
@@ -24,11 +24,11 @@ describe('formatReturnTime()', () => {
     expect(formatReturnTime(TEST_TIME, 'hh:mm:ss')).toEqual('01:30:04');
     expect(formatReturnTime(TEST_TIME, 'HH:mm:ss.SSS')).toEqual('13:30:04.000');
     expect(formatReturnTime(TEST_TIME, 'HH:mm:ss.SSS')).toEqual('13:30:04.000');
-    expect(formatReturnTime(TEST_TIME, 'hh:mm:ss.SSS aa')).toEqual('01:30:04.000 p.m.');
+    expect(formatReturnTime(TEST_TIME, 'hh:mm:ss.SSS aa')).toEqual('01:30:04.000 PM');
   });
   it('should format times with edge cases and catch errors', () => {
     // testing midnight
-    expect(formatReturnTime('00:00', 'hh:mm A')).toEqual('12:00 AM');
+    expect(formatReturnTime('00:00', 'hh:mm aa')).toEqual('12:00 AM');
     // test for edge cases (passing in time+date value) to throw an error
     expect(() => {
       formatReturnTime('2022-03-01T03:35Z', 'hh:mm:ss');

--- a/packages/paste-core/components/time-picker/package.json
+++ b/packages/paste-core/components/time-picker/package.json
@@ -24,6 +24,9 @@
     "clean": "rm -rf ./dist",
     "tsc": "tsc"
   },
+  "dependencies": {
+    "date-fns": "2.21.3"
+  },
   "peerDependencies": {
     "@twilio-paste/box": "^4.0.2",
     "@twilio-paste/design-tokens": "^6.6.0",


### PR DESCRIPTION
While I was working on the `pnpm` spike, I noticed we missed a dependency on `AlertDialog` and `TimePicker`. This adds those.