### PR TITLE
docs(label): add missing as attribute in props table

### DIFF
--- a/packages/paste-website/src/pages/components/label/index.mdx
+++ b/packages/paste-website/src/pages/components/label/index.mdx
@@ -338,6 +338,7 @@ All the valid HTML attributes for `label` are supported including the following 
 
 | Prop          | Type                 | Description                                                          | Default   |
 | ------------- | -------------------- | -------------------------------------------------------------------- | --------- |
+| as?           | 'label', 'legend'    | Choose the semantic HTML element the label is rendered as            | label     |
 | children?     | `ReactNode`          |                                                                      | null      |
 | htmlFor       | string               | Sets the for of the label. Should match the id of `Input`. Required. | null      |
 | disabled?     | boolean              | Shows the input is disabled.                                         | false     |


### PR DESCRIPTION
Add a missing prop to the prop table

