### PR TITLE
fix(combobox): let Downshift handle all props to fix out of sync events

### DIFF
--- a/.changeset/tall-phones-rescue.md
+++ b/.changeset/tall-phones-rescue.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/combobox': patch
+'@twilio-paste/core': patch
+---
+
+Allow Downshift to handle input events past by the component consumer. This allows for event data and internal state of the combobox to stay in sync correctly

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -151,6 +151,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
           <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
             <ComboboxInputSelect
               {...getToggleButtonProps({tabIndex: 0})}
+              // we spread props into `getInputProps` so that Downshift handles events correctly
               {...getInputProps({disabled, required, ref, ...props})}
               {...(!autocomplete ? {onChange: (event: React.ChangeEvent) => event.preventDefault()} : undefined)}
               autocomplete={autocomplete}

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -151,11 +151,10 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
           <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
             <ComboboxInputSelect
               {...getToggleButtonProps({tabIndex: 0})}
-              {...getInputProps({disabled, required, ref})}
+              {...getInputProps({disabled, required, ref, ...props})}
               {...(!autocomplete ? {onChange: (event: React.ChangeEvent) => event.preventDefault()} : undefined)}
               autocomplete={autocomplete}
               aria-describedby={helpTextId}
-              {...props}
               type="text"
             />
             {!autocomplete && (

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -54,6 +54,18 @@ export interface ComboboxProps extends Omit<InputProps, 'id' | 'type' | 'value'>
   groupItemsBy?: string;
   variant?: InputVariants;
   state?: Partial<UseComboboxPrimitiveReturnValue<any>>;
+  /**
+   * Use `onInputValueChange` instead.
+   * @type {never}
+   * @memberof ComboboxProps
+   */
+  onChange?: never;
+  /**
+   * Use `onInputValueChange` instead.
+   * @type {never}
+   * @memberof ComboboxProps
+   */
+  onInput?: never;
 }
 
 export interface ComboboxItemsProps


### PR DESCRIPTION
Address https://github.com/twilio-labs/paste/discussions/1631 where input events might be out of sync with Downshift internal state.

Because downshift isn't handling the events passed by the consumer, the data stored in e.target.value is out of sync with the internal state of Combobox. Meaning the value is the last value not, the current value.
