### PR TITLE
fix(website): waits longer for opengraph card previews

### DIFF
--- a/packages/paste-website/functions/opengraph.ts
+++ b/packages/paste-website/functions/opengraph.ts
@@ -77,7 +77,7 @@ const handler: Handler = async (event) => {
     // console.log('Visiting page:', pageToVisit, Date.now());
     await page.goto(pageToVisit, {
       // wait for the load event as we need JS to render the page
-      waitUntil: 'networkidle2',
+      waitUntil: 'networkidle0',
     });
     // console.log('Page visited', Date.now());
 


### PR DESCRIPTION
This PR should hopefully fix the `Invalid Request` preview cards in production.

I had this set to `2` because of Netlify's custom widget on preview deploy URLs. On prod, it is now taking screenshots too quickly and we want to wait until the page is fully loaded.