### PR TITLE
feat(display-pill-group): add package

### DIFF
--- a/.changeset/brave-clouds-press.md
+++ b/.changeset/brave-clouds-press.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/display-pill-group': major
+'@twilio-paste/core': minor
+---
+
+[DisplayPillGroup]: Adding this new Paste component package for Display Pill Group.

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -25,6 +25,7 @@
     "/packages/paste-design-tokens",
     "/packages/paste-core/components/disclosure",
     "/packages/paste-core/primitives/disclosure",
+    "/packages/paste-core/components/display-pill-group",
     "/packages/paste-libraries/dropdown",
     "/packages/paste-core/layout/flex",
     "/packages/paste-core/layout/grid",

--- a/cypress/integration/e2e/link-checker/index.spec.ts
+++ b/cypress/integration/e2e/link-checker/index.spec.ts
@@ -15,6 +15,7 @@ const IGNORE_LIST = [
   // That will need to be refactored to pull from AirTable instead of packages.
   'primitives/sibling-box',
   'components/badge',
+  'components/display-pill-group',
   'patterns/data-export', // this randomly started failing and the page doesn't exist.
   '/__/', // I don't know where this is being picked up
 ];

--- a/packages/paste-core/components/display-pill-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/display-pill-group/__tests__/index.spec.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import {matchers} from 'jest-emotion';
+import {CustomizationProvider} from '@twilio-paste/customization';
+// @ts-ignore typescript doesn't like js imports
+import axe from '../../../../../.jest/axe-helper';
+import {DisplayPillGroup, DisplayPill} from '../src';
+import {Basic, CustomDisplayPillGroup} from '../stories/index.stories';
+
+expect.extend(matchers);
+
+describe('DisplayPillGroup', () => {
+  // Verifies that the correct aria attributes and semantics are met
+  describe('Rendered shape', () => {
+    it('should render correctly', () => {
+      const {getByTestId, getByText} = render(<Basic />);
+      expect(getByText('Tennis')).toBeDefined();
+
+      const group = getByTestId('display-pill-group');
+      expect(group.getAttribute('aria-label')).toBe('Your favorite sports:');
+      expect(group.tagName).toBe('UL');
+
+      const pillLink = getByTestId('display-pill-anchor');
+      expect(pillLink.getAttribute('href')).toBe('https://google.com');
+      expect(pillLink.getAttribute('rel')).toBe('noreferrer noopener');
+      expect(pillLink.getAttribute('target')).toBe('_blank');
+      expect(pillLink.tagName).toBe('A');
+
+      const pillStandard = getByTestId('display-pill-standard');
+      expect(pillStandard.tagName).toBe('DIV');
+    });
+  });
+
+  // Verifies the component is fully customizable
+  describe('Customization', () => {
+    it('should set an element data attribute for DisplayPillGroup & DisplayPill', () => {
+      const {getByTestId} = render(<Basic />);
+      const group = getByTestId('display-pill-group');
+      expect(group.getAttribute('data-paste-element')).toEqual('DISPLAY_PILL_GROUP');
+
+      const pillLink = getByTestId('display-pill-anchor');
+      expect(pillLink.getAttribute('data-paste-element')).toEqual('DISPLAY_PILL');
+
+      const pillStandard = getByTestId('display-pill-standard');
+      expect(pillStandard.getAttribute('data-paste-element')).toEqual('DISPLAY_PILL');
+    });
+
+    it('should set a custom element data attribute for DisplayPillGroup & DisplayPill', () => {
+      const {getByTestId} = render(
+        <DisplayPillGroup element="CUSTOM_GROUP" data-testid="group" aria-label="Your favorite sports:">
+          <DisplayPill element="CUSTOM_PILL" data-testid="pill">
+            A
+          </DisplayPill>
+        </DisplayPillGroup>
+      );
+      const group = getByTestId('group');
+      expect(group.getAttribute('data-paste-element')).toEqual('CUSTOM_GROUP');
+      const pill = getByTestId('pill');
+      expect(pill.getAttribute('data-paste-element')).toEqual('CUSTOM_PILL');
+    });
+
+    it('should add custom styles to DisplayPillGroup & DisplayPill', () => {
+      const {getByTestId} = render(<CustomDisplayPillGroup />);
+
+      const group = getByTestId('display-pill-group');
+      expect(group).toHaveStyleRule('margin', '0.75rem');
+
+      const pillLink = getByTestId('display-pill-anchor');
+      expect(pillLink).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+
+      const pillStandard = getByTestId('display-pill-standard');
+      expect(pillStandard).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+    });
+    it('should add custom styles to custom element DisplayPillGroup & DisplayPill', () => {
+      const {getByTestId} = render(
+        <CustomizationProvider
+          baseTheme="default"
+          theme={{
+            textColors: {colorTextLink: 'red'},
+            fonts: {fontFamilyText: 'arial'},
+          }}
+          elements={{
+            CUSTOM_PILL_GROUP: {
+              margin: 'space40',
+            },
+            CUSTOM_PILL: {
+              backgroundColor: 'colorBackgroundNew',
+              color: 'colorText',
+              padding: 'space40',
+            },
+          }}
+        >
+          <DisplayPillGroup
+            element="CUSTOM_PILL_GROUP"
+            data-testid="display-pill-group"
+            aria-label="Your favorite sports:"
+          >
+            <DisplayPill element="CUSTOM_PILL" data-testid="display-pill-anchor" href="https://google.com">
+              Tennis
+            </DisplayPill>
+            <DisplayPill element="CUSTOM_PILL" data-testid="display-pill-standard">
+              Football
+            </DisplayPill>
+          </DisplayPillGroup>
+        </CustomizationProvider>
+      );
+      const group = getByTestId('display-pill-group');
+      expect(group).toHaveStyleRule('margin', '0.75rem');
+
+      const pillLink = getByTestId('display-pill-anchor');
+      expect(pillLink).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+
+      const pillStandard = getByTestId('display-pill-standard');
+      expect(pillStandard).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+    });
+  });
+
+  // Validates the accessibility of the component
+  describe('Accessibility', () => {
+    it('Should have no accessibility violations', async () => {
+      const {container} = render(<Basic />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/paste-core/components/display-pill-group/build.js
+++ b/packages/paste-core/components/display-pill-group/build.js
@@ -1,0 +1,3 @@
+const {build} = require('../../../../tools/build/esbuild');
+
+build(require('./package.json'));

--- a/packages/paste-core/components/display-pill-group/package.json
+++ b/packages/paste-core/components/display-pill-group/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@twilio-paste/display-pill-group",
+  "version": "0.0.0",
+  "category": "data display",
+  "status": "production",
+  "description": "A Display Pill Group is a collection of Pills that are used to visually represent a collection of entities outside of a data entry form.",
+  "author": "Twilio Inc.",
+  "license": "MIT",
+  "main:dev": "src/index.tsx",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean && NODE_ENV=production node build.js && tsc",
+    "build:js": "NODE_ENV=development node build.js",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
+    "clean": "rm -rf ./dist",
+    "tsc": "tsc"
+  },
+  "peerDependencies": {
+    "@twilio-paste/anchor": "^5.1.0",
+    "@twilio-paste/animation-library": "^0.3.2",
+    "@twilio-paste/box": "^4.2.0",
+    "@twilio-paste/customization": "^2.1.1",
+    "@twilio-paste/design-tokens": "^6.10.0",
+    "@twilio-paste/icons": "^5.1.1",
+    "@twilio-paste/style-props": "^3.1.0",
+    "@twilio-paste/styling-library": "^0.3.4",
+    "@twilio-paste/theme": "^5.3.0",
+    "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
+  "devDependencies": {
+    "@twilio-paste/anchor": "^5.1.0",
+    "@twilio-paste/animation-library": "^0.3.2",
+    "@twilio-paste/box": "^4.2.0",
+    "@twilio-paste/customization": "^2.1.1",
+    "@twilio-paste/design-tokens": "^6.10.0",
+    "@twilio-paste/icons": "^5.1.1",
+    "@twilio-paste/style-props": "^3.1.0",
+    "@twilio-paste/styling-library": "^0.3.4",
+    "@twilio-paste/theme": "^5.3.0",
+    "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/paste-core/components/display-pill-group/src/DisplayPill.tsx
+++ b/packages/paste-core/components/display-pill-group/src/DisplayPill.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BoxElementProps} from '@twilio-paste/box';
+import {secureExternalLink} from '@twilio-paste/anchor';
+
+export interface DisplayPillProps extends BoxElementProps {
+  href?: string;
+  element?: string;
+  children: React.ReactNode;
+}
+
+export const DisplayPill = React.forwardRef<HTMLElement, DisplayPillProps>(
+  ({element = 'DISPLAY_PILL', ...props}, ref) => {
+    return (
+      <Box as="li" listStyleType="none">
+        <Box
+          {...safelySpreadBoxProps(props)}
+          {...(props.href ? secureExternalLink(props.href) : {})}
+          ref={ref}
+          element={element}
+          as={props.href ? 'a' : 'div'}
+          cursor={props.href ? 'pointer' : 'default'}
+          color={props.href ? 'colorTextLink' : 'colorText'}
+          backgroundColor="colorBackground"
+          borderWidth="borderWidth10"
+          borderColor="colorBorderWeak"
+          borderStyle="solid"
+          borderRadius="borderRadius20"
+          paddingX="space30"
+          paddingY="space20"
+          height="30px"
+          display="flex"
+          columnGap="space20"
+          alignItems="center"
+        >
+          {props.children}
+        </Box>
+      </Box>
+    );
+  }
+);

--- a/packages/paste-core/components/display-pill-group/src/DisplayPillGroup.tsx
+++ b/packages/paste-core/components/display-pill-group/src/DisplayPillGroup.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+
+export interface DisplayPillGroupProps {
+  'aria-label': string;
+  element?: string;
+  children: React.ReactNode;
+}
+
+export const DisplayPillGroup = React.forwardRef<HTMLUListElement, DisplayPillGroupProps>(
+  ({element = 'DISPLAY_PILL_GROUP', ...props}, ref) => {
+    return (
+      <Box
+        {...safelySpreadBoxProps(props)}
+        element={element}
+        ref={ref}
+        as="ul"
+        margin="space0"
+        padding="space0"
+        display="flex"
+        columnGap="space30"
+      >
+        {props.children}
+      </Box>
+    );
+  }
+);

--- a/packages/paste-core/components/display-pill-group/src/index.tsx
+++ b/packages/paste-core/components/display-pill-group/src/index.tsx
@@ -1,0 +1,2 @@
+export * from './DisplayPill';
+export * from './DisplayPillGroup';

--- a/packages/paste-core/components/display-pill-group/stories/index.stories.tsx
+++ b/packages/paste-core/components/display-pill-group/stories/index.stories.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import {CustomizationProvider} from '@twilio-paste/customization';
+import {CalendarIcon} from '@twilio-paste/icons/esm/CalendarIcon';
+import {DisplayPillGroup} from '../src/DisplayPillGroup';
+import {DisplayPill} from '../src/DisplayPill';
+
+export const Basic: React.FC = () => {
+  return (
+    <DisplayPillGroup data-testid="display-pill-group" aria-label="Your favorite sports:">
+      <DisplayPill
+        data-testid="display-pill-anchor"
+        onFocus={() => {
+          console.log('Focused Tennis!');
+        }}
+        onBlur={() => {
+          console.log('Blurred Tennis!');
+        }}
+        href="https://google.com"
+      >
+        <CalendarIcon decorative size="sizeIcon10" />
+        Tennis
+      </DisplayPill>
+      <DisplayPill data-testid="display-pill-standard">Football</DisplayPill>
+      <DisplayPill href="/">Baseball</DisplayPill>
+      <DisplayPill>Basketball</DisplayPill>
+      <DisplayPill>Soccer</DisplayPill>
+    </DisplayPillGroup>
+  );
+};
+
+export const CustomDisplayPillGroup: React.FC = () => {
+  return (
+    <CustomizationProvider
+      baseTheme="default"
+      theme={{
+        textColors: {colorTextLink: 'red'},
+        fonts: {fontFamilyText: 'arial'},
+      }}
+      elements={{
+        DISPLAY_PILL_GROUP: {
+          margin: 'space40',
+        },
+        DISPLAY_PILL: {
+          backgroundColor: 'colorBackgroundNew',
+          color: 'colorText',
+          padding: 'space40',
+        },
+      }}
+    >
+      <DisplayPillGroup data-testid="display-pill-group" aria-label="Your favorite sports:">
+        <DisplayPill
+          data-testid="display-pill-anchor"
+          onFocus={() => {
+            console.log('Focused Tennis!');
+          }}
+          onBlur={() => {
+            console.log('Blurred Tennis!');
+          }}
+          href="https://google.com"
+        >
+          <CalendarIcon decorative size="sizeIcon10" />
+          Tennis
+        </DisplayPill>
+        <DisplayPill data-testid="display-pill-standard">Football</DisplayPill>
+        <DisplayPill href="/">Baseball</DisplayPill>
+        <DisplayPill>Basketball</DisplayPill>
+        <DisplayPill>Soccer</DisplayPill>
+      </DisplayPillGroup>
+    </CustomizationProvider>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Components/Display Pill Group',
+  component: Basic,
+};

--- a/packages/paste-core/components/display-pill-group/tsconfig.json
+++ b/packages/paste-core/components/display-pill-group/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/paste-core/core-bundle/.gitignore
+++ b/packages/paste-core/core-bundle/.gitignore
@@ -21,6 +21,7 @@
 /design-tokens
 /disclosure
 /disclosure-primitive
+/display-pill-group
 /dropdown-library
 /flex
 /grid

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -45,6 +45,7 @@
     "@twilio-paste/design-tokens": "^6.11.0",
     "@twilio-paste/disclosure": "^5.0.6",
     "@twilio-paste/disclosure-primitive": "^0.3.4",
+    "@twilio-paste/display-pill-group": "^0.0.0",
     "@twilio-paste/dropdown-library": "^1.1.1",
     "@twilio-paste/flex": "^2.1.0",
     "@twilio-paste/grid": "^2.1.0",

--- a/packages/paste-core/core-bundle/src/display-pill-group.tsx
+++ b/packages/paste-core/core-bundle/src/display-pill-group.tsx
@@ -1,0 +1,1 @@
+export * from '@twilio-paste/display-pill-group';

--- a/packages/paste-core/core-bundle/src/index.tsx
+++ b/packages/paste-core/core-bundle/src/index.tsx
@@ -15,6 +15,7 @@ export * from '@twilio-paste/combobox-primitive';
 export * from '@twilio-paste/date-picker';
 export * from '@twilio-paste/disclosure';
 export * from '@twilio-paste/disclosure-primitive';
+export * from '@twilio-paste/display-pill-group';
 export * from '@twilio-paste/flex';
 export * from '@twilio-paste/grid';
 export * from '@twilio-paste/heading';


### PR DESCRIPTION
Adds a new Paste component called "DisplayPillGroup". This is the pill group component intended to be used outside of forms, for visual purposes.  Another PR will be coming soon with the "FormPillGroup" component package. 

**Why did we split these up?**
- To keep the API clear and composable; it's more obvious to use the FormPillGroup variant when within forms, than if we had named it something else.
- To reduce the bundle size when not using pills in forms.
- For accessibility; each component has different keyboard controls and semantics for screenreaders

