### PR TITLE
feat(form-pill-group): add package

### DIFF
--- a/.changeset/orange-brooms-applaud.md
+++ b/.changeset/orange-brooms-applaud.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/form-pill-group': major
+'@twilio-paste/core': minor
+---
+
+[Form Pill Group] Adding the FormPillGroup component package. This component renders is a collection of Pills that can be selected or removed from within a data entry form.

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -28,6 +28,7 @@
     "/packages/paste-core/components/display-pill-group",
     "/packages/paste-libraries/dropdown",
     "/packages/paste-core/layout/flex",
+    "/packages/paste-core/components/form-pill-group",
     "/packages/paste-core/layout/grid",
     "/packages/paste-core/components/heading",
     "/packages/paste-core/components/help-text",

--- a/cypress/integration/e2e/link-checker/index.spec.ts
+++ b/cypress/integration/e2e/link-checker/index.spec.ts
@@ -16,6 +16,7 @@ const IGNORE_LIST = [
   'primitives/sibling-box',
   'components/badge',
   'components/display-pill-group',
+  'components/form-pill-group',
   'patterns/data-export', // this randomly started failing and the page doesn't exist.
   '/__/', // I don't know where this is being picked up
 ];

--- a/packages/paste-core/components/form-pill-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/form-pill-group/__tests__/index.spec.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import {matchers} from 'jest-emotion';
+import {CustomizationProvider} from '@twilio-paste/customization';
+// @ts-ignore typescript doesn't like js imports
+import axe from '../../../../../.jest/axe-helper';
+import {useFormPillState, FormPillGroup, FormPill} from '../src';
+import {Basic, SelectAndRemove, CustomFormPillGroup} from '../stories/index.stories';
+
+expect.extend(matchers);
+
+const CustomElementFormPillGroup: React.FC = () => {
+  const pillState = useFormPillState();
+
+  return (
+    <form>
+      <FormPillGroup
+        {...pillState}
+        element="CUSTOM_PILL_GROUP"
+        data-testid="form-pill-group"
+        aria-label="Your favorite sports:"
+      >
+        <FormPill {...pillState} element="CUSTOM_PILL" data-testid="form-pill">
+          Tennis
+        </FormPill>
+      </FormPillGroup>
+    </form>
+  );
+};
+
+describe('FormPillGroup', () => {
+  describe('Rendered shape', () => {
+    it('has the correct aria attributes and semantic HTML', () => {
+      const {getByTestId, getByText} = render(<Basic />);
+      expect(getByText('Tennis')).toBeDefined();
+
+      const group = getByTestId('form-pill-group');
+      expect(group.getAttribute('aria-label')).toBe('Your favorite sports:');
+      expect(group.tagName).toBe('DIV');
+      expect(group.getAttribute('role')).toBe('listbox');
+
+      const pill = getByTestId('form-pill');
+      expect(pill.tagName).toBe('BUTTON');
+      expect(pill.getAttribute('role')).toBe('option');
+      expect(pill.getAttribute('aria-selected')).toBe('false');
+
+      const pillSelected = getByTestId('form-pill-selected');
+      expect(pillSelected.getAttribute('aria-selected')).toBe('true');
+    });
+  });
+
+  describe('Selecting and Removing', () => {
+    it('can select and navigate pills', () => {
+      const {getByTestId} = render(<SelectAndRemove />);
+
+      // Get the first pill
+      const firstPill = getByTestId('form-pill-0');
+      // Click it and make sure it selected
+      fireEvent.click(firstPill);
+      expect(firstPill.getAttribute('aria-selected')).toBe('true');
+
+      // Make sure it deselects on click
+      fireEvent.click(firstPill);
+      expect(firstPill.getAttribute('aria-selected')).toBe('false');
+
+      // Make sure it selects on Enter key
+      fireEvent.keyDown(firstPill, {key: 'Enter', code: 'Enter'});
+      expect(firstPill.getAttribute('aria-selected')).toBe('true');
+
+      // Make sure we can navigate with right arrow
+      fireEvent.keyDown(firstPill, {key: 'ArrowRight', code: 'ArrowRight'});
+      if (document.activeElement == null) {
+        throw new Error('document.activeElement is null');
+      }
+      expect(document.activeElement.getAttribute('data-testid')).toBe('form-pill-1');
+      expect(document.activeElement.getAttribute('aria-selected')).toBe('false');
+
+      // Move right again and check for selection
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowRight', code: 'ArrowRight'});
+      expect(document.activeElement.getAttribute('data-testid')).toBe('form-pill-2');
+      fireEvent.keyDown(document.activeElement, {key: 'Enter', code: 'Enter'});
+      expect(document.activeElement.getAttribute('aria-selected')).toBe('true');
+
+      // Try moving left this time
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', code: 'ArrowLeft'});
+      expect(document.activeElement.getAttribute('data-testid')).toBe('form-pill-1');
+
+      // Loop movement
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', code: 'ArrowLeft'});
+      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', code: 'ArrowLeft'});
+      expect(document.activeElement.getAttribute('data-testid')).toBe('form-pill-3');
+    });
+
+    it('can remove pills', () => {
+      const {getByTestId, getAllByText} = render(<SelectAndRemove />);
+
+      /* Test click to remove */
+      const xButtonScreenReaderElement = getAllByText('. Press delete or backspace to remove');
+      // Because this example has several pills with X button
+      const firstXButtonScreenReaderElement = xButtonScreenReaderElement[0];
+      const firstPillXButton = firstXButtonScreenReaderElement.parentNode;
+      if (firstPillXButton == null) {
+        throw new Error('firstPillXButton is null');
+      }
+
+      fireEvent.click(firstPillXButton);
+      expect(firstPillXButton).not.toBeInTheDocument();
+
+      // We get `pill-0` index because after removal, the first pill is gone and the second becomes 0
+      const secondPill = getByTestId('form-pill-0');
+      fireEvent.keyDown(secondPill, {key: 'Delete', code: 'Delete'});
+      expect(secondPill).not.toBeInTheDocument();
+
+      // We get `pill-0` index because after removal, the second pill is gone and the third becomes 0
+      const thirdPill = getByTestId('form-pill-0');
+      fireEvent.keyDown(thirdPill, {key: 'Backspace', code: 'Backspace'});
+      expect(thirdPill).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Customization', () => {
+    it('should set an element data attribute for FormPillGroup & FormPill', () => {
+      const {getByTestId} = render(<Basic />);
+      const group = getByTestId('form-pill-group');
+      expect(group.getAttribute('data-paste-element')).toEqual('FORM_PILL_GROUP');
+
+      const pill = getByTestId('form-pill');
+      expect(pill.getAttribute('data-paste-element')).toEqual('FORM_PILL');
+    });
+
+    it('should set a custom element data attribute for FormPillGroup & FormPill', () => {
+      const {getByTestId} = render(<CustomElementFormPillGroup />);
+      const group = getByTestId('form-pill-group');
+      expect(group.getAttribute('data-paste-element')).toEqual('CUSTOM_PILL_GROUP');
+      const pill = getByTestId('form-pill');
+      expect(pill.getAttribute('data-paste-element')).toEqual('CUSTOM_PILL');
+    });
+
+    it('should add custom styles to FormPillGroup & FormPill', () => {
+      const {getByTestId} = render(<CustomFormPillGroup />);
+
+      const group = getByTestId('form-pill-group');
+      expect(group).toHaveStyleRule('margin', '0.75rem');
+
+      const pill = getByTestId('form-pill');
+      expect(pill).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+    });
+    it('should add custom styles to custom element FormPillGroup & FormPill', () => {
+      const {getByTestId} = render(
+        <CustomizationProvider
+          baseTheme="default"
+          theme={{
+            textColors: {colorTextLink: 'red'},
+            fonts: {fontFamilyText: 'arial'},
+          }}
+          elements={{
+            CUSTOM_PILL_GROUP: {
+              margin: 'space40',
+            },
+            CUSTOM_PILL: {
+              backgroundColor: 'colorBackgroundNew',
+              color: 'colorText',
+              padding: 'space40',
+            },
+          }}
+        >
+          <CustomElementFormPillGroup />
+        </CustomizationProvider>
+      );
+      const group = getByTestId('form-pill-group');
+      expect(group).toHaveStyleRule('margin', '0.75rem');
+
+      const pill = getByTestId('form-pill');
+      expect(pill).toHaveStyleRule('background-color', 'rgb(231,220,250)');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should have no accessibility violations #1', async () => {
+      const {container} = render(<Basic />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('Should have no accessibility violations #2', async () => {
+      const {container} = render(<SelectAndRemove />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/paste-core/components/form-pill-group/build.js
+++ b/packages/paste-core/components/form-pill-group/build.js
@@ -1,0 +1,3 @@
+const {build} = require('../../../../tools/build/esbuild');
+
+build(require('./package.json'));

--- a/packages/paste-core/components/form-pill-group/package.json
+++ b/packages/paste-core/components/form-pill-group/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@twilio-paste/form-pill-group",
+  "version": "0.0.0",
+  "category": "interaction",
+  "status": "production",
+  "description": "A Display Pill Group is a collection of Pills that can be selected or removed from within a data entry form.",
+  "author": "Twilio Inc.",
+  "license": "MIT",
+  "main:dev": "src/index.tsx",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean && NODE_ENV=production node build.js && tsc",
+    "build:js": "NODE_ENV=development node build.js",
+    "build:props": "typedoc --tsconfig ./tsconfig.json --json ./dist/prop-types.json",
+    "clean": "rm -rf ./dist",
+    "tsc": "tsc"
+  },
+  "peerDependencies": {
+    "@twilio-paste/animation-library": "^0.3.2",
+    "@twilio-paste/box": "^4.2.0",
+    "@twilio-paste/customization": "^2.1.1",
+    "@twilio-paste/design-tokens": "^6.10.0",
+    "@twilio-paste/icons": "^5.1.1",
+    "@twilio-paste/reakit-library": "^0.8.1",
+    "@twilio-paste/screen-reader-only": "^6.0.2",
+    "@twilio-paste/style-props": "^3.1.0",
+    "@twilio-paste/styling-library": "^0.3.4",
+    "@twilio-paste/theme": "^5.3.0",
+    "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
+  "devDependencies": {
+    "@twilio-paste/animation-library": "^0.3.2",
+    "@twilio-paste/box": "^4.2.0",
+    "@twilio-paste/customization": "^2.1.1",
+    "@twilio-paste/design-tokens": "^6.10.0",
+    "@twilio-paste/icons": "^5.1.1",
+    "@twilio-paste/reakit-library": "^0.8.1",
+    "@twilio-paste/screen-reader-only": "^6.0.2",
+    "@twilio-paste/style-props": "^3.1.0",
+    "@twilio-paste/styling-library": "^0.3.4",
+    "@twilio-paste/theme": "^5.3.0",
+    "@twilio-paste/types": "^3.1.1",
+    "@twilio-paste/uid-library": "^0.2.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/paste-core/components/form-pill-group/src/FormPill.tsx
+++ b/packages/paste-core/components/form-pill-group/src/FormPill.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import {CompositeItem} from '@twilio-paste/reakit-library';
+import type {CompositeStateReturn} from '@twilio-paste/reakit-library';
+import {PillCloseIcon} from './PillCloseIcon';
+
+interface FormPillStylesProps {
+  selected?: boolean;
+  element?: string;
+  children: React.ReactNode;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+  onClick?: () => void;
+}
+
+const FormPillStyles = React.forwardRef<HTMLElement, FormPillStylesProps>(
+  ({element = 'FORM_PILL', selected = false, ...props}, ref) => (
+    <Box
+      {...safelySpreadBoxProps(props)}
+      ref={ref}
+      element={element}
+      as="button"
+      type="button"
+      role="option"
+      cursor="pointer"
+      aria-selected={selected}
+      backgroundColor={selected ? 'colorBackgroundPrimaryWeakest' : 'colorBackground'}
+      borderWidth="borderWidth10"
+      borderColor="colorBorderWeak"
+      borderStyle="solid"
+      borderRadius="borderRadius20"
+      paddingX="space30"
+      paddingY="space20"
+      height="30px"
+      display="flex"
+      columnGap="space20"
+      alignItems="center"
+      _hover={{
+        boxShadow: 'shadowBorderPrimaryStronger',
+      }}
+      _focus={{
+        boxShadow: 'shadowBorderPrimaryStronger',
+      }}
+    >
+      {props.children}
+    </Box>
+  )
+);
+
+export interface FormPillProps extends CompositeStateReturn {
+  selected?: boolean;
+  element?: string;
+  children: React.ReactNode;
+  onSelect?: () => void;
+  onDismiss?: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
+}
+
+export const FormPill = React.forwardRef<HTMLElement, FormPillProps>(({onDismiss, onSelect, next, ...props}, ref) => {
+  // Handles delete and backspace keypresses
+  const handleKeydown = React.useCallback(
+    (event) => {
+      if ((event.key === 'Backspace' || event.key === 'Delete') && typeof onDismiss === 'function') {
+        onDismiss();
+
+        // Focus the next pill upon removing the current one
+        if (typeof next === 'function') {
+          next();
+        }
+      }
+    },
+    [onDismiss, next]
+  );
+
+  return (
+    <CompositeItem as={FormPillStyles} {...props} ref={ref} onKeyDown={handleKeydown} onClick={onSelect} next={next}>
+      {props.children}
+      {onDismiss != null ? <PillCloseIcon onClick={onDismiss} /> : null}
+    </CompositeItem>
+  );
+});

--- a/packages/paste-core/components/form-pill-group/src/FormPillGroup.tsx
+++ b/packages/paste-core/components/form-pill-group/src/FormPillGroup.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import {Composite} from '@twilio-paste/reakit-library';
+import type {CompositeProps} from '@twilio-paste/reakit-library';
+
+export interface FormPillGroupProps extends CompositeProps {
+  'aria-label': string;
+  element?: string;
+  children: React.ReactNode;
+}
+
+const FormPillGroupStyles = React.forwardRef<HTMLUListElement, FormPillGroupProps>(
+  ({element = 'FORM_PILL_GROUP', ...props}, ref) => (
+    <Box
+      {...safelySpreadBoxProps(props)}
+      element={element}
+      ref={ref}
+      role="listbox"
+      margin="space0"
+      padding="space0"
+      display="flex"
+      columnGap="space30"
+    >
+      {props.children}
+    </Box>
+  )
+);
+
+export const FormPillGroup = React.forwardRef<HTMLUListElement, FormPillGroupProps>((props, ref) => {
+  return (
+    <Composite as={FormPillGroupStyles} {...props} ref={ref}>
+      {props.children}
+    </Composite>
+  );
+});

--- a/packages/paste-core/components/form-pill-group/src/PillCloseIcon.tsx
+++ b/packages/paste-core/components/form-pill-group/src/PillCloseIcon.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
+
+interface PillCloseIconProps {
+  onClick: () => void;
+}
+
+export const PillCloseIcon: React.FC<PillCloseIconProps> = ({onClick}) => {
+  return (
+    <Box
+      onClick={onClick}
+      _hover={{
+        color: 'colorTextLinkDark',
+      }}
+    >
+      <ScreenReaderOnly>. Press delete or backspace to remove</ScreenReaderOnly>
+      <CloseIcon decorative size="sizeIcon10" />
+    </Box>
+  );
+};

--- a/packages/paste-core/components/form-pill-group/src/index.tsx
+++ b/packages/paste-core/components/form-pill-group/src/index.tsx
@@ -1,0 +1,3 @@
+export * from './FormPill';
+export * from './FormPillGroup';
+export * from './useFormPillState';

--- a/packages/paste-core/components/form-pill-group/src/useFormPillState.tsx
+++ b/packages/paste-core/components/form-pill-group/src/useFormPillState.tsx
@@ -1,0 +1,17 @@
+import {useCompositeState} from '@twilio-paste/reakit-library';
+import type {
+  CompositeInitialState as FormPillInitialState,
+  CompositeStateReturn as FormPillStateReturn,
+} from '@twilio-paste/reakit-library';
+
+export type {FormPillInitialState, FormPillStateReturn};
+
+export const useFormPillState = (config: FormPillInitialState = {}): FormPillStateReturn => {
+  return {
+    ...useCompositeState({
+      ...config,
+      orientation: 'horizontal', // <- -> arrow keys
+      loop: true, // loops when reaches end of pill list
+    }),
+  };
+};

--- a/packages/paste-core/components/form-pill-group/stories/index.stories.tsx
+++ b/packages/paste-core/components/form-pill-group/stories/index.stories.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import {Text} from '@twilio-paste/text';
+import {CustomizationProvider} from '@twilio-paste/customization';
+import {CalendarIcon} from '@twilio-paste/icons/esm/CalendarIcon';
+import {useFormPillState, FormPillGroup, FormPill} from '../src';
+
+export const Basic: React.FC = () => {
+  const pillState = useFormPillState();
+
+  return (
+    <form>
+      <FormPillGroup {...pillState} data-testid="form-pill-group" aria-label="Your favorite sports:">
+        <FormPill data-testid="form-pill" {...pillState}>
+          <CalendarIcon decorative size="sizeIcon10" />
+          Tennis
+        </FormPill>
+        <FormPill {...pillState} selected data-testid="form-pill-selected">
+          Baseball
+        </FormPill>
+        <FormPill {...pillState}>Football</FormPill>
+        <FormPill {...pillState} selected>
+          Soccer
+        </FormPill>
+      </FormPillGroup>
+    </form>
+  );
+};
+
+type Pills = string[];
+
+export const SelectAndRemove: React.FC = () => {
+  const [pills, setPills] = React.useState<Pills>(['Tennis', 'Baseball', 'Football', 'Soccer']);
+  const [selectedSet, updateSelectedSet] = React.useState<Set<string>>(new Set('Football'));
+  const pillState = useFormPillState();
+
+  return (
+    <form>
+      <FormPillGroup {...pillState} data-testid="form-pill-group" aria-label="Your favorite sports:">
+        {pills.map((pill, index) => (
+          <FormPill
+            key={pill}
+            data-testid={`form-pill-${index}`}
+            {...pillState}
+            selected={selectedSet.has(pill)}
+            onDismiss={() => {
+              setPills(pills.filter((_, i) => i !== index));
+            }}
+            onSelect={() => {
+              const newSelectedSet = new Set(selectedSet);
+              if (newSelectedSet.has(pill)) {
+                newSelectedSet.delete(pill);
+              } else {
+                newSelectedSet.add(pill);
+              }
+              updateSelectedSet(newSelectedSet);
+            }}
+          >
+            {pill}
+          </FormPill>
+        ))}
+        {pills.length === 0 ? <Text as="p">No sports remaining</Text> : null}
+      </FormPillGroup>
+    </form>
+  );
+};
+
+export const CustomFormPillGroup: React.FC = () => {
+  const pillState = useFormPillState();
+
+  return (
+    <CustomizationProvider
+      baseTheme="default"
+      theme={{
+        textColors: {colorTextLink: 'red'},
+        fonts: {fontFamilyText: 'arial'},
+      }}
+      elements={{
+        FORM_PILL_GROUP: {
+          margin: 'space40',
+        },
+        FORM_PILL: {
+          backgroundColor: 'colorBackgroundNew',
+          color: 'colorText',
+          padding: 'space40',
+        },
+      }}
+    >
+      <form>
+        <FormPillGroup {...pillState} data-testid="form-pill-group" aria-label="Your favorite sports:">
+          <FormPill
+            data-testid="form-pill"
+            {...pillState}
+            onDismiss={() => {
+              console.log('removed the first pill');
+            }}
+            onSelect={() => {}}
+            onFocus={() => {}}
+            onBlur={() => {}}
+          >
+            <CalendarIcon decorative size="sizeIcon10" />
+            Tennis
+          </FormPill>
+          <FormPill {...pillState} onSelect={() => {}}>
+            Baseball
+          </FormPill>
+          <FormPill {...pillState} onSelect={() => {}}>
+            Football
+          </FormPill>
+          <FormPill {...pillState} onSelect={() => {}}>
+            Soccer
+          </FormPill>
+        </FormPillGroup>
+      </form>
+    </CustomizationProvider>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Components/Form Pill Group',
+  component: Basic,
+};

--- a/packages/paste-core/components/form-pill-group/tsconfig.json
+++ b/packages/paste-core/components/form-pill-group/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/paste-core/core-bundle/.gitignore
+++ b/packages/paste-core/core-bundle/.gitignore
@@ -24,6 +24,7 @@
 /display-pill-group
 /dropdown-library
 /flex
+/form-pill-group
 /grid
 /heading
 /help-text

--- a/packages/paste-core/core-bundle/package.json
+++ b/packages/paste-core/core-bundle/package.json
@@ -48,6 +48,7 @@
     "@twilio-paste/display-pill-group": "^0.0.0",
     "@twilio-paste/dropdown-library": "^1.1.1",
     "@twilio-paste/flex": "^2.1.0",
+    "@twilio-paste/form-pill-group": "^0.0.0",
     "@twilio-paste/grid": "^2.1.0",
     "@twilio-paste/heading": "^5.1.0",
     "@twilio-paste/help-text": "^6.0.3",

--- a/packages/paste-core/core-bundle/src/form-pill-group.tsx
+++ b/packages/paste-core/core-bundle/src/form-pill-group.tsx
@@ -1,0 +1,1 @@
+export * from '@twilio-paste/form-pill-group';

--- a/packages/paste-core/core-bundle/src/index.tsx
+++ b/packages/paste-core/core-bundle/src/index.tsx
@@ -17,6 +17,7 @@ export * from '@twilio-paste/disclosure';
 export * from '@twilio-paste/disclosure-primitive';
 export * from '@twilio-paste/display-pill-group';
 export * from '@twilio-paste/flex';
+export * from '@twilio-paste/form-pill-group';
 export * from '@twilio-paste/grid';
 export * from '@twilio-paste/heading';
 export * from '@twilio-paste/help-text';


### PR DESCRIPTION
The second pill group package ([see the first package PR here](https://github.com/twilio-labs/paste/pull/1800)).

The FormPillGroup is intended to be used within form elements.

**Why did we split these up?**

- To keep the API clear and composable; it's more obvious to use the FormPillGroup variant when within forms, than if we had named it something else.
- To reduce the bundle size when not using pills in forms.
- For accessibility; each component has different keyboard controls and semantics for screenreaders