### PR TITLE
chore: ensure changes to icon svgs are reviewed by a designer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 
 # Design tokens - ensure someone from design reviews to keep in sync with Figma
 /packages/paste-design-tokens @twilio-labs/design-systems-pd @twilio-labs/design-system-eng-leads
+
+# Icons - ensure changes to icons are reviewed by a designer
+/packages/paste-icons/svg @twilio-labs/design-systems-pd


### PR DESCRIPTION
Setting the `@twilio-labs/design-systems-pd` team as a code owner of the SVGs means that any PRs opened that change any of the SVGs will automatically get a product designer as a required reviewer
