### PR TITLE
chore(website): fix typo on patterns page

### DIFF
--- a/packages/paste-website/src/pages/patterns/index.mdx
+++ b/packages/paste-website/src/pages/patterns/index.mdx
@@ -74,7 +74,7 @@ export const pageQuery = graphql`
 
 ## What is a pattern?
 
-Patterns outline how to bring a collection of components together into a reusable solution that solves customer problems and delivers cohesion across our platforms. They are set of guidelines around a particular user flow or interaction that designers and engineers should follow when creating customer experiences.
+Patterns outline how to bring a collection of components together into a reusable solution that solves customer problems and delivers cohesion across our platforms. They are a set of guidelines around a particular user flow or interaction that designers and engineers should follow when creating customer experiences.
 
 There are two primary goals of patterns:
 


### PR DESCRIPTION
I found a typo on the patterns page.