### PR TITLE
feat(combobox-primitive): expose multiple selection hook

### DIFF
--- a/.changeset/happy-moons-unite.md
+++ b/.changeset/happy-moons-unite.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/combobox-primitive': minor
+'@twilio-paste/core': minor
+---
+
+[Combobox Primitive] expose useMultiSelectPrimitive

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.2",
     "@testing-library/react-hooks": "^3.4.2",
+    "@testing-library/user-event": "^13.2.1",
     "@twilio-labs/svg-to-react": "^2.1.0",
     "@types/browser-sync": "^2.26.1",
     "@types/color": "^3.0.0",

--- a/packages/paste-core/primitives/combobox/__tests__/useMultiSelectPrimitive.test.tsx
+++ b/packages/paste-core/primitives/combobox/__tests__/useMultiSelectPrimitive.test.tsx
@@ -1,0 +1,1716 @@
+import * as React from 'react';
+
+import {act, renderHook} from '@testing-library/react-hooks';
+import {render, fireEvent, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {useUIDSeed} from '@twilio-paste/uid-library';
+
+import type {FireObject} from '@testing-library/react';
+import type {
+  UseMultipleSelectionGetSelectedItemPropsOptions,
+  UseMultipleSelectionGetDropdownProps,
+} from '@twilio-paste/dropdown-library';
+
+import {useMultiSelectPrimitive, useComboboxPrimitive} from '../src';
+import type {UseComboboxPrimitiveProps, UseMultiSelectPrimitiveProps} from '../src';
+
+const {stateChangeTypes} = useMultiSelectPrimitive;
+
+jest.mock('@twilio-paste/dropdown-library', () => {
+  const {default: all, ...rest} = jest.requireActual('@twilio-paste/dropdown-library');
+
+  return {
+    ...rest,
+    default: {
+      ...all,
+      generateId: () => 'test-id',
+      useGetterPropsCalledChecker: () => all.noop,
+    },
+  };
+});
+
+const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
+
+const dataTestIds = {
+  selectedItemPrefix: 'selected-item-id',
+  selectedItem: (index) => `selected-item-id-${index}`,
+  input: 'input-id',
+  menu: 'menu-id',
+  combobox: 'combobox-id',
+  label: 'label-id',
+};
+
+type DropdownMultipleComboboxProps = {
+  multipleSelectionProps?: Partial<UseMultiSelectPrimitiveProps<string>>;
+  comboboxProps?: Partial<UseComboboxPrimitiveProps<string>>;
+};
+
+const DropdownMultipleCombobox: React.FC<DropdownMultipleComboboxProps> = ({
+  multipleSelectionProps = {},
+  comboboxProps = {},
+}) => {
+  const {getSelectedItemProps, getDropdownProps, selectedItems} = useMultiSelectPrimitive(multipleSelectionProps);
+  const {getToggleButtonProps, getLabelProps, getMenuProps, getInputProps, getComboboxProps} = useComboboxPrimitive({
+    items,
+    ...comboboxProps,
+  });
+  const seed = useUIDSeed();
+
+  return (
+    <div>
+      <label htmlFor={dataTestIds.input} data-testid={dataTestIds.label} {...getLabelProps()}>
+        Choose a component:
+      </label>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
+        {selectedItems.map((selectedItem, index) => (
+          <span
+            key={seed(`selected-item-${index}`)}
+            data-testid={dataTestIds.selectedItem(index)}
+            {...getSelectedItemProps({selectedItem, index})}
+          >
+            {selectedItem}
+          </span>
+        ))}
+        <div data-testid={dataTestIds.combobox} {...getComboboxProps()}>
+          <input
+            aria-labelledby={dataTestIds.label}
+            id={dataTestIds.input}
+            data-testid={dataTestIds.input}
+            {...getInputProps(getDropdownProps())}
+          />
+          <button type="button" {...getToggleButtonProps()}>
+            Toggle
+          </button>
+        </div>
+      </div>
+      <ul data-testid={dataTestIds.menu} {...getMenuProps()} />
+    </div>
+  );
+};
+
+const renderMultipleCombobox = (
+  props
+): {
+  label: HTMLElement;
+  menu: HTMLElement;
+  rerender: (props: DropdownMultipleComboboxProps) => void;
+  getSelectedItemAtIndex: (index: number) => HTMLSpanElement;
+  keyDownOnSelectedItemAtIndex: (
+    index: number,
+    key: string,
+    options?: Record<string, any>
+  ) => ReturnType<FireObject['keyDown']>;
+  focusSelectedItemAtIndex: (index: number) => void;
+  getSelectedItems: () => HTMLSpanElement[];
+  getA11yStatusContainer: () => HTMLElement;
+  input: HTMLInputElement;
+  keyDownOnInput: (key: string, options?: Record<string, any>) => void;
+} => {
+  const utils = render(<DropdownMultipleCombobox {...props} />);
+
+  const label = screen.getByText(/choose a component/i);
+  const menu = screen.getByRole('listbox');
+  const input = screen.getByTestId(dataTestIds.input) as HTMLInputElement;
+  const rerender = (newProps: DropdownMultipleComboboxProps): void =>
+    utils.rerender(<DropdownMultipleCombobox {...newProps} />);
+  const getSelectedItemAtIndex = (index: number): HTMLElement => screen.getByTestId(dataTestIds.selectedItem(index));
+  const getSelectedItems = (): HTMLElement[] => screen.queryAllByTestId(new RegExp(dataTestIds.selectedItemPrefix));
+
+  const keyDownOnSelectedItemAtIndex = (index: number, key: string, options = {}): ReturnType<FireObject['keyDown']> =>
+    fireEvent.keyDown(getSelectedItemAtIndex(index), {key, ...options});
+
+  const focusSelectedItemAtIndex = (index: number): void => {
+    getSelectedItemAtIndex(index).focus();
+  };
+  const getA11yStatusContainer = (): HTMLElement => screen.queryByRole('status');
+  const keyDownOnInput = (key: string, options = {}): void => {
+    if (document.activeElement !== input) {
+      input.focus();
+    }
+
+    fireEvent.keyDown(input, {key, ...options});
+  };
+
+  return {
+    ...utils,
+    label,
+    menu,
+    rerender,
+    getSelectedItemAtIndex,
+    keyDownOnSelectedItemAtIndex,
+    focusSelectedItemAtIndex,
+    getSelectedItems,
+    getA11yStatusContainer,
+    input,
+    keyDownOnInput,
+  };
+};
+
+describe('useMultiSelectPrimitive', () => {
+  jest.useFakeTimers();
+  beforeEach(jest.resetAllMocks);
+
+  afterAll(jest.restoreAllMocks);
+  describe('props', () => {
+    test('if falsy then no prop types error is thrown', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      renderHook(() => {
+        const {getDropdownProps} = useMultiSelectPrimitive({});
+        getDropdownProps({}, {suppressRefError: true});
+      });
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    describe('selectedItems', () => {
+      afterEach(() => {
+        act(() => jest.runAllTimers());
+      });
+
+      test('passed as objects should work with custom itemToString', () => {
+        const {keyDownOnSelectedItemAtIndex, getA11yStatusContainer} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            initialActiveIndex: 0,
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(getA11yStatusContainer()).toHaveTextContent('Alert has been removed');
+      });
+
+      test('controls the state property if passed', () => {
+        const inputItems = [items[0], items[1]];
+        const {keyDownOnSelectedItemAtIndex, getSelectedItems} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            selectedItems: inputItems,
+            initialActiveIndex: 0,
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(getSelectedItems()).toHaveLength(2);
+      });
+    });
+
+    describe('getA11yRemovalMessage', () => {
+      afterEach(() => {
+        act(() => jest.runAllTimers());
+      });
+
+      test('is called with object that contains specific props', () => {
+        const getA11yRemovalMessage = jest.fn();
+
+        const initialSelectedItems = [items[0], items[1]];
+        const {keyDownOnSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems,
+            initialActiveIndex: 0,
+            getA11yRemovalMessage,
+            activeIndex: 0,
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(getA11yRemovalMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            resultCount: 1,
+            removedSelectedItem: initialSelectedItems[0],
+            activeIndex: 0,
+            activeSelectedItem: initialSelectedItems[1],
+          })
+        );
+      });
+
+      test('is replaced with the user provided one', () => {
+        const initialSelectedItems = [items[0], items[1]];
+        const {keyDownOnSelectedItemAtIndex, getA11yStatusContainer} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems,
+            initialActiveIndex: 0,
+            getA11yRemovalMessage: () => 'custom message',
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(getA11yStatusContainer()).toHaveTextContent('custom message');
+      });
+    });
+
+    describe('activeIndex', () => {
+      test('controls the state property if passed', () => {
+        const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex, focusSelectedItemAtIndex} = renderMultipleCombobox(
+          {
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              activeIndex: 1,
+            },
+          }
+        );
+
+        focusSelectedItemAtIndex(1);
+
+        expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+        expect(getSelectedItemAtIndex(1)).toHaveFocus();
+
+        keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+        expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+        expect(getSelectedItemAtIndex(1)).toHaveFocus();
+
+        keyDownOnSelectedItemAtIndex(1, 'ArrowRight');
+
+        expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+        expect(getSelectedItemAtIndex(1)).toHaveFocus();
+      });
+    });
+
+    describe('stateReducer', () => {
+      test('is called at each state change with the function change type', () => {
+        const stateReducer = jest.fn((s, a) => a.changes);
+        const {result} = renderHook(() => useMultiSelectPrimitive({stateReducer}));
+
+        act(() => {
+          result.current.addSelectedItem(items[0]);
+        });
+
+        expect(stateReducer).toHaveBeenCalledTimes(1);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([items[0]]),
+            }),
+            type: stateChangeTypes.FunctionAddSelectedItem,
+          })
+        );
+
+        act(() => {
+          result.current.removeSelectedItem(items[0]);
+        });
+
+        expect(stateReducer).toHaveBeenCalledTimes(2);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[0]]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([]),
+            }),
+            type: stateChangeTypes.FunctionRemoveSelectedItem,
+          })
+        );
+
+        act(() => {
+          result.current.setSelectedItems([items[0], items[1]]);
+        });
+
+        expect(stateReducer).toHaveBeenCalledTimes(3);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([items[0], items[1]]),
+            }),
+            type: stateChangeTypes.FunctionSetSelectedItems,
+          })
+        );
+
+        act(() => {
+          result.current.setActiveIndex(1);
+        });
+
+        expect(stateReducer).toHaveBeenCalledTimes(4);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeIndex: -1,
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: 1,
+            }),
+            type: stateChangeTypes.FunctionSetActiveIndex,
+          })
+        );
+
+        act(() => {
+          result.current.reset();
+        });
+
+        expect(stateReducer).toHaveBeenCalledTimes(5);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[0], items[1]]),
+            activeIndex: 1,
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([]),
+              activeIndex: -1,
+            }),
+            type: stateChangeTypes.FunctionReset,
+          })
+        );
+      });
+
+      test('is called at each state change with the appropriate change type', async () => {
+        const stateReducer = jest.fn((s, {changes}) => {
+          return changes;
+        });
+        const {keyDownOnSelectedItemAtIndex, keyDownOnInput, input, getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1], items[2]],
+            stateReducer,
+          },
+        });
+
+        input.focus();
+        keyDownOnInput('Backspace');
+
+        expect(stateReducer).toHaveBeenCalledTimes(1);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[0], items[1], items[2]]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([items[0], items[1]]),
+            }),
+            type: stateChangeTypes.DropdownKeyDownBackspace,
+          })
+        );
+
+        keyDownOnInput('ArrowLeft');
+
+        expect(stateReducer).toHaveBeenCalledTimes(2);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({activeIndex: -1}),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: 1,
+            }),
+            type: stateChangeTypes.DropdownKeyDownNavigationPrevious,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+        expect(stateReducer).toHaveBeenCalledTimes(3);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({activeIndex: 1}),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: 0,
+            }),
+            type: stateChangeTypes.SelectedItemKeyDownNavigationPrevious,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'ArrowRight');
+
+        expect(stateReducer).toHaveBeenCalledTimes(4);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({activeIndex: 0}),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: 1,
+            }),
+            type: stateChangeTypes.SelectedItemKeyDownNavigationNext,
+          })
+        );
+
+        input.click();
+
+        expect(stateReducer).toHaveBeenCalledTimes(5);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({activeIndex: 1}),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: -1,
+            }),
+            type: stateChangeTypes.DropdownClick,
+          })
+        );
+
+        await userEvent.click(getSelectedItemAtIndex(0));
+
+        expect(stateReducer).toHaveBeenCalledTimes(6);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({activeIndex: -1}),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              activeIndex: 0,
+            }),
+            type: stateChangeTypes.SelectedItemClick,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(stateReducer).toHaveBeenCalledTimes(7);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[0], items[1]]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([items[1]]),
+            }),
+            type: stateChangeTypes.SelectedItemKeyDownDelete,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'Backspace');
+
+        expect(stateReducer).toHaveBeenCalledTimes(8);
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[1]]),
+          }),
+          expect.objectContaining({
+            changes: expect.objectContaining({
+              selectedItems: expect.arrayContaining([]),
+            }),
+            type: stateChangeTypes.SelectedItemKeyDownBackspace,
+          })
+        );
+      });
+
+      test('replaces prop values with user defined', () => {
+        const stateReducer = jest.fn((s, {changes}) => {
+          const shallowClone = {...changes};
+          shallowClone.activeIndex = 0;
+          return shallowClone;
+        });
+
+        const {getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            stateReducer,
+          },
+        });
+
+        userEvent.click(getSelectedItemAtIndex(0));
+
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+        expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+        expect(getSelectedItemAtIndex(0)).toHaveFocus();
+      });
+
+      test('receives state, changes and type', () => {
+        const stateReducer = jest.fn((s, a) => {
+          expect(a.type).not.toBeUndefined();
+          expect(a.type).not.toBeNull();
+
+          expect(s).not.toBeUndefined();
+          expect(s).not.toBeNull();
+
+          expect(a.changes).not.toBeUndefined();
+          expect(a.changes).not.toBeNull();
+
+          return a.changes;
+        });
+        const {getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            stateReducer,
+          },
+        });
+
+        userEvent.click(getSelectedItemAtIndex(0));
+      });
+
+      test('changes are visible in onChange handlers', () => {
+        const activeIndex = 0;
+        const stateReducer = jest.fn(() => ({
+          activeIndex,
+          selectedItems: [],
+        }));
+        const onSelectedItemsChange = jest.fn();
+        const onActiveIndexChange = jest.fn();
+        const onStateChange = jest.fn();
+        const {keyDownOnInput} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            stateReducer,
+            onStateChange,
+            onActiveIndexChange,
+            onSelectedItemsChange,
+            selectedItems: [items[0], items[2]],
+          },
+        });
+
+        keyDownOnInput('ArrowLeft');
+
+        expect(onActiveIndexChange).toHaveBeenCalledTimes(1);
+        expect(onActiveIndexChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeIndex,
+          })
+        );
+        expect(onSelectedItemsChange).toHaveBeenCalledTimes(1);
+        expect(onSelectedItemsChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selectedItems: [],
+          })
+        );
+        expect(onStateChange).toHaveBeenCalledTimes(1);
+        expect(onStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeIndex,
+            selectedItems: [],
+            type: stateChangeTypes.DropdownKeyDownNavigationPrevious,
+          })
+        );
+      });
+    });
+
+    describe('onActiveIndexChange', () => {
+      test('is called at activeIndex change', () => {
+        const onActiveIndexChange = jest.fn();
+        const {getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            onActiveIndexChange,
+            initialActiveIndex: 0,
+          },
+        });
+
+        fireEvent.click(getSelectedItemAtIndex(1));
+
+        expect(onActiveIndexChange).toHaveBeenCalledTimes(1);
+
+        expect(onActiveIndexChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeIndex: 1,
+          })
+        );
+      });
+
+      test('is not called at if selectedItem is the same', () => {
+        const onActiveIndexChange = jest.fn();
+        const {getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            onActiveIndexChange,
+            initialActiveIndex: 1,
+          },
+        });
+
+        userEvent.click(getSelectedItemAtIndex(1));
+
+        expect(onActiveIndexChange).not.toHaveBeenCalled();
+      });
+
+      test('works correctly with the corresponding control prop', () => {
+        let activeIndex = 3;
+        const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex, rerender} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: items,
+            activeIndex,
+            onActiveIndexChange: (changes) => {
+              activeIndex = changes.activeIndex;
+            },
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(3, 'ArrowLeft');
+        rerender({multipleSelectionProps: {activeIndex}});
+
+        expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '0');
+      });
+
+      test('can have downshift actions executed', () => {
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            onActiveIndexChange: () => {
+              result.current.setSelectedItems([items[0]]);
+            },
+          })
+        );
+
+        act(() => {
+          result.current
+            .getSelectedItemProps({
+              index: 3,
+            } as UseMultipleSelectionGetSelectedItemPropsOptions<string>)
+            .onClick({});
+        });
+
+        expect(result.current.selectedItems).toEqual([items[0]]);
+      });
+    });
+
+    describe('onSelectedItemsChange', () => {
+      test('is called at items change', () => {
+        const onSelectedItemsChange = jest.fn();
+        const {keyDownOnSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            onSelectedItemsChange,
+            initialActiveIndex: 1,
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(1, 'Delete');
+
+        expect(onSelectedItemsChange).toHaveBeenCalledTimes(1);
+        expect(onSelectedItemsChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selectedItems: [items[0]],
+          })
+        );
+      });
+
+      test('is not called at if items is the same', () => {
+        const onSelectedItemsChange = jest.fn();
+        const {getSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            onSelectedItemsChange,
+            initialActiveIndex: 1,
+          },
+        });
+
+        userEvent.click(getSelectedItemAtIndex(0));
+
+        expect(onSelectedItemsChange).not.toHaveBeenCalled();
+      });
+
+      test('works correctly with the corresponding control prop', () => {
+        let selectedItems = [items[0], items[1]];
+        const {keyDownOnSelectedItemAtIndex, getSelectedItems, rerender} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            selectedItems,
+            initialActiveIndex: 0,
+            onSelectedItemsChange: (changes) => {
+              selectedItems = changes.selectedItems;
+            },
+          },
+        });
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+        rerender({multipleSelectionProps: {selectedItems}});
+
+        expect(getSelectedItems()).toHaveLength(1);
+      });
+
+      test('can have downshift actions executed', () => {
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            onSelectedItemsChange: () => {
+              result.current.setActiveIndex(1);
+            },
+            initialSelectedItems: items,
+          })
+        );
+
+        act(() => {
+          result.current
+            .getSelectedItemProps({index: 3} as UseMultipleSelectionGetSelectedItemPropsOptions<string>)
+            .onKeyDown({key: 'Backspace'});
+        });
+
+        expect(result.current.activeIndex).toEqual(1);
+      });
+    });
+
+    describe('onStateChange', () => {
+      test('is called at each state property change', () => {
+        const onStateChange = jest.fn();
+        const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex, keyDownOnInput, input} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1], items[2]],
+            onStateChange,
+          },
+        });
+
+        input.focus();
+        keyDownOnInput('Backspace');
+
+        expect(onStateChange).toHaveBeenCalledTimes(1);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[0], items[1]]),
+            type: stateChangeTypes.DropdownKeyDownBackspace,
+          })
+        );
+
+        keyDownOnInput('ArrowLeft');
+
+        expect(onStateChange).toHaveBeenCalledTimes(2);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeIndex: 1,
+            type: stateChangeTypes.DropdownKeyDownNavigationPrevious,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+        expect(onStateChange).toHaveBeenCalledTimes(3);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeIndex: 0,
+            type: stateChangeTypes.SelectedItemKeyDownNavigationPrevious,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'ArrowRight');
+
+        expect(onStateChange).toHaveBeenCalledTimes(4);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeIndex: 1,
+            type: stateChangeTypes.SelectedItemKeyDownNavigationNext,
+          })
+        );
+
+        fireEvent.click(getSelectedItemAtIndex(0));
+
+        expect(onStateChange).toHaveBeenCalledTimes(5);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeIndex: 0,
+            type: stateChangeTypes.SelectedItemClick,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+        expect(onStateChange).toHaveBeenCalledTimes(6);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([items[1]]),
+            type: stateChangeTypes.SelectedItemKeyDownDelete,
+          })
+        );
+
+        keyDownOnSelectedItemAtIndex(0, 'Backspace');
+
+        expect(onStateChange).toHaveBeenCalledTimes(7);
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            selectedItems: expect.arrayContaining([]),
+            type: stateChangeTypes.SelectedItemKeyDownBackspace,
+          })
+        );
+      });
+    });
+
+    test('overrides navigation previous and next keys correctly', () => {
+      const {keyDownOnInput, getSelectedItemAtIndex, keyDownOnSelectedItemAtIndex, input} = renderMultipleCombobox({
+        multipleSelectionProps: {
+          keyNavigationPrevious: 'ArrowUp',
+          keyNavigationNext: 'ArrowDown',
+          initialSelectedItems: [items[0], items[1]],
+        },
+      });
+
+      keyDownOnInput('ArrowUp');
+
+      expect(getSelectedItemAtIndex(1)).toHaveFocus();
+
+      keyDownOnSelectedItemAtIndex(1, 'ArrowUp');
+
+      expect(getSelectedItemAtIndex(0)).toHaveFocus();
+
+      keyDownOnSelectedItemAtIndex(0, 'ArrowDown');
+
+      expect(getSelectedItemAtIndex(1)).toHaveFocus();
+
+      keyDownOnSelectedItemAtIndex(1, 'ArrowDown');
+
+      expect(input).toHaveFocus();
+    });
+
+    test('can have downshift actions executed', () => {
+      const {result} = renderHook(() =>
+        useMultiSelectPrimitive({
+          initialSelectedItems: items,
+          onStateChange: () => {
+            result.current.setActiveIndex(4);
+          },
+        })
+      );
+
+      act(() => {
+        result.current
+          .getSelectedItemProps({index: 2} as UseMultipleSelectionGetSelectedItemPropsOptions<string>)
+          .onClick({});
+      });
+
+      expect(result.current.activeIndex).toEqual(4);
+    });
+  });
+
+  describe('returnProps', () => {
+    test('should have stateChangeTypes attached to hook', () => {
+      expect(useMultiSelectPrimitive).toHaveProperty('stateChangeTypes', stateChangeTypes);
+    });
+
+    describe('prop getters', () => {
+      test('are returned as functions', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        expect(result.current.getDropdownProps).toBeInstanceOf(Function);
+        expect(result.current.getSelectedItemProps).toBeInstanceOf(Function);
+      });
+    });
+
+    describe('actions', () => {
+      test('addSelectedItem adds an item to the selected array', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        act(() => {
+          result.current.addSelectedItem('test');
+        });
+
+        expect(result.current.selectedItems).toStrictEqual(['test']);
+      });
+
+      test('removeSelectedItem removes an item from the selected array and keeps active index if not last item', () => {
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            initialSelectedItems: ['test', 'more test'],
+            initialActiveIndex: 0,
+          })
+        );
+
+        act(() => {
+          result.current.removeSelectedItem('test');
+        });
+
+        expect(result.current.selectedItems).toStrictEqual(['more test']);
+        expect(result.current.activeIndex).toEqual(0);
+      });
+
+      test('removeSelectedItem removes an item from the selected array and decreases active index if last item', () => {
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            initialSelectedItems: ['test', 'more test'],
+            initialActiveIndex: 1,
+          })
+        );
+
+        act(() => {
+          result.current.removeSelectedItem('more test');
+        });
+
+        expect(result.current.selectedItems).toStrictEqual(['test']);
+        expect(result.current.activeIndex).toEqual(0);
+      });
+
+      test('setActiveIndex sets activeIndex', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        act(() => {
+          result.current.setActiveIndex(3);
+        });
+
+        expect(result.current.activeIndex).toBe(3);
+      });
+
+      test('setSelectedItems sets selectedItems', () => {
+        const inputItems = [1, 2, 3];
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        act(() => {
+          result.current.setSelectedItems(inputItems);
+        });
+
+        expect(result.current.selectedItems).toBe(inputItems);
+      });
+
+      test('reset sets the state to default values', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        act(() => {
+          result.current.setSelectedItems([1, 2, 3]);
+          result.current.setActiveIndex(5);
+          result.current.reset();
+        });
+
+        expect(result.current.activeIndex).toBe(-1);
+        expect(result.current.selectedItems).toStrictEqual([]);
+      });
+
+      test('reset sets the state to default prop values passed by user', () => {
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            defaultSelectedItems: [3, 4],
+            defaultActiveIndex: 0,
+          })
+        );
+
+        act(() => {
+          result.current.setSelectedItems([1, 2]);
+          result.current.setActiveIndex(1);
+          result.current.reset();
+        });
+
+        expect(result.current.activeIndex).toBe(0);
+        expect(result.current.selectedItems).toStrictEqual([3, 4]);
+      });
+    });
+
+    describe('state and props', () => {
+      test('activeIndex is returned', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({activeIndex: 4}));
+
+        expect(result.current.activeIndex).toBe(4);
+      });
+
+      test('selectedItems is returned', () => {
+        const itemsInput = [1, 2, 3];
+        const {result} = renderHook(() => useMultiSelectPrimitive({selectedItems: itemsInput}));
+
+        expect(result.current.selectedItems).toBe(itemsInput);
+      });
+    });
+  });
+
+  describe('test memoization', () => {
+    test('functions are memoized', () => {
+      const {result, rerender} = renderHook(() => useMultiSelectPrimitive({}));
+      const firstRenderResult = result.current;
+      rerender();
+      const secondRenderResult = result.current;
+      expect(firstRenderResult).toEqual(secondRenderResult);
+    });
+  });
+
+  describe('getSelectedItemProps', () => {
+    test('throws error if no index or item has been passed', () => {
+      const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+      expect(result.current.getSelectedItemProps).toThrowError(
+        'Pass either selectedItem or index in getSelectedItemProps!'
+      );
+    });
+
+    describe('hook props', () => {
+      test("assign '-1' to tabindex for a non-active item", () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+        const itemProps = result.current.getSelectedItemProps({
+          index: 0,
+          selectedItem: items[0],
+        });
+
+        expect(itemProps.tabIndex).toEqual(-1);
+      });
+
+      test("assign '0' to tabindex for an active item", () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({activeIndex: 0}));
+
+        const itemProps = result.current.getSelectedItemProps({
+          index: 0,
+          selectedItem: items[0],
+        });
+
+        expect(itemProps.tabIndex).toEqual(0);
+      });
+    });
+
+    describe('user props', () => {
+      test('are passed down', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        expect(
+          result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            foo: 'bar',
+          } as UseMultipleSelectionGetSelectedItemPropsOptions<string>)
+        ).toHaveProperty('foo', 'bar');
+      });
+
+      test('custom ref passed by the user is used', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+        const refFn = jest.fn();
+        const itemNode = {};
+
+        act(() => {
+          const {ref} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            ref: refFn,
+          });
+
+          ref(itemNode);
+        });
+
+        expect(refFn).toHaveBeenCalledTimes(1);
+        expect(refFn).toHaveBeenCalledWith(itemNode);
+      });
+
+      test('custom ref with custom name passed by the user is used', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+        const refFn = jest.fn();
+        const itemNode = {};
+
+        act(() => {
+          const {blablaRef} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            refKey: 'blablaRef',
+            blablaRef: refFn,
+          } as UseMultipleSelectionGetSelectedItemPropsOptions<string>);
+
+          blablaRef(itemNode);
+        });
+
+        expect(refFn).toHaveBeenCalledTimes(1);
+        expect(refFn).toHaveBeenCalledWith(itemNode);
+      });
+
+      test('event handler onClick is called along with downshift handler', () => {
+        const userOnClick = jest.fn();
+        const {result} = renderHook(() => useMultiSelectPrimitive({initialSelectedItems: [items[0], items[1]]}));
+
+        act(() => {
+          const {onClick} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            onClick: userOnClick,
+          });
+
+          onClick({});
+        });
+
+        expect(userOnClick).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(1);
+      });
+
+      test("event handler onClick is called without downshift handler if 'preventDownshiftDefault' is passed in user event", () => {
+        const userOnClick = jest.fn((event) => {
+          // eslint-disable-next-line no-param-reassign
+          event.preventDownshiftDefault = true;
+        });
+        const {result} = renderHook(() => useMultiSelectPrimitive({initialSelectedItems: [items[0], items[1]]}));
+
+        act(() => {
+          const {onClick} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            onClick: userOnClick,
+          });
+
+          onClick({});
+        });
+
+        expect(userOnClick).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(-1);
+      });
+
+      test('event handler onKeyDown is called along with downshift handler', () => {
+        const userOnKeyDown = jest.fn();
+        const {result} = renderHook(() => useMultiSelectPrimitive({initialSelectedItems: [items[0], items[1]]}));
+
+        act(() => {
+          const {onKeyDown} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            onKeyDown: userOnKeyDown,
+          });
+
+          onKeyDown({key: 'ArrowLeft'});
+        });
+
+        expect(userOnKeyDown).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(0);
+      });
+
+      test("event handler onKeyDown is called without downshift handler if 'preventDownshiftDefault' is passed in user event", () => {
+        const userOnKeyDown = jest.fn((event) => {
+          // eslint-disable-next-line no-param-reassign
+          event.preventDownshiftDefault = true;
+        });
+        const {result} = renderHook(() => useMultiSelectPrimitive({initialSelectedItems: [items[0], items[1]]}));
+
+        act(() => {
+          const {onKeyDown} = result.current.getSelectedItemProps({
+            index: 1,
+            selectedItem: items[1],
+            onKeyDown: userOnKeyDown,
+          });
+
+          onKeyDown({key: 'ArrowLeft'});
+        });
+
+        expect(userOnKeyDown).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(-1);
+      });
+    });
+
+    describe('event handlers', () => {
+      describe('on click', () => {
+        test('sets tabindex to "0"', () => {
+          const {getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {initialSelectedItems: [items[0], items[1]]},
+          });
+
+          userEvent.click(getSelectedItemAtIndex(0));
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(0)).toHaveFocus();
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+        });
+
+        test('keeps tabindex "0" to an already active item', () => {
+          const {getSelectedItemAtIndex, focusSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          focusSelectedItemAtIndex(0);
+          userEvent.click(getSelectedItemAtIndex(0));
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(0)).toHaveFocus();
+        });
+      });
+
+      describe('on key down', () => {
+        test('arrow left should change active item in a descending order', () => {
+          const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              initialActiveIndex: 1,
+            },
+          });
+
+          keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(0)).toHaveFocus();
+        });
+
+        test(`arrow left should not change active item if it's the first one added`, () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItemAtIndex,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          focusSelectedItemAtIndex(0);
+          keyDownOnSelectedItemAtIndex(0, 'ArrowLeft');
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(0)).toHaveFocus();
+        });
+
+        test('arrow right should change active item ascendently', () => {
+          const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          keyDownOnSelectedItemAtIndex(0, 'ArrowRight');
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+        });
+
+        test(`arrow right should make no item active if it's on last one added`, () => {
+          const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex, input} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+              initialActiveIndex: 1,
+            },
+          });
+
+          keyDownOnSelectedItemAtIndex(1, 'ArrowRight');
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+          expect(input).toHaveFocus();
+        });
+
+        test('arrow navigation moves focus back and forth', () => {
+          const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 2,
+            },
+          });
+
+          keyDownOnSelectedItemAtIndex(2, 'ArrowLeft');
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+
+          keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+
+          keyDownOnSelectedItemAtIndex(0, 'ArrowRight');
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+
+          keyDownOnSelectedItemAtIndex(2, 'ArrowRight');
+
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+        });
+
+        test('backspace removes item and moves focus to next item if any', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 1,
+            },
+          });
+
+          focusSelectedItemAtIndex(1);
+          keyDownOnSelectedItemAtIndex(1, 'Backspace');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+          expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[2]);
+        });
+
+        test('backspace removes item and moves focus to input if no items left', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+            input,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          focusSelectedItemAtIndex(0);
+          keyDownOnSelectedItemAtIndex(0, 'Backspace');
+
+          expect(getSelectedItems()).toHaveLength(0);
+          expect(input).toHaveFocus();
+        });
+
+        test('backspace removes item and moves focus to previous item if it was the last in the array', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 2,
+            },
+          });
+
+          focusSelectedItemAtIndex(2);
+          keyDownOnSelectedItemAtIndex(2, 'Backspace');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+          expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[1]);
+        });
+
+        test('delete removes item and moves focus to next item if any', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 1,
+            },
+          });
+
+          focusSelectedItemAtIndex(1);
+          keyDownOnSelectedItemAtIndex(1, 'Delete');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+          expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[2]);
+        });
+
+        test('delete removes item and moves focus to input if no items left', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+            input,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          focusSelectedItemAtIndex(0);
+          keyDownOnSelectedItemAtIndex(0, 'Delete');
+
+          expect(getSelectedItems()).toHaveLength(0);
+          expect(input).toHaveFocus();
+        });
+
+        test('delete removes item and moves focus to previous item if it was the last in the array', () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItemAtIndex,
+            getSelectedItems,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 2,
+            },
+          });
+
+          focusSelectedItemAtIndex(2);
+          keyDownOnSelectedItemAtIndex(2, 'Delete');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+          expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[1]);
+        });
+
+        test('navigation works correctly with both click and arrow keys', () => {
+          const {keyDownOnSelectedItemAtIndex, getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+            },
+          });
+
+          userEvent.click(getSelectedItemAtIndex(1));
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+
+          keyDownOnSelectedItemAtIndex(1, 'ArrowLeft');
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+
+          userEvent.click(getSelectedItemAtIndex(1));
+
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+
+          keyDownOnSelectedItemAtIndex(2, 'ArrowRight');
+
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '-1');
+        });
+
+        test("other than the ones supported don't affect anything", () => {
+          const {
+            keyDownOnSelectedItemAtIndex,
+            getSelectedItems,
+            getSelectedItemAtIndex,
+            focusSelectedItemAtIndex,
+          } = renderMultipleCombobox({
+            multipleSelectionProps: {initialSelectedItems: [items[0], items[1]]},
+          });
+
+          focusSelectedItemAtIndex(1);
+          keyDownOnSelectedItemAtIndex(1, 'Alt');
+          keyDownOnSelectedItemAtIndex(1, 'Control');
+          keyDownOnSelectedItemAtIndex(1, 'ArrowUp');
+          keyDownOnSelectedItemAtIndex(1, 'ArrowDown');
+          keyDownOnSelectedItemAtIndex(1, 'Enter');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+        });
+      });
+
+      describe('on focus', () => {
+        test('keeps tabindex "0" when focusing input by tab/click so user can return via tab', () => {
+          const {getSelectedItemAtIndex, focusSelectedItemAtIndex, input} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1], items[2]],
+              initialActiveIndex: 0,
+            },
+          });
+
+          focusSelectedItemAtIndex(0);
+          input.focus();
+
+          expect(getSelectedItemAtIndex(0)).toHaveAttribute('tabindex', '0');
+          expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+          expect(getSelectedItemAtIndex(2)).toHaveAttribute('tabindex', '-1');
+          expect(input).toHaveFocus();
+        });
+      });
+    });
+  });
+
+  describe('getDropdownProps', () => {
+    test('returns no keydown events if preventKeyAction is true', () => {
+      const {result} = renderHook(() => useMultiSelectPrimitive({}));
+      const dropdownProps = result.current.getDropdownProps({
+        preventKeyAction: true,
+      });
+
+      expect(dropdownProps.onKeyDown).toBeUndefined();
+    });
+
+    describe('user props', () => {
+      test('are passed down', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+
+        expect(result.current.getDropdownProps({foo: 'bar'} as UseMultipleSelectionGetDropdownProps)).toHaveProperty(
+          'foo',
+          'bar'
+        );
+      });
+
+      test('custom ref passed by the user is used', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+        const refFn = jest.fn();
+        const dropdownNode = {};
+
+        act(() => {
+          const {ref} = result.current.getDropdownProps({
+            ref: refFn,
+          });
+
+          ref(dropdownNode);
+        });
+
+        expect(refFn).toHaveBeenCalledTimes(1);
+        expect(refFn).toHaveBeenCalledWith(dropdownNode);
+      });
+
+      test('custom ref with custom name passed by the user is used', () => {
+        const {result} = renderHook(() => useMultiSelectPrimitive({}));
+        const refFn = jest.fn();
+        const dropdownNode = {};
+
+        act(() => {
+          const {blablaRef} = result.current.getDropdownProps({
+            refKey: 'blablaRef',
+            blablaRef: refFn,
+          } as UseMultipleSelectionGetDropdownProps);
+
+          blablaRef(dropdownNode);
+        });
+
+        expect(refFn).toHaveBeenCalledTimes(1);
+        expect(refFn).toHaveBeenCalledWith(dropdownNode);
+      });
+
+      test('event handler onKeyDown is called along with downshift handler', () => {
+        const userOnKeyDown = jest.fn();
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            initialSelectedItems: [items[0]],
+          })
+        );
+
+        act(() => {
+          const {onKeyDown} = result.current.getDropdownProps({
+            onKeyDown: userOnKeyDown,
+          });
+
+          onKeyDown({key: 'ArrowLeft'});
+        });
+
+        expect(userOnKeyDown).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(0);
+      });
+
+      test("event handler onKeyDown is called without downshift handler if 'preventDownshiftDefault' is passed in user event", () => {
+        const userOnKeyDown = jest.fn((event) => {
+          // eslint-disable-next-line no-param-reassign
+          event.preventDownshiftDefault = true;
+        });
+        const {result} = renderHook(() =>
+          useMultiSelectPrimitive({
+            initialSelectedItems: [items[0]],
+          })
+        );
+
+        act(() => {
+          const {onKeyDown} = result.current.getDropdownProps({
+            onKeyDown: userOnKeyDown,
+          });
+
+          onKeyDown({key: 'ArrowLeft'});
+        });
+
+        expect(userOnKeyDown).toHaveBeenCalledTimes(1);
+        expect(result.current.activeIndex).toBe(-1);
+      });
+    });
+
+    describe('event handlers', () => {
+      describe('on keydown', () => {
+        test('arrow left should make first selected item active', () => {
+          const {keyDownOnInput, getSelectedItemAtIndex} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+            },
+          });
+
+          keyDownOnInput('ArrowLeft');
+
+          expect(getSelectedItemAtIndex(1)).toHaveFocus();
+        });
+
+        test('arrow left should not work if pressed with modifier keys', () => {
+          const {keyDownOnInput, getSelectedItems} = renderMultipleCombobox({
+            multipleSelectionProps: {initialSelectedItems: [items[0], items[1]]},
+          });
+
+          keyDownOnInput('ArrowLeft', {shiftKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('ArrowLeft', {altKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('ArrowLeft', {metaKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('ArrowLeft', {ctrlKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+        });
+
+        test('backspace should remove the first selected item', () => {
+          const {keyDownOnInput, getSelectedItems} = renderMultipleCombobox({
+            multipleSelectionProps: {initialSelectedItems: [items[0], items[1]]},
+          });
+
+          keyDownOnInput('Backspace');
+
+          expect(getSelectedItems()).toHaveLength(1);
+        });
+
+        test('backspace should not work if pressed with modifier keys', () => {
+          const {keyDownOnInput, getSelectedItems} = renderMultipleCombobox({
+            multipleSelectionProps: {initialSelectedItems: [items[0], items[1]]},
+          });
+
+          keyDownOnInput('Backspace', {shiftKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('Backspace', {altKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('Backspace', {metaKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+
+          keyDownOnInput('Backspace', {ctrlKey: true});
+
+          expect(getSelectedItems()).toHaveLength(2);
+        });
+
+        test('backspace should not work if pressed with cursor not on first position', () => {
+          const {keyDownOnInput, getSelectedItems, input} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+            },
+            comboboxProps: {initialInputValue: 'test'},
+          });
+
+          input.selectionStart = 1;
+          input.selectionEnd = 1;
+          keyDownOnInput('Backspace');
+
+          expect(getSelectedItems()).toHaveLength(2);
+        });
+
+        test('backspace should not work if pressed with cursor highlighting text', () => {
+          const {keyDownOnInput, getSelectedItems, input} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+            },
+            comboboxProps: {initialInputValue: 'test'},
+          });
+
+          input.selectionStart = 0;
+          input.selectionEnd = 3;
+          keyDownOnInput('Backspace');
+
+          expect(getSelectedItems()).toHaveLength(2);
+        });
+
+        test("other than the ones supported don't affect anything", () => {
+          const {keyDownOnInput, getSelectedItems, input} = renderMultipleCombobox({
+            multipleSelectionProps: {
+              initialSelectedItems: [items[0], items[1]],
+            },
+          });
+
+          keyDownOnInput('Alt');
+          keyDownOnInput('Control');
+
+          expect(getSelectedItems()).toHaveLength(2);
+          expect(input).toHaveFocus();
+        });
+      });
+
+      test('on click it should remove active status from item if any', () => {
+        const {keyDownOnInput, getSelectedItemAtIndex, input, focusSelectedItemAtIndex} = renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1]],
+            initialActiveIndex: 1,
+          },
+        });
+
+        focusSelectedItemAtIndex(1);
+        userEvent.click(input);
+
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '-1');
+
+        keyDownOnInput('ArrowLeft');
+
+        expect(getSelectedItemAtIndex(1)).toHaveFocus();
+        expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0');
+      });
+    });
+  });
+});

