### PR TITLE
fix: default prop types for element name in combobox, select and textarea

### DIFF
--- a/.changeset/many-dryers-punch.md
+++ b/.changeset/many-dryers-punch.md
@@ -1,0 +1,8 @@
+---
+'@twilio-paste/combobox': patch
+'@twilio-paste/select': patch
+'@twilio-paste/textarea': patch
+'@twilio-paste/core': patch
+---
+
+[Combobox], [Select] and [Textarea] all given a default element name to meet their PropTypes validation.

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -37,7 +37,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
     {
       autocomplete,
       disabled,
-      element,
+      element = 'COMBOBOX',
       hasError,
       helpText,
       initialSelectedItem,

--- a/packages/paste-core/components/select/src/Select.tsx
+++ b/packages/paste-core/components/select/src/Select.tsx
@@ -57,7 +57,10 @@ export const SelectElement = React.forwardRef<HTMLSelectElement, SelectProps>(({
 });
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  ({disabled, element, hasError, insertBefore, insertAfter, children, size, multiple, variant, ...props}, ref) => {
+  (
+    {disabled, element = 'SELECT', hasError, insertBefore, insertAfter, children, size, multiple, variant, ...props},
+    ref
+  ) => {
     let iconColor = 'colorTextIcon' as TextColor;
     if (disabled) {
       iconColor = 'colorTextWeaker';

--- a/packages/paste-core/components/textarea/src/TextArea.tsx
+++ b/packages/paste-core/components/textarea/src/TextArea.tsx
@@ -74,7 +74,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     {
       children,
       disabled,
-      element,
+      element = 'TEXTAREA',
       hasError,
       id,
       insertBefore,


### PR DESCRIPTION
- fix(combobox): must have a default element name
- fix(select): must have a default element name
- fix(textarea): must have a default element name
- chore: combobox, select and textarea changeset
