### PR TITLE
Feat/stack customization

### DIFF
--- a/.changeset/nice-ravens-remember.md
+++ b/.changeset/nice-ravens-remember.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/stack': minor
+'@twilio-paste/core': minor
+---
+
+[Stack] Enable stack and stack children to respect element customizations set on the customization provider. Stack and stack children now enable setting an element name on the underlying HTML element, and checks the emotion theme object to determine whether it should merge in custom styles to the ones set by the component author.

--- a/packages/paste-core/layout/stack/__tests__/stack.test.tsx
+++ b/packages/paste-core/layout/stack/__tests__/stack.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {matchers} from 'jest-emotion';
 import {Card} from '@twilio-paste/card';
 import {getStackDisplay, getStackStyles, getStackChildMargins, Stack, StackOrientation} from '../src';
+import {CustomizationProvider} from '@twilio-paste/customization';
 
 expect.extend(matchers);
 
@@ -103,5 +104,91 @@ describe('Stack', () => {
     expect(mockSingleChildHorizontal).not.toHaveStyleRule('marginRight', 'space60');
     const mockSingleChildVertical = getByTestId('single-vertical');
     expect(mockSingleChildVertical).not.toHaveStyleRule('marginBottom', 'space60');
+  });
+});
+
+describe('Stack Customization', () => {
+  it('should set a custom element attribute for Stack', (): void => {
+    render(
+      <CustomizationProvider baseTheme="default">
+        <Stack orientation="vertical" spacing="space0" data-testid="stack-customization">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    const renderedBox = screen.getByTestId('stack-customization');
+    expect(renderedBox).toHaveAttribute('data-paste-element', 'STACK');
+  });
+
+  it('should set a custom element attribute for Stack Children', (): void => {
+    const {container} = render(
+      <CustomizationProvider baseTheme="default">
+        <Stack orientation="vertical" spacing="space0">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    expect(container.querySelector('[data-paste-element="STACK_CHILD"]')).toBeInTheDocument();
+  });
+
+  it('should allow a custom element name to be set for Stack', (): void => {
+    render(
+      <CustomizationProvider baseTheme="default">
+        <Stack element="STACKY" orientation="vertical" spacing="space0" data-testid="stack-customization-name">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    const renderedBox = screen.getByTestId('stack-customization-name');
+    expect(renderedBox).toHaveAttribute('data-paste-element', 'STACKY');
+  });
+
+  it('should allow a custom element name to be set for Stack children', (): void => {
+    const {container} = render(
+      <CustomizationProvider baseTheme="default">
+        <Stack element="STACKY" orientation="vertical" spacing="space0">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    expect(container.querySelector('[data-paste-element="STACKY_CHILD"]')).toBeInTheDocument();
+  });
+
+  it('should style Stack according to the customization provider', (): void => {
+    render(
+      <CustomizationProvider
+        baseTheme="default"
+        elements={{STACK: {color: 'colorTextWeak', backgroundColor: 'colorBackground'}}}
+      >
+        <Stack orientation="vertical" spacing="space0" data-testid="customizable-stack">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    const renderedBox = screen.getByTestId('customizable-stack');
+    expect(renderedBox).toHaveStyleRule('background-color', 'rgb(244,244,246)');
+    expect(renderedBox).toHaveStyleRule('color', 'rgb(96,107,133)');
+  });
+
+  it('should style Stack children according to the customization provider', (): void => {
+    const {container} = render(
+      <CustomizationProvider
+        baseTheme="default"
+        elements={{STACK_CHILD: {color: 'colorTextWeak', backgroundColor: 'colorBackground'}}}
+      >
+        <Stack orientation="vertical" spacing="space0">
+          <p>One</p>
+          <p>Two</p>
+        </Stack>
+      </CustomizationProvider>
+    );
+    const childNode = container.querySelector('[data-paste-element="STACK_CHILD"]');
+    expect(childNode).toHaveStyleRule('background-color', 'rgb(244,244,246)');
+    expect(childNode).toHaveStyleRule('color', 'rgb(96,107,133)');
   });
 });

--- a/packages/paste-core/layout/stack/__tests__/stack.test.tsx
+++ b/packages/paste-core/layout/stack/__tests__/stack.test.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import {render, screen} from '@testing-library/react';
 import {matchers} from 'jest-emotion';
 import {Card} from '@twilio-paste/card';
-import {getStackDisplay, getStackStyles, getStackChildMargins, Stack, StackOrientation} from '../src';
 import {CustomizationProvider} from '@twilio-paste/customization';
+import type {StackOrientation} from '../src';
+import {getStackDisplay, getStackStyles, getStackChildMargins, Stack} from '../src';
 
 expect.extend(matchers);
 

--- a/packages/paste-core/layout/stack/__tests__/stack.test.tsx
+++ b/packages/paste-core/layout/stack/__tests__/stack.test.tsx
@@ -109,7 +109,7 @@ describe('Stack', () => {
 });
 
 describe('Stack Customization', () => {
-  it('should set a custom element attribute for Stack', (): void => {
+  it('should set the data-paste-element attribute for Stack to "STACK"', (): void => {
     render(
       <CustomizationProvider baseTheme="default">
         <Stack orientation="vertical" spacing="space0" data-testid="stack-customization">
@@ -122,7 +122,7 @@ describe('Stack Customization', () => {
     expect(renderedBox).toHaveAttribute('data-paste-element', 'STACK');
   });
 
-  it('should set a custom element attribute for Stack Children', (): void => {
+  it('should set the data-paste-attribute attribute for Stack Children to "STACK_CHILD"', (): void => {
     const {container} = render(
       <CustomizationProvider baseTheme="default">
         <Stack orientation="vertical" spacing="space0">

--- a/packages/paste-core/layout/stack/src/index.tsx
+++ b/packages/paste-core/layout/stack/src/index.tsx
@@ -81,37 +81,42 @@ export const getStackChildMargins = (orientation: StackOrientation, spacing: Spa
   return styles;
 };
 
-const Stack = React.forwardRef<HTMLDivElement, StackProps>(({children, orientation, spacing, ...props}, ref) => {
-  const [childrenCount, validChildren] = React.useMemo(() => {
-    const filteredChildren = React.Children.toArray(children).filter(
-      (child) => React.isValidElement(child) || typeof child === 'string'
-    );
-    return [filteredChildren.length, filteredChildren];
-  }, [children]);
-  const stackStyles = React.useMemo(() => getStackStyles(orientation), [orientation]);
-  const childMargins = React.useMemo(() => getStackChildMargins(orientation, spacing), [orientation, spacing]);
-  const keySeed = useUIDSeed();
+const Stack = React.forwardRef<HTMLDivElement, StackProps>(
+  ({children, orientation, spacing, element = 'STACK', ...props}, ref) => {
+    const [childrenCount, validChildren] = React.useMemo(() => {
+      const filteredChildren = React.Children.toArray(children).filter(
+        (child) => React.isValidElement(child) || typeof child === 'string'
+      );
+      return [filteredChildren.length, filteredChildren];
+    }, [children]);
+    const stackStyles = React.useMemo(() => getStackStyles(orientation), [orientation]);
+    const childMargins = React.useMemo(() => getStackChildMargins(orientation, spacing), [orientation, spacing]);
+    const keySeed = useUIDSeed();
 
-  return (
-    <Box {...safelySpreadBoxProps(props)} {...stackStyles} ref={ref}>
-      {validChildren.map((child, index) => {
-        return (
-          <Box {...(childrenCount !== index + 1 ? childMargins : null)} key={keySeed(`stack-${index}`)}>
-            {child}
-          </Box>
-        );
-      })}
-    </Box>
-  );
-});
+    return (
+      <Box element={element} {...safelySpreadBoxProps(props)} {...stackStyles} ref={ref}>
+        {validChildren.map((child, index) => {
+          return (
+            <Box
+              element={`${element}_CHILD`}
+              {...(childrenCount !== index + 1 ? childMargins : null)}
+              key={keySeed(`stack-${index}`)}
+            >
+              {child}
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  }
+);
 
 Stack.displayName = 'Stack';
 
-if (process.env.NODE_ENV === 'development') {
-  Stack.propTypes = {
-    orientation: ResponsiveProp(PropTypes.oneOf(['horizontal', 'vertical'])).isRequired,
-    spacing: isSpaceTokenProp,
-  };
-}
+Stack.propTypes = {
+  orientation: ResponsiveProp(PropTypes.oneOf(['horizontal', 'vertical'])).isRequired,
+  spacing: isSpaceTokenProp,
+  element: PropTypes.string,
+};
 
 export {Stack};

--- a/packages/paste-core/layout/stack/src/index.tsx
+++ b/packages/paste-core/layout/stack/src/index.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {useUIDSeed} from '@twilio-paste/uid-library';
-import {ResponsiveValue} from '@twilio-paste/styling-library';
-import {
-  isSpaceTokenProp,
-  ResponsiveProp,
-  LayoutProps,
-  FlexboxProps,
-  MarginProps,
-  SpaceOptions,
-} from '@twilio-paste/style-props';
-import {Box, BoxElementProps, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {ResponsiveValue} from '@twilio-paste/styling-library';
+import type {LayoutProps, FlexboxProps, MarginProps, SpaceOptions} from '@twilio-paste/style-props';
+import {isSpaceTokenProp, ResponsiveProp} from '@twilio-paste/style-props';
+import type {BoxElementProps} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 
 type StackChildMargins = Pick<MarginProps, 'marginRight' | 'marginBottom'>;
 type DisplayOptions = 'block' | 'flex';

--- a/packages/paste-core/layout/stack/stories/index.stories.tsx
+++ b/packages/paste-core/layout/stack/stories/index.stories.tsx
@@ -5,6 +5,7 @@ import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
 import {Paragraph} from '@twilio-paste/paragraph';
+import {CustomizationProvider} from '@twilio-paste/customization';
 import {Stack, StackOrientation} from '../src';
 
 const orientationOptions = ['horizontal', 'vertical'];
@@ -145,4 +146,86 @@ export const OneChild = (): React.ReactNode => {
 
 OneChild.story = {
   name: 'Stack - One Child',
+};
+
+export const CustomizedStack = (): React.ReactNode => {
+  return (
+    <>
+      <Stack orientation="vertical" spacing="space40">
+        <Card>
+          <Heading as="h2" variant="heading20">
+            First Card
+          </Heading>
+        </Card>
+
+        <Card>
+          <Heading as="h2" variant="heading20">
+            Second Card
+          </Heading>
+        </Card>
+      </Stack>
+
+      <CustomizationProvider
+        baseTheme="default"
+        elements={{
+          STACK: {
+            backgroundColor: 'colorBackground',
+            padding: 'space40',
+            color: 'colorTextWarning',
+          },
+          STACK_CHILD: {
+            flex: 1,
+          },
+          STACKY: {
+            padding: 'space40',
+          },
+          STACKY_CHILD: {
+            fontWeight: 'fontWeightBold',
+          },
+        }}
+      >
+        {/* Default Customized Stack */}
+        <Stack orientation={['vertical', 'vertical', 'horizontal']} spacing="space40">
+          <Card>
+            <Heading as="h2" variant="heading20">
+              First Card
+            </Heading>
+
+            <p>Customized Card content.</p>
+          </Card>
+
+          <Card>
+            <Heading as="h2" variant="heading20">
+              Second Card
+            </Heading>
+
+            <p>Customized Card content.</p>
+          </Card>
+        </Stack>
+
+        {/* Custom Named Stack */}
+        <Stack orientation="vertical" spacing="space40" element="STACKY">
+          <Card>
+            <Heading as="h2" variant="heading20">
+              First Card
+            </Heading>
+
+            <p>Customized Card content.</p>
+          </Card>
+
+          <Card>
+            <Heading as="h2" variant="heading20">
+              Second Card
+            </Heading>
+
+            <p>Customized Card content.</p>
+          </Card>
+        </Stack>
+      </CustomizationProvider>
+    </>
+  );
+};
+
+CustomizedStack.story = {
+  name: 'Stack - Customized',
 };

--- a/packages/paste-core/layout/stack/stories/index.stories.tsx
+++ b/packages/paste-core/layout/stack/stories/index.stories.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import {withKnobs, select} from '@storybook/addon-knobs';
-import {DefaultTheme, ThemeShape} from '@twilio-paste/theme';
+import type {ThemeShape} from '@twilio-paste/theme';
+import {DefaultTheme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {Stack, StackOrientation} from '../src';
+import type {StackOrientation} from '../src';
+import {Stack} from '../src';
 
 const orientationOptions = ['horizontal', 'vertical'];
 const spaceOptions = Object.keys(DefaultTheme.space);


### PR DESCRIPTION
* Enable stack and stack children to respect element customizations set on the customization provider. 
* Stack and stack children now enable setting an element name on the underlying HTML element, and checks the emotion theme object to determine whether it should merge in custom styles to the ones set by the component author.
* Stories and tests added to support this change