--- a/packages/paste-core/primitives/combobox/__tests__/useMultiSelectPrimitive.test.tsx
+++ b/packages/paste-core/primitives/combobox/__tests__/useMultiSelectPrimitive.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {act, renderHook} from '@testing-library/react-hooks';
-import {render, fireEvent, screen, waitFor} from '@testing-library/react';
+import {render, fireEvent, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useUIDSeed} from '@twilio-paste/uid-library';
 
@@ -33,7 +33,7 @@ const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 
 
 const dataTestIds = {
   selectedItemPrefix: 'selected-item-id',
-  selectedItem: (index) => `selected-item-id-${index}`,
+  selectedItem: (index: number) => `selected-item-id-${index}`,
   input: 'input-id',
   menu: 'menu-id',
   combobox: 'combobox-id',
@@ -89,7 +89,7 @@ const DropdownMultipleCombobox: React.FC<DropdownMultipleComboboxProps> = ({
 };
 
 const renderMultipleCombobox = (
-  props
+  props: DropdownMultipleComboboxProps
 ): {
   label: HTMLElement;
   menu: HTMLElement;
@@ -102,7 +102,7 @@ const renderMultipleCombobox = (
   ) => ReturnType<FireObject['keyDown']>;
   focusSelectedItemAtIndex: (index: number) => void;
   getSelectedItems: () => HTMLSpanElement[];
-  getA11yStatusContainer: () => HTMLElement;
+  getA11yStatusContainer: () => HTMLElement | null;
   input: HTMLInputElement;
   keyDownOnInput: (key: string, options?: Record<string, any>) => void;
 } => {
@@ -122,7 +122,7 @@ const renderMultipleCombobox = (
   const focusSelectedItemAtIndex = (index: number): void => {
     getSelectedItemAtIndex(index).focus();
   };
-  const getA11yStatusContainer = (): HTMLElement => screen.queryByRole('status');
+  const getA11yStatusContainer = (): HTMLElement | null => screen.queryByRole('status');
   const keyDownOnInput = (key: string, options = {}): void => {
     if (document.activeElement !== input) {
       input.focus();
@@ -166,7 +166,9 @@ describe('useMultiSelectPrimitive', () => {
 
     describe('selectedItems', () => {
       afterEach(() => {
-        act(() => jest.runAllTimers());
+        act(() => {
+          jest.runAllTimers();
+        });
       });
 
       test('passed as objects should work with custom itemToString', () => {
@@ -199,7 +201,9 @@ describe('useMultiSelectPrimitive', () => {
 
     describe('getA11yRemovalMessage', () => {
       afterEach(() => {
-        act(() => jest.runAllTimers());
+        act(() => {
+          jest.runAllTimers();
+        });
       });
 
       test('is called with object that contains specific props', () => {
@@ -276,7 +280,7 @@ describe('useMultiSelectPrimitive', () => {
 
     describe('stateReducer', () => {
       test('is called at each state change with the function change type', () => {
-        const stateReducer = jest.fn((s, a) => a.changes);
+        const stateReducer = jest.fn((_s, a) => a.changes);
         const {result} = renderHook(() => useMultiSelectPrimitive({stateReducer}));
 
         act(() => {
@@ -368,7 +372,7 @@ describe('useMultiSelectPrimitive', () => {
       });
 
       test('is called at each state change with the appropriate change type', async () => {
-        const stateReducer = jest.fn((s, {changes}) => {
+        const stateReducer = jest.fn((_s, {changes}) => {
           return changes;
         });
         const {keyDownOnSelectedItemAtIndex, keyDownOnInput, input, getSelectedItemAtIndex} = renderMultipleCombobox({
@@ -491,7 +495,7 @@ describe('useMultiSelectPrimitive', () => {
       });
 
       test('replaces prop values with user defined', () => {
-        const stateReducer = jest.fn((s, {changes}) => {
+        const stateReducer = jest.fn((_s, {changes}) => {
           const shallowClone = {...changes};
           shallowClone.activeIndex = 0;
           return shallowClone;
@@ -622,7 +626,7 @@ describe('useMultiSelectPrimitive', () => {
             initialSelectedItems: items,
             activeIndex,
             onActiveIndexChange: (changes) => {
-              activeIndex = changes.activeIndex;
+              activeIndex = changes.activeIndex as number;
             },
           },
         });
@@ -697,7 +701,7 @@ describe('useMultiSelectPrimitive', () => {
             selectedItems,
             initialActiveIndex: 0,
             onSelectedItemsChange: (changes) => {
-              selectedItems = changes.selectedItems;
+              selectedItems = changes.selectedItems as string[];
             },
           },
         });

--- a/packages/paste-core/primitives/combobox/package.json
+++ b/packages/paste-core/primitives/combobox/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^13.2.1",
     "@twilio-paste/dropdown-library": "^1.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/packages/paste-core/primitives/combobox/package.json
+++ b/packages/paste-core/primitives/combobox/package.json
@@ -31,7 +31,6 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^13.2.1",
     "@twilio-paste/dropdown-library": "^1.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/packages/paste-core/primitives/combobox/src/index.tsx
+++ b/packages/paste-core/primitives/combobox/src/index.tsx
@@ -2,7 +2,10 @@ import Downshift from '@twilio-paste/dropdown-library';
 
 export {Downshift as ComboboxPrimitive};
 
-export {useCombobox as useComboboxPrimitive} from '@twilio-paste/dropdown-library';
+export {
+  useCombobox as useComboboxPrimitive,
+  useMultipleSelection as useMultiSelectPrimitive,
+} from '@twilio-paste/dropdown-library';
 
 export type {
   UseComboboxInterface as UseComboboxPrimitiveInterface,
@@ -10,4 +13,9 @@ export type {
   UseComboboxState as UseComboboxPrimitiveState,
   UseComboboxReturnValue as UseComboboxPrimitiveReturnValue,
   UseComboboxStateChange as UseComboboxPrimitiveStateChange,
+  UseMultipleSelectionInterface as UseMultiSelectPrimitiveInterface,
+  UseMultipleSelectionProps as UseMultiSelectPrimitiveProps,
+  UseMultipleSelectionState as UseMultiSelectState,
+  UseMultipleSelectionReturnValue as UseMultiSelectPrimitiveReturnValue,
+  UseMultipleSelectionStateChange as UseMultiSelectPrimitiveStateChange,
 } from '@twilio-paste/dropdown-library';

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -159,8 +159,6 @@ export const ComboboxNonHooks = (): React.ReactNode => {
   );
 };
 
-const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
-
 export const BasicMultiCombobox: React.FC = () => {
   const seed = useUIDSeed();
   const [filteredItems, setFilteredItems] = React.useState([...items]);

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -159,31 +159,7 @@ export const ComboboxNonHooks = (): React.ReactNode => {
   );
 };
 
-// @TODO resolve this issue here.
-const BasicSelectedItem = React.forwardRef(({...props}, ref) => (
-  <Box as="li" listStyleType="none" display="inline-block" marginRight="space30">
-    <Box
-      {...props}
-      ref={ref}
-      as="div"
-      cursor="pointer"
-      color="colorText"
-      backgroundColor="colorBackground"
-      borderWidth="borderWidth10"
-      borderColor="colorBorderWeak"
-      borderStyle="solid"
-      borderRadius="borderRadius20"
-      paddingX="space30"
-      paddingY="space20"
-      height="30px"
-      display="flex"
-      columnGap="space20"
-      alignItems="center"
-    >
-      {props.children}
-    </Box>
-  </Box>
-));
+const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
 
 export const BasicMultiCombobox: React.FC = () => {
   const seed = useUIDSeed();
@@ -262,17 +238,33 @@ export const BasicMultiCombobox: React.FC = () => {
         </ul>
       </Box>
       <Box>
-        {selectedItems.map((selectedItem, index) => (
-          <BasicSelectedItem
-            {...getSelectedItemProps({
-              selectedItem,
-              index,
-            })}
-            key={seed(`selected-item-${selectedItem}`)}
-            onClick={() => handleRemoveItemOnClick(selectedItem)}
-          >
-            {selectedItem}
-          </BasicSelectedItem>
+        {selectedItems.map((item, index) => (
+          <Box as="li" listStyleType="none" display="inline-block" marginRight="space30">
+            <Box
+              {...getSelectedItemProps({
+                selectedItem,
+                index,
+              })}
+              key={seed(`selected-item-${item}`)}
+              onClick={() => handleRemoveItemOnClick(item)}
+              as="div"
+              cursor="pointer"
+              color="colorText"
+              backgroundColor="colorBackground"
+              borderWidth="borderWidth10"
+              borderColor="colorBorderWeak"
+              borderStyle="solid"
+              borderRadius="borderRadius20"
+              paddingX="space30"
+              paddingY="space20"
+              height="30px"
+              display="flex"
+              columnGap="space20"
+              alignItems="center"
+            >
+              {item}
+            </Box>
+          </Box>
         ))}
       </Box>
     </>

--- a/packages/paste-website/src/component-examples/ComboboxPrimitiveExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxPrimitiveExamples.ts
@@ -16,11 +16,11 @@ const BasicCombobox = () => {
   const uid = useUID();
   return (
     <>
-      <FormLabel htmlFor={uid} {...getLabelProps()}>
+      <Label htmlFor={uid} {...getLabelProps()}>
         Choose a component:
-      </FormLabel>
+      </Label>
       <Box {...getComboboxProps({role: 'combobox'})}>
-        <FormInput
+        <Input
           id={uid}
           type="text"
           {...getInputProps()}
@@ -72,11 +72,11 @@ const AutocompleteCombobox = () => {
   const uid = useUID();
   return (
     <>
-      <FormLabel htmlFor={uid} {...getLabelProps()}>
+      <Label htmlFor={uid} {...getLabelProps()}>
         Choose a component:
-      </FormLabel>
+      </Label>
       <Box display="flex" {...getComboboxProps()}>
-        <FormInput id={uid} type="text" {...getInputProps()} />
+        <Input id={uid} type="text" {...getInputProps()} />
         <Button {...getToggleButtonProps()} aria-label="toggle menu" variant="primary">
           <ChevronDownIcon size="sizeIcon30" decorative={false} title="toggle menu" />
         </Button>
@@ -101,3 +101,119 @@ render(
   <AutocompleteCombobox />
 )
 `.trim();
+
+export const multiSelectExample = `const items = ['Alert', 'Anchor', 'Button', 'Card', 'Heading', 'List', 'Modal', 'Paragraph'];
+
+const BasicMultiCombobox = () => {
+  const seed = useUIDSeed();
+  const [filteredItems, setFilteredItems] = React.useState([...items]);
+
+  const {
+    getSelectedItemProps,
+    getDropdownProps,
+    addSelectedItem,
+    removeSelectedItem,
+    selectedItems,
+  } = useMultiSelectPrimitive({});
+
+  const handleSelectItemOnClick = React.useCallback(
+    ({selectedItem}) => {
+      addSelectedItem(selectedItem);
+
+      setFilteredItems((currentFilteredItems) => currentFilteredItems.filter((item) => item !== selectedItem));
+    },
+    [addSelectedItem, setFilteredItems]
+  );
+
+  const handleRemoveItemOnClick = React.useCallback(
+    (selectedItem) => {
+      removeSelectedItem(selectedItem);
+
+      setFilteredItems((currentFilteredItems) => [...currentFilteredItems, selectedItem].sort());
+    },
+    [removeSelectedItem]
+  );
+
+  const {
+    getComboboxProps,
+    getInputProps,
+    getItemProps,
+    getLabelProps,
+    getMenuProps,
+    getToggleButtonProps,
+    highlightedIndex,
+    isOpen,
+    selectedItem,
+  } = useComboboxPrimitive({
+    items: filteredItems,
+    onSelectedItemChange: (args) => {
+      handleSelectItemOnClick(args);
+    },
+  });
+  const uid = useUID();
+
+  return (
+    <>
+      <Box>
+        <Label htmlFor={uid} {...getLabelProps()}>
+          Choose a component
+        </Label>
+        <Box {...getComboboxProps({role: 'combobox'})}>
+          <Input
+            id={uid}
+            type="text"
+            {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}
+            {...getToggleButtonProps({tabIndex: 0})}
+            value={selectedItem || ''}
+          />
+        </Box>
+        <ul {...getMenuProps()}>
+          {isOpen &&
+            filteredItems.map((item, index) => (
+              <li
+                style={highlightedIndex === index ? {textDecoration: 'underline'} : {}}
+                key={seed('item-' + item)}
+                {...getItemProps({item, index})}
+              >
+                {item}
+              </li>
+            ))}
+        </ul>
+      </Box>
+      <Box>
+        {selectedItems.map((item, index) => (
+          <Box as="li" listStyleType="none" display="inline-block" marginRight="space30">
+            <Box
+              {...getSelectedItemProps({
+                selectedItem,
+                index,
+              })}
+              key={seed('selected-item-' + item)}
+              onClick={() => handleRemoveItemOnClick(item)}
+              as="div"
+              cursor="pointer"
+              color="colorText"
+              backgroundColor="colorBackground"
+              borderWidth="borderWidth10"
+              borderColor="colorBorderWeak"
+              borderStyle="solid"
+              borderRadius="borderRadius20"
+              paddingX="space30"
+              paddingY="space20"
+              height="30px"
+              display="flex"
+              columnGap="space20"
+              alignItems="center"
+            >
+              {item}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+};
+
+render(
+  <BasicMultiCombobox />
+)`.trim();

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -102,37 +102,9 @@ This primitive should be used to compose all custom Comboboxes to ensure accessi
   </CalloutText>
 </Callout>
 
-## Usage Guide
+## Examples
 
-This package is a wrapper around the [`Downshift` package](https://downshift.netlify.com).
-Our wrapper currently only exposes the useCombobox hook, but renamed for Paste. The reason we chose
-to just expose the hook is that we feel it is the most flexible way of consuming downshift and better
-fit our chosen styling model.
-
-If you’re wondering why we wrapped that package into our own, we reasoned that it would be
-best for our consumers' developer experience. For example:
-
-- If we want to migrate the underlying nuts and bolts in the future, Twilio products
-  that depend on this primitive would need to replace all occurrences of `import … from ‘x-package’`
-  to `import … from ‘@some-new/package’`. By wrapping it in `@twilio-paste/x-primitive`, this
-  refactor can be avoided. The only change would be a version bump in the package.json file for the primitive.
-- We can more strictly enforce semver and backwards compatibility than some of our dependencies.
-- We can control when to provide an update and which versions we allow, to help reduce potential
-  bugs our consumers may face.
-- We can control which APIs we expose. For example, we may chose to enable or disable usage of
-  certain undocumented APIs.
-
-### Installation
-
-This package is available individually or as part of `@twilio-paste/core`.
-
-```
-yarn add @twilio-paste/combobox-primitive - or - yarn add @twilio-paste/core
-```
-
-### Examples
-
-#### Basic Combobox
+### Basic Combobox
 
 A basic Combobox is a direct replacement for the native HTML select element. It should function in roughly
 the same way, the difference being in the ability to style everything about it; the input trigger, option list
@@ -155,7 +127,7 @@ getter or directly on the element itself. You can see this demonstrated below:
   {defaultExample}
 </LivePreview>
 
-#### Autcomplete Combobox Example
+### Autcomplete Combobox Example
 
 This hook can be used to create custom autocomplete Combobox controls. These controls are useful when the
 customer needs to filter a list of available options, or provide a custom free form value to the input.
@@ -164,7 +136,7 @@ customer needs to filter a list of available options, or provide a custom free f
   {autocompleteExample}
 </LivePreview>
 
-#### Multiselect Combobox Example
+### Multiselect Combobox Example
 
 <LivePreview
   scope={{
@@ -184,12 +156,38 @@ customer needs to filter a list of available options, or provide a custom free f
   {multiSelectExample}
 </LivePreview>
 
-### useComboboxPrimitive Arguments
+## Usage Guide
 
-#### Basic Props
+This package is a wrapper around the [`Downshift` package](https://downshift.netlify.com).
+Our wrapper currently only exposes the useCombobox hook, but renamed for Paste. The reason we chose
+to just expose the hook is that we feel it is the most flexible way of consuming downshift and better
+fit our chosen styling model.
+
+If you’re wondering why we wrapped that package into our own, we reasoned that it would be
+best for our consumers' developer experience. For example:
+
+- If we want to migrate the underlying nuts and bolts in the future, Twilio products
+  that depend on this primitive would need to replace all occurrences of `import … from ‘x-package’`
+  to `import … from ‘@some-new/package’`. By wrapping it in `@twilio-paste/x-primitive`, this
+  refactor can be avoided. The only change would be a version bump in the package.json file for the primitive.
+- We can more strictly enforce semver and backwards compatibility than some of our dependencies.
+- We can control when to provide an update and which versions we allow, to help reduce potential
+  bugs our consumers may face.
+- We can control which APIs we expose. For example, we may chose to enable or disable usage of
+  certain undocumented APIs.
+
+### Installation
+
+```
+yarn add @twilio-paste/combobox-primitive - or - yarn add @twilio-paste/core
+```
+
+### API
+
+#### useComboboxPrimitive basic props
 
 This is the list of props that you should probably know about. There are some
-[advanced props](#advanced-props) below as well.
+[advanced props](#usecomboboxprimitive-advanced-props) below as well.
 
 ##### items `any[]` | _required_
 
@@ -218,7 +216,7 @@ item is highlighted (Tab, Shift-Tab or clicking away).
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `selectedItem` property
   with the newly selected value. This also has a `type` property which you can
-  learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
+  learn more about in the [`stateChangeTypes`](#usecomboboxprimitive-state-actiontypes) section. This
   property will be part of the actions that can trigger a `selectedItem` change,
   for example `useCombobox.stateChangeTypes.ItemClick`.
 
@@ -236,9 +234,9 @@ and the state that will be set, and you return the state that you want to set.
 - `actionAndChanges`: Object that contains the action `type`, props needed to
   return a new state based on that type and the changes suggested by the
   Downshift default reducer. About the `type` property you can learn more about
-  in the [`stateChangeTypes`](#statechangetypes) section.
+  in the [`stateChangeTypes`](#usecomboboxprimitive-state-actiontypes) section.
 
-#### Advanced Props
+#### useCombobox advanced props
 
 ##### initialSelectedItem `any` | defaults to `null`
 
@@ -325,7 +323,7 @@ keys that are part of their starting string equivalent.
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `highlightedIndex`
   property with the new value. This also has a `type` property which you can
-  learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
+  learn more about in the [`stateChangeTypes`](#usecomboboxprimitive-state-action-types) section. This
   property will be part of the actions that can trigger a `highlightedIndex`
   change, for example `useCombobox.stateChangeTypes.MenuKeyDownArrowUp`.
 
@@ -339,7 +337,7 @@ again or hitting Escape key.
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `isOpen` property with
   the new value. This also has a `type` property which you can learn more about
-  in the [`stateChangeTypes`](#statechangetypes) section. This property will be
+  in the [`stateChangeTypes`](#usecomboboxprimitive-state-action-types) section. This property will be
   part of the actions that can trigger a `isOpen` change, for example
   `useCombobox.stateChangeTypes.ToggleButtonClick`.
 
@@ -352,7 +350,7 @@ change like any input of type text, at any character key press, `Space`,
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `inputValue` property
   with the new value. This also has a `type` property which you can learn more
-  about in the [`stateChangeTypes`](#statechangetypes) section. This property
+  about in the [`stateChangeTypes`](#usecomboboxprimitive-state-action-types) section. This property
   will be part of the actions that can trigger a `inputValue` change, for
   example `useCombobox.stateChangeTypes.InputChange`.
 
@@ -365,11 +363,9 @@ pass it as props, rather than letting downshift control all its state itself.
 
 - `changes`: These are the properties that actually have changed since the last
   state change. This also has a `type` property which you can learn more about
-  in the [`stateChangeTypes`](#statechangetypes) section.
+  in the [`stateChangeTypes`](#usecomboboxprimitive-state-action-types) section.
 
-##### highlightedIndex
-
-> `number`
+##### highlightedIndex `number`
 
 The index of the item that should be highlighted when menu is open.
 
@@ -411,9 +407,7 @@ Used for `aria` attributes and the `id` prop of the element (`button`) you use
 Used for `aria` attributes and the `id` prop of the element (`input`) you use
 [`getInputProps`](#getmenuprops) with.
 
-##### getItemId `function(index)` | defaults to a function that generates an ID based on the
-
-> index
+##### getItemId `function(index)` | defaults to a function that generates an ID based on the index
 
 Used for `aria` attributes and the `id` prop of the element (`li`) you use
 [`getItemProps`](#getitemprops) with.
@@ -434,9 +428,72 @@ Controls the circular keyboard navigation between items. If set to `true`, when
 first item is highlighted, the Arrow Up will move highlight to the last item,
 and viceversa using Arrow Down.
 
-### useComboboxPrimitive Returned
+#### useComboboxPrimitive state change types
 
-##### getLabelProps
+There are a few props that expose changes to state
+(`onStateChange` and `stateReducer`). For you
+to make the most of these APIs, it's important for you to understand why state
+is being changed. To accomplish this, there's a `type` property on the `changes`
+object you get. This `type` corresponds to a `stateChangeTypes` property.
+
+The list of all possible values this `type` property can take is defined in
+[this file][state-change-file] and is as follows:
+
+- `useCombobox.stateChangeTypes.InputKeyDownArrowDown`
+- `useCombobox.stateChangeTypes.InputKeyDownArrowUp`
+- `useCombobox.stateChangeTypes.InputKeyDownEscape`
+- `useCombobox.stateChangeTypes.InputKeyDownHome`
+- `useCombobox.stateChangeTypes.InputKeyDownEnd`
+- `useCombobox.stateChangeTypes.InputKeyDownEnter`
+- `useCombobox.stateChangeTypes.InputChange`
+- `useCombobox.stateChangeTypes.InputBlur`
+- `useCombobox.stateChangeTypes.MenuMouseLeave`
+- `useCombobox.stateChangeTypes.ItemMouseMove`
+- `useCombobox.stateChangeTypes.ItemClick`
+- `useCombobox.stateChangeTypes.ToggleButtonClick`
+- `useCombobox.stateChangeTypes.FunctionToggleMenu`
+- `useCombobox.stateChangeTypes.FunctionOpenMenu`
+- `useCombobox.stateChangeTypes.FunctionCloseMenu`
+- `useCombobox.stateChangeTypes.FunctionSetHighlightedIndex`
+- `useCombobox.stateChangeTypes.FunctionSelectItem`
+- `useCombobox.stateChangeTypes.FunctionSetInputValue`
+- `useCombobox.stateChangeTypes.FunctionReset`
+
+#### useComboboxPrimitive control props
+
+Downshift manages its own state internally and calls your
+`onSelectedItemChange`, `onIsOpenChange`, `onHighlightedIndexChange`,
+`onInputChange` and `onStateChange` handlers with any relevant changes. The
+state that downshift manages includes: `isOpen`, `selectedItem`, `inputValue`
+and `highlightedIndex`. Returned action function (read more below) can be used
+to manipulate this state and can likely support many of your use cases.
+
+However, if more control is needed, you can pass any of these pieces of state as
+a prop (as indicated above) and that state becomes controlled. As soon as
+`this.props[statePropKey] !== undefined`, internally, `downshift` will determine
+its state based on your prop's value rather than its own internal state. You
+will be required to keep the state up to date (this is where `onStateChange`
+comes in really handy), but you can also control the state from anywhere, be
+that state from other components, `redux`, `react-router`, or anywhere else.
+
+> Note: This is very similar to how normal controlled components work elsewhere
+> in react (like `<input />`). If you want to learn more about this concept, you
+> can learn about that from this the
+> [Advanced React Component Patterns course](#advanced-react-component-patterns-course)
+
+#### useComboboxPrimitive returned
+
+##### useComboboxPrimitive prop getters
+
+<Callout>
+  <CalloutTitle>On prop getters and accessibility</CalloutTitle>
+  <CalloutText>
+    These prop-getters provide `aria-` attributes which are very important > to your component being accessible. It's
+    recommended that you utilize these > functions and apply the props they give you to your components.
+  </CalloutText>
+</Callout>
+
+###### getLabelProps
 
 This method should be applied to the `label` you render. It will generate an
 `id` that will be used to label the toggle button and the menu.
@@ -445,7 +502,7 @@ There are no required properties for this method.
 
 > Note: For accessibility purposes, calling this method is highly recommended.
 
-##### getMenuProps
+###### getMenuProps
 
 This method should be applied to the element which contains your list of items.
 Typically, this will be a `<div>` or a `<ul>` that surrounds a `map` expression.
@@ -479,7 +536,7 @@ unexpectedly fail.**
 > Note that for accessibility reasons it's best if you always render this
 > element whether or not downshift is in an `isOpen` state.
 
-##### getItemProps
+###### getItemProps
 
 The props returned from calling this function should be applied to any menu
 items you render.
@@ -521,7 +578,7 @@ Optional properties:
   handlers will be omitted. Items will not be highlighted when hovered, and
   items will not be selected when clicked.
 
-##### getToggleButtonProps
+###### getToggleButtonProps
 
 Call this and apply the returned props to a `button`. It allows you to toggle
 the `Menu` component.
@@ -545,7 +602,7 @@ Optional properties:
 - `disabled`: If this is set to `true`, then all of the downshift button event
   handlers will be omitted (it won't toggle the menu when clicked).
 
-##### getInputProps
+###### getInputProps
 
 This method should be applied to the `input` you render. It is recommended that
 you pass all props as an object to this method which will compose together any
@@ -579,7 +636,7 @@ can provide the object `{suppressRefError : true}` as the second argument to
 sure that the ref is correctly forwarded otherwise `useCombobox` will
 unexpectedly fail.**
 
-##### getComboboxProps
+###### getComboboxProps
 
 This method should be applied to the `input` wrapper element. It has similar
 return values to the `getRootProps` from vanilla `Downshift`, but renaming it as
@@ -597,7 +654,7 @@ can provide the object `{suppressRefError : true}` as the second argument to
 absolutely sure that the ref is correctly forwarded otherwise `useCombobox` will
 unexpectedly fail.**
 
-#### Actions
+##### useComboboxPrimitive actions
 
 These are functions you can call to change the state of the downshift
 `useCombobox` hook.
@@ -612,7 +669,7 @@ These are functions you can call to change the state of the downshift
 | `toggleMenu`          | `function()`              | toggle the menu open state                            |
 | `reset`               | `function()`              | this resets downshift's state to a reasonable default |
 
-#### State
+##### useComboboxPrimitive state
 
 These are values that represent the current state of the downshift component.
 
@@ -622,6 +679,463 @@ These are values that represent the current state of the downshift component.
 | `isOpen`           | `boolean` | the menu open state               |
 | `selectedItem`     | `any`     | the currently selected item input |
 | `inputValue`       | `string`  | the value in the input            |
+
+---
+
+#### useMultiSelectPrimitive basic props
+
+This is the list of props that you should probably know about. There are some
+[advanced props](#usemultiselectprimitive-basic-props) below as well.
+
+##### itemToString `function(item: any)` | defaults to: `i => (i == null ? '' : String(i))`
+
+If your items are stored as, say, objects instead of strings, downshift still
+needs a string representation for each one. This is required for accessibility
+aria-live messages (e.g., after removing a selection).
+
+##### onSelectedItemsChange `function(changes: object)` | optional, no useful default
+
+Called each time the selected items array changes. Especially useful when items
+are removed, as there are many ways to do that: `Backspace` from dropdown,
+`Backspace` or `Delete` while focus is the item, executing `removeSelectedItem`
+when clicking an associated `X` icon for the item.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `selectedItems`
+  property with the new array value. This also has a `type` property which you
+  can learn more about in the [`stateChangeTypes`](#usemultiselectprimitive-state-action-types) section.
+  This property will be part of the actions that can trigger an `selectedItems`
+  change, for example `useSelect.stateChangeTypes.DropdownKeyDownBackspace`.
+
+##### stateReducer `function(state: object, actionAndChanges: object)` | optional
+
+**🚨 This is a really handy power feature 🚨**
+
+This function will be called each time `useMultipleSelection` sets its internal
+state (or calls your `onStateChange` handler for control props). It allows you
+to modify the state change that will take place which can give you fine grain
+control over how the component interacts with user updates. It gives you the
+current state and the state that will be set, and you return the state that you
+want to set.
+
+- `state`: The full current state of downshift.
+- `actionAndChanges`: Object that contains the action `type`, props needed to
+  return a new state based on that type and the changes suggested by the
+  Downshift default reducer. About the `type` property you can learn more about
+  in the [`stateChangeTypes`](#usemultiselectprimitive-state-action-types) section.
+
+#### useMultiSelectPrimitive advanced props
+
+##### keyNavigationNext `string` | defaults to `ArrowRight`
+
+The navigation key that increments `activeIndex` and moves focus to the selected
+item whose index corresponds to the new value. For a `RTL` scenario, a common
+overriden value could be `ArrowLeft`. In some scenarios it can be `ArrowDown`.
+It mostly depends on the UI the user is presented with.
+
+##### keyNavigationPrevious `string` | defaults to `ArrowLeft`
+
+The navigation key that decrements `activeIndex` and moves focus to the selected
+item whose index corresponds to the new value. Also moves focus from `dropdown`
+to item with the last index. For a `RTL` scenario, a common overriden value
+could be `ArrowRight`. In some scenarios it can be `ArrowUp`. It mostly depends
+on the UI the user is presented with.
+
+##### initialSelectedItems `any[]` | defaults to `[]`
+
+Pass an initial array of items that are considered to be selected.
+
+##### initialActiveIndex `number` | defaults to `-1`
+
+Pass a number that sets the index of the focused / active selected item when
+downshift is initialized.
+
+##### defaultSelectedItems `any[]` | defaults to `[]`
+
+Pass an array of items that are going to be used when downshift is reset.
+
+##### defaultActiveIndex `number` | defaults to `-1`
+
+Pass a number that sets the index of the focused / active selected item when
+downshift is reset.
+
+##### getA11yRemovalMessage `function({})` | default messages provided in English
+
+This function is similar to the `getA11yStatusMessage` or
+`getA11ySelectionMessage` from `useSelect` and `useCombobox` but it is
+generating an ARIA a11y message when an item is removed. It is passed as props
+to a status updating function nested within that allows you to create your own
+ARIA statuses. It is called when an item is removed and the size of
+`selectedItems` decreases.
+
+A default `getA11yRemovalMessage` function is provided. When an item is removed,
+the message is a removal related one, narrating "`itemToString(removedItem)` has
+been removed".
+
+The object you are passed to generate your status message for
+`getA11yRemovalMessage` has the following properties:
+
+| property              | type            | description                                                                                  |
+| --------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `resultCount`         | `number`        | The count of selected items in the list.                                                     |
+| `itemToString`        | `function(any)` | The `itemToString` function (see props) for getting the string value from one of the options |
+| `removedSelectedItem` | `any`           | The value of the currently removed item                                                      |
+| `activeSelectedItem`  | `any`           | The value of the currently active item                                                       |
+| `activeIndex`         | `number`        | The index of the currently active item.                                                      |
+
+##### onActiveIndexChange `function(changes: object)` | optional, no useful default
+
+Called each time the index of the active item changes. When an item becomes
+active, it receives focus, so it can receive keyboard events. To change
+`activeIndex` you can either click on the item or use navigation keys between
+the items and the dropdown.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This object is guaranteed to contain the `activeIndex` property
+  with the new value. This also has a `type` property which you can learn more
+  about in the [`stateChangeTypes`](#usemultiselectprimitive-state-action-types) section.
+
+##### onStateChange `function(changes: object)` | optional, no useful default
+
+This function is called anytime the internal state changes. This can be useful
+if you're using downshift as a "controlled" component, where you manage some or
+all of the state (e.g. selectedItems and activeIndex) and then pass it as props,
+rather than letting downshift control all its state itself.
+
+- `changes`: These are the properties that actually have changed since the last
+  state change. This also has a `type` property which you can learn more about
+  in the [`stateChangeTypes`](#usemultiselectprimitive-state-action-types) section.
+
+> Tip: This function will be called any time _any_ state is changed. The best
+> way to determine whether any particular state was changed, you can use
+> `changes.hasOwnProperty('propName')` or use the `on[statePropKey]Change` props
+> described above.
+
+> NOTE: This is only called when state actually changes. You should not attempt
+> to use this to handle events. If you wish handle events, put your event
+> handlers directly on the elements (make sure to use the prop getters though!
+>
+> For example: `<button onBlur={handleBlur} />` should be
+> `<button {...getDropdownProps({onBlur: handleBlur})} />`).
+
+##### activeIndex `number` | **control prop**
+
+(read more about this in [the Control Props section](#control-props))
+
+The index of the item that should be active and focused.
+
+##### selectedItems `any[]` | **control prop**
+
+(read more about this in [the Control Props section](#usecomboboxprimitive-control-props))
+
+The items that are considered selected at the time.
+
+##### environment `window` | defaults to `window`
+
+This prop is only useful if you're rendering downshift within a different
+`window` context from where your JavaScript is running; for example, an iframe
+or a shadow-root. If the given context is lacking `document` and/or
+`add|removeEventListener` on its prototype (as is the case for a shadow-root)
+then you will need to pass in a custom object that is able to provide
+[access to these properties](https://gist.github.com/Rendez/1dd55882e9b850dd3990feefc9d6e177)
+for downshift.
+
+#### useMultiSelectPrimitive state change types
+
+There are a few props that expose changes to state
+(`onStateChange` and `stateReducer`). For you
+to make the most of these APIs, it's important for you to understand why state
+is being changed. To accomplish this, there's a `type` property on the `changes`
+object you get. This `type` corresponds to a `stateChangeTypes` property.
+
+The list of all possible values this `type` property can take is defined in
+[this file][state-change-file] and is as follows:
+
+- `useMultipleSelection.stateChangeTypes.SelectedItemClick`
+- `useMultipleSelection.stateChangeTypes.SelectedItemKeyDownDelete`
+- `useMultipleSelection.stateChangeTypes.SelectedItemKeyDownBackspace`
+- `useMultipleSelection.stateChangeTypes.SelectedItemKeyDownNavigationNext`
+- `useMultipleSelection.stateChangeTypes.SelectedItemKeyDownNavigationPrevious`
+- `useMultipleSelection.stateChangeTypes.DropdownKeyDownNavigationPrevious`
+- `useMultipleSelection.stateChangeTypes.DropdownKeyDownBackspace`
+- `useMultipleSelection.stateChangeTypes.DropdownClick`
+- `useMultipleSelection.stateChangeTypes.FunctionAddSelectedItem`
+- `useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem`
+- `useMultipleSelection.stateChangeTypes.FunctionSetSelectedItems`
+- `useMultipleSelection.stateChangeTypes.FunctionSetActiveIndex`
+- `useMultipleSelection.stateChangeTypes.FunctionReset`
+
+#### useMultiSelectPrimitive control Props
+
+Downshift manages its own state internally and calls your
+`onSelectedItemsChange`, `onActiveIndexChange` and `onStateChange` handlers with
+any relevant changes. The state that downshift manages includes: `selectedItems`
+and `activeIndex`. Returned action function (read more below) can be used to
+manipulate this state and can likely support many of your use cases.
+
+However, if more control is needed, you can pass any of these pieces of state as
+a prop (as indicated above) and that state becomes controlled. As soon as
+`this.props[statePropKey] !== undefined`, internally, `downshift` will determine
+its state based on your prop's value rather than its own internal state. You
+will be required to keep the state up to date (this is where `onStateChange`
+comes in really handy), but you can also control the state from anywhere, be
+that state from other components, `redux`, `react-router`, or anywhere else.
+
+> Note: This is very similar to how normal controlled components work elsewhere
+> in react (like `<input />`).
+
+#### useMultipleSelection returned props
+
+The properties of `useMultipleSelection` can be split into three categories as indicated below.
+
+##### useMultiSelectPrimitive prop getters
+
+<Callout>
+  <CalloutTitle>On prop getters and accessibility</CalloutTitle>
+  <CalloutText>
+    These prop-getters provide `aria-` attributes which are very important > to your component being accessible. It's
+    recommended that you utilize these > functions and apply the props they give you to your components.
+  </CalloutText>
+</Callout>
+
+These functions are used to apply props to the elements that you render. This
+gives you maximum flexibility to render what, when, and wherever you like. You
+call these on the element in question, for example on the toggle button:
+
+```jsx
+<button {...getDropdownProps()}
+```
+
+It's advisable to pass all your props to that
+function rather than applying them on the element yourself to avoid your props
+being overridden (or overriding the props returned).
+
+For example:
+`getDropdownProps({preventKeyAction: isOpen})`.
+
+See this [blog post about prop getters](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters 'How to give rendering control to users with prop getters')
+
+| property               | type           | description                                                                                      |
+| ---------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| `getDropdownProps`     | `function({})` | returns the props you should apply to either your input or toggle button, depending on the case. |
+| `getSelectedItemProps` | `function({})` | returns the props you should apply to any selected item elements you render.                     |
+
+##### getSelectedItemProps
+
+The props returned from calling this function should be applied to any selected
+items you render. It allows changing the activeIndex by using arrow keys or by
+clicking, but also removing items by `Delete` or `Backspace` on active item. It
+also ensures that focus moves along with the activeIndex, and it keeps a
+`tabindex="0"` on the active element even if user decides to `Tab` away. That
+way, when tabbing back, the user can pick up where he left off with selection.
+
+**This is an impure function**, so it should only be called when you will
+actually be applying the props to an item.
+
+Required properties:
+
+It is required to pass either `selectedItem` or `index` to
+`getSelectedItemProps` in order to be able to apply the activeIndex logic.
+
+- `selectedItem`: this is the item data that will be selected when the user
+  selects a particular item.
+- `index`: This is how `downshift` keeps track of your item when updating the
+  `activeIndex` as the user keys around. By default, `downshift` will assume the
+  `index` is the order in which you're calling `getSelectedItemProps`. This is
+  often good enough, but if you find odd behavior, try setting this explicitly.
+  It's probably best to be explicit about `index` when using a windowing library
+  like `react-virtualized`.
+
+Optional properties:
+
+- `ref`: if you need to access the dropdown element via a ref object, you'd call
+  the function like this: `getDropdown({ref: yourDropdownRef})`. As a result,
+  the dropdown element will receive a composed `ref` property, which guarantees
+  that both your code and `useMultipleSelection` use the same correct reference
+  to the element.
+
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call:
+  `getSelectedItemProps({refKey: 'innerRef'})` and your composite component
+  would forward like: `<li ref={props.innerRef} />`. However, if you are just
+  rendering a primitive component like `<div>`, there is no need to specify this
+  property. It defaults to `ref`.
+
+##### getDropdownProps
+
+Call this and apply the returned props to a `button` if you are building a
+`select` or to an `input` if you're building a `combobox`. It allows you to move
+focus from this element to the last item selected by using `ArrowLeft` and also
+to remove the last item using `Backspace`.
+
+Optional properties:
+
+- `preventKeyAction`: tells `useMultipleSelection` if `dropdown` is allowed to
+  execute `downshift` handlers on `keydown`. For example, you can pass `isOpen`
+  as value and user will not be able to delete selecteditems by `Backspace` or
+  to navigate to them by arrow keys. This is useful if you don't want to mix key
+  actions from multiple selection with the ones from the dropdown. Once the
+  dropdown is closed then deletion / navigation can be resumed for multiple
+  selection. The value is `false` by default.
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getDropdownProps({refKey: 'innerRef'})`
+  and your composite component would forward like:
+  `<button ref={props.innerRef} />`. However, if you are just rendering a
+  primitive component like `<div>`, there is no need to specify this property.
+  It defaults to `ref`.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError: true}` as the second argument to
+`getDropdownProps`.
+
+**Please use it with extreme care and only if you are
+absolutely sure that the ref is correctly forwarded otherwise
+`useMultipleSelection` will unexpectedly fail.**
+
+```javascript
+const {getDropdownProps} = useMultipleSelection()
+const {isOpen, ...rest} = useComboboxPrimitve({items})
+const myButton = (
+  {/* selected items */}
+  <button {...getDropdownProps({preventKeyAction: isOpen})}>Click me</button>
+  {/* menu and items */}
+)
+```
+
+##### Actions
+
+These are functions you can call to change the state of the downshift
+`useMultipleSelection` hook.
+
+| property             | type                      | description                                           |
+| -------------------- | ------------------------- | ----------------------------------------------------- |
+| `addSelectedItem`    | `function(item: any)`     | adds an item to the selected array                    |
+| `removeSelectedItem` | `function(item: any)`     | removes an item from the selected array               |
+| `reset`              | `function()`              | resets the selectedItems and active index to defaults |
+| `setActiveIndex`     | `function(index: number)` | sets activeIndex to the new value                     |
+| `setSelectedItems`   | `function(items: any[])`  | sets selectedItems to the new value                   |
+
+##### State
+
+These are values that represent the current state of the downshift component.
+
+| property        | type     | description                           |
+| --------------- | -------- | ------------------------------------- |
+| `activeIndex`   | `number` | the index of thecurrently active item |
+| `selectedItems` | `any[]`  | the items of the selection            |
+
+#### Event Handlers
+
+Downshift has a few events for which it provides implicit handlers. Several of
+these handlers call `event.preventDefault()`. Their additional functionality is
+described below.
+
+##### Default handlers
+
+###### Dropdown - button or input
+
+- `ArrowLeft`: Moves focus from `button`/`input` to the last selected item and
+  makes `activeIndex` to be `selectedItems.length - 1`. Performs this action if
+  there are any items selected. `ArrowLeft` can be overriden with any other key
+  depeding on the requirements.
+- `Backspace`: Removes the last selected item from selection. It always performs
+  this action on a non-input element. If the `dropdown` is a `combobox` the text
+  cursor of the `input` must be at the start of the `input` and not highlight
+  any text in order for the removal to work.
+
+###### Item
+
+- `Click`: It will make the item active, will modify `activeIndex` to reflect
+  the new change, and will add focus to that item.
+- `Delete`: It will remove the item from selection. `activeIndex` will stay the
+  same if the item removed was not the last one, but focus will move to the item
+  which now has that index. If the last item was removed, the `activeIndex` will
+  decrease by one and will also move focus to the corresponding item. If there
+  are no items available anymore, the focus moves to the dropdown and
+  `activeIndex` becomes `-1`.
+- `Backspace`: Same effect as `Delete`.
+- `ArrowLeft`: Moves `activeIndex` and focus to previous item. It stops at the
+  first item in the selection. `ArrowLeft` can be overriden with any other key
+  depeding on the requirements.
+- `ArrowRight`: Moves `activeIndex` and focus to next item. It will move focus
+  to the `dropdown` if it occurs on the last selected item. `ArrowRight` can be
+  overriden with any other key depeding on the requirements.
+
+##### Customizing Handlers
+
+You can provide your own event handlers to `useMultipleSelection` which will be
+called before the default handlers:
+
+```javascript
+const items = [...] // items here.
+const {getDropdownProps} = useMultipleSelection()
+const {getInputProps} = useCombobox({items})
+const ui = (
+  /* label, selected items, ... */
+  <input
+    {...getInputProps(
+      getDropdownProps({
+        onKeyDown: event => {
+          // your custom keyDown handler here.
+        },
+      }),
+    )}
+  />
+)
+```
+
+If you would like to prevent the default handler behavior in some cases, you can
+set the event's `preventDownshiftDefault` property to `true`:
+
+```javascript
+const items = [...] // items here.
+const {getDropdownProps} = useMultipleSelection()
+const {getInputProps} = useCombobox({items})
+const ui = (
+  /* label, selected items, ... */
+  <input
+    {...getInputProps(
+      getDropdownProps({
+        onKeyDown: event => {
+          // your custom keyDown handler here.
+          if (event.key === 'Enter') {
+            // Prevent Downshift's default 'Enter' behavior.
+            event.nativeEvent.preventDownshiftDefault = true
+
+            // your handler code
+          }
+        },
+      }),
+    )}
+  />
+)
+```
+
+If you would like to completely override Downshift's behavior for a handler, in
+favor of your own, you can bypass prop getters:
+
+```javascript
+const items = [...] // items here.
+const {getDropdownProps} = useMultipleSelection()
+const {getInputProps} = useCombobox({items})
+const ui = (
+  /* label, selected items, ... */
+  <input
+    {...getInputProps(
+      getDropdownProps({
+        onKeyDown: event => {
+          // your custom keyDown handler here.
+        },
+      }),
+    )}
+    onKeyDown={event => {
+      // your custom keyDown handler here.
+    }}
+  />
+)
+```
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -5,15 +5,21 @@ slug: /primitives/combobox-primitive/
 ---
 
 import {graphql} from 'gatsby';
-import {useUID} from '@twilio-paste/uid-library';
-import {useComboboxPrimitive} from '@twilio-paste/combobox-primitive';
+import {useUID, useUIDSeed} from '@twilio-paste/uid-library';
+import {useComboboxPrimitive, useMultiSelectPrimitive} from '@twilio-paste/combobox-primitive';
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
+import {Label} from '@twilio-paste/label';
+import {Input} from '@twilio-paste/input';
 import {ChevronDownIcon} from '@twilio-paste/icons/esm/ChevronDownIcon';
-import {FormLabel, FormInput} from '@twilio-paste/form';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
-import {autocompleteExample, defaultExample} from '../../../component-examples/ComboboxPrimitiveExamples';
+import {
+  autocompleteExample,
+  defaultExample,
+  multiSelectExample,
+} from '../../../component-examples/ComboboxPrimitiveExamples';
 import Changelog from '@twilio-paste/combobox-primitive/CHANGELOG.md';
 
 export const pageQuery = graphql`
@@ -145,7 +151,7 @@ getter or directly on the element itself. You can see this demonstrated below:
   </CalloutText>
 </Callout>
 
-<LivePreview scope={{useComboboxPrimitive, Box, FormLabel, FormInput, useUID}} noInline language="jsx">
+<LivePreview scope={{useComboboxPrimitive, Box, Label, Input, useUID}} noInline language="jsx">
   {defaultExample}
 </LivePreview>
 
@@ -154,12 +160,28 @@ getter or directly on the element itself. You can see this demonstrated below:
 This hook can be used to create custom autocomplete Combobox controls. These controls are useful when the
 customer needs to filter a list of available options, or provide a custom free form value to the input.
 
+<LivePreview scope={{useComboboxPrimitive, Box, Button, ChevronDownIcon, Label, Input, useUID}} noInline language="jsx">
+  {autocompleteExample}
+</LivePreview>
+
+#### Multiselect Combobox Example
+
 <LivePreview
-  scope={{useComboboxPrimitive, Box, Button, ChevronDownIcon, FormLabel, FormInput, useUID}}
+  scope={{
+    useComboboxPrimitive,
+    useMultiSelectPrimitive,
+    Box,
+    Button,
+    ChevronDownIcon,
+    Label,
+    Input,
+    useUID,
+    useUIDSeed,
+  }}
   noInline
   language="jsx"
 >
-  {autocompleteExample}
+  {multiSelectExample}
 </LivePreview>
 
 ### useComboboxPrimitive Arguments

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,22 +4402,10 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@10.0.28", "@emotion/core@^10.0.9":
+"@emotion/core@10.0.28", "@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
   version "10.0.28"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
   integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
-"@emotion/core@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
-  integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"
@@ -12495,23 +12483,6 @@ camelcase-css@2.0.1, camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
-  dependencies:
-    camelcase "^2.0.0"
-    map-obj "^1.0.0"
-
-camelcase-keys@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
-  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
-  dependencies:
-    camelcase "^4.1.0"
-    map-obj "^2.0.0"
-    quick-lru "^1.0.0"
-
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -12526,17 +12497,12 @@ camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
-
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -14997,7 +14963,7 @@ decache@^4.6.0:
   dependencies:
     callsite "^1.0.0"
 
-decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
+decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
   integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
@@ -15005,7 +14971,7 @@ decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -19967,19 +19933,19 @@ graphql-import@^0.7.1:
     lodash "^4.17.4"
     resolve-from "^4.0.0"
 
-graphql-playground-html@1.6.25:
-  version "1.6.25"
-  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.25.tgz#2d8fa250cec4036a4f5b7f8ad069c86d6d64c95f"
-  integrity sha512-wMNvGsQ0OwBVhn72VVi7OdpI85IxiIZT43glRx7gQIwQ6NvhFnzMYBIVmcJAJ4UlXRYiWtrQhuOItDXObiR3kg==
+graphql-playground-html@^1.6.29:
+  version "1.6.29"
+  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz#5b0c60a0161cc0f3116085f64c5a16cb3b2d9a16"
+  integrity sha512-fbF/zZKuw2sdfKp8gjTORJ/I9xBsqeEYRseWxBzuR15NHMptRTT9414IyRCs3ognZzUDr5MDJgx97SlLZCtQyA==
   dependencies:
     xss "^1.0.6"
 
-graphql-playground-middleware-express@^1.7.14:
-  version "1.7.18"
-  resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.18.tgz#306d64d54ccb531baf7df0699df3220ca4e25364"
-  integrity sha512-EywRL+iBa4u//5YbY1iJxrl0n4IKyomBKgLXrMbG8gHJUwxmFs5FCWJJ4Q6moSn5Q3RgMZvrWzXB27lKwN8Kgw==
+graphql-playground-middleware-express@^1.7.14, graphql-playground-middleware-express@^1.7.18:
+  version "1.7.22"
+  resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.22.tgz#e4bbe4faaa56b48e95769c8b87b65e53355d91a4"
+  integrity sha512-PJLiCxLmN6Dp+dHGyHU92m9y3hB/RAkcUBWcqYl2fiP+EbpDDgNfElrsVzW60MhJe+LTV1PFqiInH2d3KNvlCQ==
   dependencies:
-    graphql-playground-html "1.6.25"
+    graphql-playground-html "^1.6.29"
 
 graphql-request@^1.5.0:
   version "1.8.2"
@@ -24519,14 +24485,6 @@ lottie-web@^5.7.4:
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.4.tgz#3b252148e904a0aa9833879ffb64924c85a0888c"
   integrity sha512-LxqhXlHnHXOPmu+o2ipFKGv42jZLmn/GiEwXP0YC331fFwa+y96OUV22OF9r4i29uWKDciXiJr8tzy6jL8KygA==
 
-loud-rejection@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.0"
-
 loud-rejection@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c"
@@ -24713,15 +24671,10 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^1.0.0, map-obj@^1.0.1:
+map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-
-map-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
-  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
 map-obj@^4.0.0:
   version "4.1.0"
@@ -25054,55 +25007,7 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
-  dependencies:
-    camelcase-keys "^2.0.0"
-    decamelize "^1.1.2"
-    loud-rejection "^1.0.0"
-    map-obj "^1.0.1"
-    minimist "^1.1.3"
-    normalize-package-data "^2.3.4"
-    object-assign "^4.0.1"
-    read-pkg-up "^1.0.1"
-    redent "^1.0.0"
-    trim-newlines "^1.0.0"
-
-meow@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
-  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
-  dependencies:
-    camelcase-keys "^4.0.0"
-    decamelize-keys "^1.0.0"
-    loud-rejection "^1.0.0"
-    minimist-options "^3.0.1"
-    normalize-package-data "^2.3.4"
-    read-pkg-up "^3.0.0"
-    redent "^2.0.0"
-    trim-newlines "^2.0.0"
-    yargs-parser "^10.0.0"
-
-meow@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
-  integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "^4.0.2"
-    normalize-package-data "^2.5.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.13.1"
-    yargs-parser "^18.1.3"
-
-meow@^8.0.0:
+meow@^3.3.0, meow@^5.0.0, meow@^6.0.0, meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
   integrity sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==
@@ -25340,7 +25245,7 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@4.1.0, minimist-options@^4.0.2:
+minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
   integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
@@ -25349,15 +25254,7 @@ minimist-options@4.1.0, minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist-options@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
-  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -26331,7 +26228,7 @@ normalize-node-version@^10.0.0:
     jest-validate "^25.3.0"
     semver "^7.3.2"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -29412,11 +29309,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-quick-lru@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
-  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
-
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -30406,22 +30298,6 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
-
-redent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
-  dependencies:
-    indent-string "^2.1.0"
-    strip-indent "^1.0.1"
-
-redent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
-  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
-  dependencies:
-    indent-string "^3.0.0"
-    strip-indent "^2.0.0"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -33170,18 +33046,6 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-indent@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
-  dependencies:
-    get-stdin "^4.0.1"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
-
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -34234,16 +34098,6 @@ trim-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.3.tgz#839514be82428fd9e7ec89e35081afe8f6f93115"
   integrity sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -34448,11 +34302,6 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
-
-type-fest@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.16.0:
   version "0.16.0"
@@ -36006,7 +35855,7 @@ websocket-driver@^0.7.4:
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
-websocket-extensions@>=0.1.1:
+websocket-extensions@>=0.1.1, websocket-extensions@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
@@ -36694,13 +36543,6 @@ yargs-parser@20.2.4, yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
@@ -36717,7 +36559,7 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,10 +4402,22 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@10.0.28", "@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
+"@emotion/core@10.0.28", "@emotion/core@^10.0.9":
   version "10.0.28"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
   integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/core@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
+  integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"
@@ -8274,6 +8286,13 @@
   dependencies:
     "@babel/runtime" "^7.12.1"
     "@testing-library/dom" "^7.26.6"
+
+"@testing-library/user-event@^13.2.1":
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.2.1.tgz#7a71a39e50b4a733afbe2916fa2b99966e941f98"
+  integrity sha512-cczlgVl+krjOb3j1625usarNEibI0IFRJrSWX9UsJ1HKYFgCQv9Nb7QAipUDXl3Xdz8NDTsiS78eAkPSxlzTlw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -12476,6 +12495,23 @@ camelcase-css@2.0.1, camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
+  dependencies:
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
+
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -12490,12 +12526,17 @@ camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelcase@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
+
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.0.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -14956,7 +14997,7 @@ decache@^4.6.0:
   dependencies:
     callsite "^1.0.0"
 
-decamelize-keys@^1.1.0:
+decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
   integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
@@ -14964,7 +15005,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -19933,7 +19974,7 @@ graphql-playground-html@1.6.25:
   dependencies:
     xss "^1.0.6"
 
-graphql-playground-middleware-express@^1.7.14, graphql-playground-middleware-express@^1.7.18:
+graphql-playground-middleware-express@^1.7.14:
   version "1.7.18"
   resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.18.tgz#306d64d54ccb531baf7df0699df3220ca4e25364"
   integrity sha512-EywRL+iBa4u//5YbY1iJxrl0n4IKyomBKgLXrMbG8gHJUwxmFs5FCWJJ4Q6moSn5Q3RgMZvrWzXB27lKwN8Kgw==
@@ -24478,6 +24519,14 @@ lottie-web@^5.7.4:
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.4.tgz#3b252148e904a0aa9833879ffb64924c85a0888c"
   integrity sha512-LxqhXlHnHXOPmu+o2ipFKGv42jZLmn/GiEwXP0YC331fFwa+y96OUV22OF9r4i29uWKDciXiJr8tzy6jL8KygA==
 
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
 loud-rejection@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c"
@@ -24664,10 +24713,15 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^1.0.0:
+map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
 map-obj@^4.0.0:
   version "4.1.0"
@@ -25000,7 +25054,55 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0, meow@^5.0.0, meow@^6.0.0, meow@^8.0.0:
+meow@^3.3.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
+  dependencies:
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
+
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
+
+meow@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
+  integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "^4.0.2"
+    normalize-package-data "^2.5.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.13.1"
+    yargs-parser "^18.1.3"
+
+meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
   integrity sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==
@@ -25238,7 +25340,7 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@4.1.0:
+minimist-options@4.1.0, minimist-options@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
   integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
@@ -25247,7 +25349,15 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -26221,7 +26331,7 @@ normalize-node-version@^10.0.0:
     jest-validate "^25.3.0"
     semver "^7.3.2"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -29302,6 +29412,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -30291,6 +30406,22 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
+  dependencies:
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -33039,6 +33170,18 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
+  dependencies:
+    get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -34091,6 +34234,16 @@ trim-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.3.tgz#839514be82428fd9e7ec89e35081afe8f6f93115"
   integrity sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==
 
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -34295,6 +34448,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.16.0:
   version "0.16.0"
@@ -35848,7 +36006,7 @@ websocket-driver@^0.7.4:
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
-websocket-extensions@>=0.1.1, websocket-extensions@^0.1.4:
+websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
@@ -36536,6 +36694,13 @@ yargs-parser@20.2.4, yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
@@ -36552,7 +36717,7 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.2:
+yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
## Description

### Summary of changes
- [x] Export `useMultipleSelection` from downshift, renamed `useMultiSelectPrimitive` from the combobox primitive package
- [x] Export types for `useMultipleSelection` renamed appropriately
- [x] Add Examples to the combobox primitive docs page on how to use the new primitive.
- [x] Pull API docs from [README.md](https://github.com/downshift-js/downshift/blob/master/src/hooks/useMultipleSelection/README.md) (use `useComboboxPrimitive` as guide)
- [x] add some unit test coverage (protect against breaking changes)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
