### PR TITLE
feat(tabs): add element customization

### DIFF
--- a/.changeset/cool-cats-fly.md
+++ b/.changeset/cool-cats-fly.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/tabs': minor
+'@twilio-paste/core': minor
+---
+
+[Tabs]: Enable Component to respect element customizations set on the customization provider. Component now enables setting an element name on the underlying HTML element and checks the emotion theme object to determine whether it should merge in custom styles to the ones set by the component author.

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -7,10 +7,33 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import axe from '../../../../../.jest/axe-helper';
 import {HorizontalTabs, StateHookTabs} from '../stories/index.stories';
 import {Tabs, Tab, TabList, TabPanels, TabPanel} from '../src';
+import {getElementName} from '../src/utils';
 
 expect.extend(matchers);
 
 describe('Tabs', () => {
+  describe('Utils', () => {
+    describe('getElementName', () => {
+      const mockFallbackName = 'TEST_ELEMENT_FALLBACK';
+
+      it('should return the correct string when element is undefined', () => {
+        expect(getElementName('horizontal', mockFallbackName)).toEqual('HORIZONTAL_TEST_ELEMENT_FALLBACK');
+        expect(getElementName('vertical', mockFallbackName)).toEqual('VERTICAL_TEST_ELEMENT_FALLBACK');
+      });
+      it('should return the correct string when element is null', () => {
+        expect(getElementName('horizontal', mockFallbackName, null)).toEqual('HORIZONTAL_TEST_ELEMENT_FALLBACK');
+        expect(getElementName('vertical', mockFallbackName, null)).toEqual('VERTICAL_TEST_ELEMENT_FALLBACK');
+      });
+      it('should return the correct string when element is defined', () => {
+        expect(getElementName('horizontal', mockFallbackName, 'CUSTOM_NAME')).toEqual('CUSTOM_NAME');
+        expect(getElementName('vertical', mockFallbackName, 'CUSTOM_NAME')).toEqual('CUSTOM_NAME');
+      });
+      it('should return the correct string when element is an empty string', () => {
+        expect(getElementName('horizontal', mockFallbackName, '')).toEqual('');
+        expect(getElementName('vertical', mockFallbackName, '')).toEqual('');
+      });
+    });
+  });
   describe('Render', () => {
     it('relevant html and aria attributes', () => {
       const [tabOneId, tabTwoId, tabThreeId, panelOneId, panelTwoId, panelThreeId] = [...new Array(6)].map(

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
+import {matchers} from 'jest-emotion';
 import {render, screen} from '@testing-library/react';
+import {CustomizationProvider} from '@twilio-paste/customization';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {HorizontalTabs, StateHookTabs} from '../stories/index.stories';
 import {Tabs, Tab, TabList, TabPanels, TabPanel} from '../src';
+
+expect.extend(matchers);
 
 describe('Tabs', () => {
   describe('Render', () => {
@@ -89,6 +94,317 @@ describe('Tabs', () => {
       expect(activePanel.getAttribute('aria-labelledby')).toBe('state-hook-tab-example-2');
       expect(activePanel.getAttribute('id')).toBe('state-hook-tab-example-4');
       expect(activePanel.getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('HTML Attribute', () => {
+    it('should set an element data attribute for Horizontal Tabs (default)', () => {
+      render(
+        <Tabs orientation="horizontal" baseId="">
+          <TabList data-testid="tab-list" aria-label="My tabs">
+            <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
+            <Tab data-testid="tab-2">Tab 2</Tab>
+            <Tab data-testid="tab-3">Tab 3</Tab>
+          </TabList>
+          <TabPanels data-testid="tab-panels">
+            <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
+            <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
+            <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
+          </TabPanels>
+        </Tabs>
+      );
+
+      const outerDiv = screen.getByTestId('tab-list').parentElement;
+
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORIZONTAL_TABS');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_LIST');
+      expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
+        'HORIZONTAL_TAB_LIST_CHILD'
+      );
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_PANELS');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_PANEL');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_PANEL');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_PANEL');
+    });
+
+    it('should set an element data attribute for Vertical Tabs (default)', () => {
+      render(
+        <Tabs orientation="vertical" baseId="">
+          <TabList data-testid="tab-list" aria-label="My tabs">
+            <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
+            <Tab data-testid="tab-2">Tab 2</Tab>
+            <Tab data-testid="tab-3">Tab 3</Tab>
+          </TabList>
+          <TabPanels data-testid="tab-panels">
+            <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
+            <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
+            <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
+          </TabPanels>
+        </Tabs>
+      );
+
+      const outerDiv = screen.getByTestId('tab-list').parentElement;
+
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('VERTICAL_TABS');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_LIST');
+      expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
+        'VERTICAL_TAB_LIST_CHILD'
+      );
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_PANELS');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_PANEL');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_PANEL');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_PANEL');
+    });
+
+    it('should set an element data attribute Horizontal Tabs', () => {
+      render(
+        <Tabs element="HORSE" orientation="horizontal" baseId="">
+          <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
+            <Tab element="TIGER" data-testid="tab-1">
+              Tab 1 is a long tab name because the server sent a long tab name
+            </Tab>
+            <Tab element="PANTHER" data-testid="tab-2">
+              Tab 2
+            </Tab>
+            <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
+              Tab 3
+            </Tab>
+          </TabList>
+          <TabPanels element="DOG" data-testid="tab-panels">
+            <TabPanel element="CORGI" data-testid="tab-panel-1">
+              Tab 1
+            </TabPanel>
+            <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
+              Tab 2
+            </TabPanel>
+            <TabPanel element="PUG" data-testid="tab-panel-3">
+              Tab 3
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      );
+
+      const outerDiv = screen.getByTestId('tab-list').parentElement;
+
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORIZONTAL_HORSE');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('HORIZONTAL_CAT');
+      expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
+        'HORIZONTAL_CAT_CHILD'
+      );
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TIGER');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_PANTHER');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_SCOTTISH_FOLD');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('HORIZONTAL_DOG');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_CORGI');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_GOLDEN_DOODLE');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_PUG');
+    });
+
+    it('should set an element data attribute for Vertical Tabs', () => {
+      render(
+        <Tabs element="HORSE" orientation="vertical" baseId="">
+          <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
+            <Tab element="TIGER" data-testid="tab-1">
+              Tab 1 is a long tab name because the server sent a long tab name
+            </Tab>
+            <Tab element="PANTHER" data-testid="tab-2">
+              Tab 2
+            </Tab>
+            <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
+              Tab 3
+            </Tab>
+          </TabList>
+          <TabPanels element="DOG" data-testid="tab-panels">
+            <TabPanel element="CORGI" data-testid="tab-panel-1">
+              Tab 1
+            </TabPanel>
+            <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
+              Tab 2
+            </TabPanel>
+            <TabPanel element="PUG" data-testid="tab-panel-3">
+              Tab 3
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      );
+
+      const outerDiv = screen.getByTestId('tab-list').parentElement;
+
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('VERTICAL_HORSE');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('VERTICAL_CAT');
+      expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
+        'VERTICAL_CAT_CHILD'
+      );
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('VERTICAL_TIGER');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('VERTICAL_PANTHER');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('VERTICAL_SCOTTISH_FOLD');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('VERTICAL_DOG');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('VERTICAL_CORGI');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('VERTICAL_GOLDEN_DOODLE');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('VERTICAL_PUG');
+    });
+  });
+
+  describe('Customization', () => {
+    it('should add custom styles to Tabs', () => {
+      render(
+        <CustomizationProvider
+          baseTheme="default"
+          elements={{
+            HORIZONTAL_TABS: {
+              margin: 'space100',
+              padding: 'space100',
+              borderStyle: 'solid',
+              borderWidth: 'borderWidth30',
+              borderColor: 'colorBorderPrimary',
+            },
+            HORIZONTAL_TAB_LIST: {
+              borderColor: 'colorBorderDestructive',
+              marginY: 'space100',
+            },
+            HORIZONTAL_TAB_LIST_CHILD: {borderColor: 'colorBorderDestructive'},
+            HORIZONTAL_TAB: {
+              fontFamily: 'fontFamilyCode',
+            },
+            HORIZONTAL_TAB_PANELS: {
+              marginY: 'space10',
+            },
+            HORIZONTAL_TAB_PANEL: {
+              paddingX: 'space30',
+            },
+          }}
+        >
+          <Tabs orientation="horizontal" baseId="">
+            <TabList data-testid="tab-list" aria-label="My tabs">
+              <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
+              <Tab data-testid="tab-2">Tab 2</Tab>
+              <Tab data-testid="tab-3">Tab 3</Tab>
+            </TabList>
+            <TabPanels data-testid="tab-panels">
+              <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
+              <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
+              <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
+            </TabPanels>
+          </Tabs>
+        </CustomizationProvider>
+      );
+
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('margin', '2.25rem');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('padding', '2.25rem');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-style', 'solid');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-width', '4px');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-color', 'rgb(2,99,224)');
+
+      expect(screen.getByTestId('tab-list')).toHaveStyleRule('margin-top', '2.25rem');
+      expect(screen.getByTestId('tab-list')).toHaveStyleRule('margin-bottom', '2.25rem');
+
+      expect(screen.getByTestId('tab-list').firstChild).toHaveStyleRule('border-color', 'rgb(214,31,31)');
+
+      expect(screen.getByTestId('tab-1')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+      expect(screen.getByTestId('tab-2')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+      expect(screen.getByTestId('tab-3')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+
+      expect(screen.getByTestId('tab-panels')).toHaveStyleRule('margin-top', '0.125rem');
+      expect(screen.getByTestId('tab-panels')).toHaveStyleRule('margin-bottom', '0.125rem');
+
+      expect(screen.getByTestId('tab-panel-1')).toHaveStyleRule('padding-right', '0.5rem');
+      expect(screen.getByTestId('tab-panel-2')).toHaveStyleRule('padding-left', '0.5rem');
+    });
+
+    it('should add custom styles to Tabs with a custom element data attribute', () => {
+      render(
+        <CustomizationProvider
+          baseTheme="default"
+          elements={{
+            HORIZONTAL_HORSE: {
+              margin: 'space100',
+              padding: 'space100',
+              borderStyle: 'solid',
+              borderWidth: 'borderWidth30',
+              borderColor: 'colorBorderPrimary',
+            },
+            HORIZONTAL_CATS: {
+              borderColor: 'colorBorderDestructive',
+              marginY: 'space100',
+            },
+            HORIZONTAL_CATS_CHILD: {borderColor: 'colorBorderDestructive'},
+            HORIZONTAL_RAGDOLL: {
+              fontFamily: 'fontFamilyCode',
+            },
+            HORIZONTAL_JAGUAR: {
+              fontFamily: 'fontFamilyCode',
+            },
+            HORIZONTAL_CHEETAH: {
+              fontFamily: 'fontFamilyCode',
+            },
+            HORIZONTAL_DOGS: {
+              marginY: 'space10',
+            },
+            HORIZONTAL_CORGI: {
+              paddingX: 'space0',
+            },
+            HORIZONTAL_DOODLE: {
+              paddingX: 'space20',
+            },
+            HORIZONTAL_TERRIER: {
+              paddingX: 'space40',
+            },
+          }}
+        >
+          <Tabs element="HORSE" orientation="horizontal" baseId="">
+            <TabList element="CATS" data-testid="tab-list" aria-label="My tabs">
+              <Tab element="RAGDOLL" data-testid="tab-1">
+                Tab 1 is a long tab name because the server sent a long tab name
+              </Tab>
+              <Tab element="JAGUAR" data-testid="tab-2">
+                Tab 2
+              </Tab>
+              <Tab element="CHEETAH" data-testid="tab-3">
+                Tab 3
+              </Tab>
+            </TabList>
+            <TabPanels element="DOGS" data-testid="tab-panels">
+              <TabPanel element="CORGI" data-testid="tab-panel-1">
+                Tab 1
+              </TabPanel>
+              <TabPanel element="DOODLE" data-testid="tab-panel-2">
+                Tab 2
+              </TabPanel>
+              <TabPanel element="TERRIER" data-testid="tab-panel-3">
+                Tab 3
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </CustomizationProvider>
+      );
+
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('margin', '2.25rem');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('padding', '2.25rem');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-style', 'solid');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-width', '4px');
+      expect(screen.getByTestId('tab-list').parentElement).toHaveStyleRule('border-color', 'rgb(2,99,224)');
+
+      expect(screen.getByTestId('tab-list')).toHaveStyleRule('margin-top', '2.25rem');
+      expect(screen.getByTestId('tab-list')).toHaveStyleRule('margin-bottom', '2.25rem');
+
+      expect(screen.getByTestId('tab-list').firstChild).toHaveStyleRule('border-color', 'rgb(214,31,31)');
+
+      expect(screen.getByTestId('tab-1')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+      expect(screen.getByTestId('tab-2')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+      expect(screen.getByTestId('tab-3')).toHaveStyleRule('font-family', "'Fira Mono','Courier New',Courier,monospace");
+
+      expect(screen.getByTestId('tab-panels')).toHaveStyleRule('margin-top', '0.125rem');
+      expect(screen.getByTestId('tab-panels')).toHaveStyleRule('margin-bottom', '0.125rem');
+
+      expect(screen.getByTestId('tab-panel-1')).toHaveStyleRule('padding-right', '0');
+      expect(screen.getByTestId('tab-panel-2')).toHaveStyleRule('padding-left', '0.25rem');
+      expect(screen.getByTestId('tab-panel-3')).toHaveStyleRule('padding-left', '0.75rem');
     });
   });
 

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -114,7 +114,7 @@ describe('Tabs', () => {
         </Tabs>
       );
 
-      const outerDiv = screen.getByTestId('tab-list').parentElement;
+      const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
       expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORIZONTAL_TABS');
       expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TAB_LIST');
@@ -146,7 +146,7 @@ describe('Tabs', () => {
         </Tabs>
       );
 
-      const outerDiv = screen.getByTestId('tab-list').parentElement;
+      const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
       expect(outerDiv.getAttribute('data-paste-element')).toEqual('VERTICAL_TABS');
       expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('VERTICAL_TAB_LIST');
@@ -190,7 +190,7 @@ describe('Tabs', () => {
         </Tabs>
       );
 
-      const outerDiv = screen.getByTestId('tab-list').parentElement;
+      const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
       expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORIZONTAL_HORSE');
       expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('HORIZONTAL_CAT');
@@ -234,7 +234,7 @@ describe('Tabs', () => {
         </Tabs>
       );
 
-      const outerDiv = screen.getByTestId('tab-list').parentElement;
+      const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
       expect(outerDiv.getAttribute('data-paste-element')).toEqual('VERTICAL_HORSE');
       expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('VERTICAL_CAT');

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -20,14 +20,12 @@ describe('Tabs', () => {
         expect(getElementName('horizontal', mockFallbackName)).toEqual('HORIZONTAL_TEST_ELEMENT_FALLBACK');
         expect(getElementName('vertical', mockFallbackName)).toEqual('VERTICAL_TEST_ELEMENT_FALLBACK');
       });
-      it('should return the correct string when element is null', () => {
-        expect(getElementName('horizontal', mockFallbackName, null)).toEqual('HORIZONTAL_TEST_ELEMENT_FALLBACK');
-        expect(getElementName('vertical', mockFallbackName, null)).toEqual('VERTICAL_TEST_ELEMENT_FALLBACK');
-      });
+
       it('should return the correct string when element is defined', () => {
         expect(getElementName('horizontal', mockFallbackName, 'CUSTOM_NAME')).toEqual('CUSTOM_NAME');
         expect(getElementName('vertical', mockFallbackName, 'CUSTOM_NAME')).toEqual('CUSTOM_NAME');
       });
+
       it('should return the correct string when element is an empty string', () => {
         expect(getElementName('horizontal', mockFallbackName, '')).toEqual('');
         expect(getElementName('vertical', mockFallbackName, '')).toEqual('');

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -192,18 +192,18 @@ describe('Tabs', () => {
 
       const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
-      expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORIZONTAL_HORSE');
-      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('HORIZONTAL_CAT');
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORSE');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('CAT');
       expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
-        'HORIZONTAL_CAT_CHILD'
+        'CAT_CHILD'
       );
-      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_TIGER');
-      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_PANTHER');
-      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_SCOTTISH_FOLD');
-      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('HORIZONTAL_DOG');
-      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('HORIZONTAL_CORGI');
-      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('HORIZONTAL_GOLDEN_DOODLE');
-      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('HORIZONTAL_PUG');
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('TIGER');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('PANTHER');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('SCOTTISH_FOLD');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('DOG');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('CORGI');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('GOLDEN_DOODLE');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('PUG');
     });
 
     it('should set an element data attribute for Vertical Tabs', () => {
@@ -236,18 +236,18 @@ describe('Tabs', () => {
 
       const outerDiv = screen.getByTestId('tab-list').parentElement as HTMLElement;
 
-      expect(outerDiv.getAttribute('data-paste-element')).toEqual('VERTICAL_HORSE');
-      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('VERTICAL_CAT');
+      expect(outerDiv.getAttribute('data-paste-element')).toEqual('HORSE');
+      expect(screen.getByTestId('tab-list').getAttribute('data-paste-element')).toEqual('CAT');
       expect((screen.getByTestId('tab-list').firstChild as HTMLElement).getAttribute('data-paste-element')).toEqual(
-        'VERTICAL_CAT_CHILD'
+        'CAT_CHILD'
       );
-      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('VERTICAL_TIGER');
-      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('VERTICAL_PANTHER');
-      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('VERTICAL_SCOTTISH_FOLD');
-      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('VERTICAL_DOG');
-      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('VERTICAL_CORGI');
-      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('VERTICAL_GOLDEN_DOODLE');
-      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('VERTICAL_PUG');
+      expect(screen.getByTestId('tab-1').getAttribute('data-paste-element')).toEqual('TIGER');
+      expect(screen.getByTestId('tab-2').getAttribute('data-paste-element')).toEqual('PANTHER');
+      expect(screen.getByTestId('tab-3').getAttribute('data-paste-element')).toEqual('SCOTTISH_FOLD');
+      expect(screen.getByTestId('tab-panels').getAttribute('data-paste-element')).toEqual('DOG');
+      expect(screen.getByTestId('tab-panel-1').getAttribute('data-paste-element')).toEqual('CORGI');
+      expect(screen.getByTestId('tab-panel-2').getAttribute('data-paste-element')).toEqual('GOLDEN_DOODLE');
+      expect(screen.getByTestId('tab-panel-3').getAttribute('data-paste-element')).toEqual('PUG');
     });
   });
 
@@ -322,37 +322,37 @@ describe('Tabs', () => {
         <CustomizationProvider
           baseTheme="default"
           elements={{
-            HORIZONTAL_HORSE: {
+            HORSE: {
               margin: 'space100',
               padding: 'space100',
               borderStyle: 'solid',
               borderWidth: 'borderWidth30',
               borderColor: 'colorBorderPrimary',
             },
-            HORIZONTAL_CATS: {
+            CATS: {
               borderColor: 'colorBorderDestructive',
               marginY: 'space100',
             },
-            HORIZONTAL_CATS_CHILD: {borderColor: 'colorBorderDestructive'},
-            HORIZONTAL_RAGDOLL: {
+            CATS_CHILD: {borderColor: 'colorBorderDestructive'},
+            RAGDOLL: {
               fontFamily: 'fontFamilyCode',
             },
-            HORIZONTAL_JAGUAR: {
+            JAGUAR: {
               fontFamily: 'fontFamilyCode',
             },
-            HORIZONTAL_CHEETAH: {
+            CHEETAH: {
               fontFamily: 'fontFamilyCode',
             },
-            HORIZONTAL_DOGS: {
+            DOGS: {
               marginY: 'space10',
             },
-            HORIZONTAL_CORGI: {
+            CORGI: {
               paddingX: 'space0',
             },
-            HORIZONTAL_DOODLE: {
+            DOODLE: {
               paddingX: 'space20',
             },
-            HORIZONTAL_TERRIER: {
+            TERRIER: {
               paddingX: 'space40',
             },
           }}

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -103,8 +103,8 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element = 'TA
   const tab = React.useContext(TabsContext);
   const boxStyles = React.useMemo(() => getTabBoxStyles(tab.orientation, tab.variant), [tab.orientation, tab.variant]);
 
-  // Do we need to pass into the primitive wrapper?
-  // is this just an HOC? Does it add something to the DOM? --> needs element prop.
+  const {orientation} = tab;
+
   return (
     <TabPrimitive {...(tab as any)} {...tabProps} ref={ref}>
       {(props: TabProps) => {
@@ -114,14 +114,14 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element = 'TA
             {...boxStyles}
             as="span"
             cursor={props['aria-disabled'] ? 'not-allowed' : 'pointer'}
-            element={element}
+            element={`${orientation.toUpperCase()}_${element}`}
             fontSize="fontSize30"
             fontWeight="fontWeightSemibold"
-            overflow={tab.orientation !== 'vertical' ? 'hidden' : undefined}
+            overflow={orientation !== 'vertical' ? 'hidden' : undefined}
             position="relative"
-            textOverflow={tab.orientation !== 'vertical' ? 'ellipsis' : undefined}
+            textOverflow={orientation !== 'vertical' ? 'ellipsis' : undefined}
             transition="border-color 100ms ease, color 100ms ease"
-            whiteSpace={tab.orientation !== 'vertical' ? 'nowrap' : undefined}
+            whiteSpace={orientation !== 'vertical' ? 'nowrap' : undefined}
           >
             {children}
           </Box>
@@ -136,7 +136,6 @@ if (process.env.NODE_ENV === 'development') {
     id: PropTypes.string,
     focusable: PropTypes.bool,
     disabled: PropTypes.bool,
-    element: PropTypes.string,
   };
 }
 

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -6,6 +6,8 @@ import {TabPrimitive} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
 import type {Orientation, Variants} from './types';
 
+import {getElementName} from './utils';
+
 // TODO:
 // Split vertical tabs into a separate component
 // because fitted tabs do nothing when orientation
@@ -99,11 +101,12 @@ export interface TabProps extends React.HTMLAttributes<HTMLElement> {
   'aria-disabled'?: boolean;
 }
 
-const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element = 'TAB', ...tabProps}, ref) => {
+const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element, ...tabProps}, ref) => {
   const tab = React.useContext(TabsContext);
   const boxStyles = React.useMemo(() => getTabBoxStyles(tab.orientation, tab.variant), [tab.orientation, tab.variant]);
 
   const {orientation} = tab;
+  const elementName = getElementName(orientation, 'TAB', element);
 
   return (
     <TabPrimitive {...(tab as any)} {...tabProps} ref={ref}>
@@ -114,7 +117,7 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element = 'TA
             {...boxStyles}
             as="span"
             cursor={props['aria-disabled'] ? 'not-allowed' : 'pointer'}
-            element={`${orientation.toUpperCase()}_${element}`}
+            element={elementName}
             fontSize="fontSize30"
             fontWeight="fontWeightSemibold"
             overflow={orientation !== 'vertical' ? 'hidden' : undefined}

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
-import type {BoxStyleProps} from '@twilio-paste/box';
+import type {BoxStyleProps, BoxProps} from '@twilio-paste/box';
 import {TabPrimitive} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
-import {Orientation, Variants} from './types';
+import type {Orientation, Variants} from './types';
 
 // TODO:
 // Split vertical tabs into a separate component
@@ -94,13 +94,17 @@ export interface TabProps extends React.HTMLAttributes<HTMLElement> {
   id?: string | undefined;
   focusable?: boolean | undefined;
   disabled?: boolean | undefined;
+  element?: BoxProps['element'];
   children: React.ReactNode;
   'aria-disabled'?: boolean;
 }
 
-const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, ...tabProps}, ref) => {
+const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element = 'TAB', ...tabProps}, ref) => {
   const tab = React.useContext(TabsContext);
   const boxStyles = React.useMemo(() => getTabBoxStyles(tab.orientation, tab.variant), [tab.orientation, tab.variant]);
+
+  // Do we need to pass into the primitive wrapper?
+  // is this just an HOC? Does it add something to the DOM? --> needs element prop.
   return (
     <TabPrimitive {...(tab as any)} {...tabProps} ref={ref}>
       {(props: TabProps) => {
@@ -110,6 +114,7 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, ...tabProps},
             {...boxStyles}
             as="span"
             cursor={props['aria-disabled'] ? 'not-allowed' : 'pointer'}
+            element={element}
             fontSize="fontSize30"
             fontWeight="fontWeightSemibold"
             overflow={tab.orientation !== 'vertical' ? 'hidden' : undefined}
@@ -131,6 +136,7 @@ if (process.env.NODE_ENV === 'development') {
     id: PropTypes.string,
     focusable: PropTypes.bool,
     disabled: PropTypes.bool,
+    element: PropTypes.string,
   };
 }
 

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -10,6 +10,7 @@ export interface TabListProps {
   'aria-label': string;
   disabled?: boolean | undefined;
   element?: BoxProps['element'];
+
   focusable?: boolean | undefined;
   children: React.ReactNode;
   variant?: Variants;
@@ -21,7 +22,7 @@ const HorizontalTabList: React.FC<{element?: BoxProps['element']}> = ({children,
     borderBottomWidth="borderWidth10"
     borderBottomColor="colorBorderWeak"
     borderBottomStyle="solid"
-    element={element}
+    element={`HORIZONTAL_${element}`}
     marginBottom="space60"
   >
     {children}
@@ -33,7 +34,7 @@ const VerticalTabList: React.FC<{element?: BoxProps['element']}> = ({children, e
     borderLeftWidth="borderWidth10"
     borderLeftColor="colorBorderWeak"
     borderLeftStyle="solid"
-    element={element}
+    element={`VERTICAL_${element}`}
     marginRight="space110"
     minWidth="size20"
     maxWidth="size40"
@@ -45,10 +46,17 @@ const VerticalTabList: React.FC<{element?: BoxProps['element']}> = ({children, e
 const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
   ({children, element = 'TAB_LIST', variant, ...props}, ref) => {
     const tab = React.useContext(TabsContext);
-    const TabListWrapper = tab.orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
+    const {orientation} = tab;
+    const TabListWrapper = orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
 
     return (
-      <TabPrimitiveList {...(tab as any)} as={Box} {...props} element={element} ref={ref}>
+      <TabPrimitiveList
+        {...(tab as any)}
+        as={Box}
+        {...props}
+        element={`${orientation.toUpperCase()}_${element}`}
+        ref={ref}
+      >
         <TabListWrapper element={`${element}_CHILD`}>{children}</TabListWrapper>
       </TabPrimitiveList>
     );

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -5,12 +5,12 @@ import type {BoxProps} from '@twilio-paste/box';
 import {TabPrimitiveList} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
 import type {Variants} from './types';
+import {getElementName} from './utils';
 
 export interface TabListProps {
   'aria-label': string;
   disabled?: boolean | undefined;
   element?: BoxProps['element'];
-
   focusable?: boolean | undefined;
   children: React.ReactNode;
   variant?: Variants;
@@ -22,7 +22,7 @@ const HorizontalTabList: React.FC<{element?: BoxProps['element']}> = ({children,
     borderBottomWidth="borderWidth10"
     borderBottomColor="colorBorderWeak"
     borderBottomStyle="solid"
-    element={`HORIZONTAL_${element}`}
+    element={element}
     marginBottom="space60"
   >
     {children}
@@ -34,7 +34,7 @@ const VerticalTabList: React.FC<{element?: BoxProps['element']}> = ({children, e
     borderLeftWidth="borderWidth10"
     borderLeftColor="colorBorderWeak"
     borderLeftStyle="solid"
-    element={`VERTICAL_${element}`}
+    element={element}
     marginRight="space110"
     minWidth="size20"
     maxWidth="size40"
@@ -43,25 +43,18 @@ const VerticalTabList: React.FC<{element?: BoxProps['element']}> = ({children, e
   </Box>
 );
 
-const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
-  ({children, element = 'TAB_LIST', variant, ...props}, ref) => {
-    const tab = React.useContext(TabsContext);
-    const {orientation} = tab;
-    const TabListWrapper = orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
+const TabList = React.forwardRef<HTMLDivElement, TabListProps>(({children, element, variant, ...props}, ref) => {
+  const tab = React.useContext(TabsContext);
+  const {orientation} = tab;
+  const elementName = getElementName(orientation, 'TAB_LIST', element);
+  const TabListWrapper = orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
 
-    return (
-      <TabPrimitiveList
-        {...(tab as any)}
-        as={Box}
-        {...props}
-        element={`${orientation.toUpperCase()}_${element}`}
-        ref={ref}
-      >
-        <TabListWrapper element={`${element}_CHILD`}>{children}</TabListWrapper>
-      </TabPrimitiveList>
-    );
-  }
-);
+  return (
+    <TabPrimitiveList {...(tab as any)} as={Box} {...props} element={elementName} ref={ref}>
+      <TabListWrapper element={`${elementName}_CHILD`}>{children}</TabListWrapper>
+    </TabPrimitiveList>
+  );
+});
 
 if (process.env.NODE_ENV === 'development') {
   TabList.propTypes = {

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -1,35 +1,39 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Box} from '@twilio-paste/box';
+import type {BoxProps} from '@twilio-paste/box';
 import {TabPrimitiveList} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
-import {Variants} from './types';
+import type {Variants} from './types';
 
 export interface TabListProps {
   'aria-label': string;
   disabled?: boolean | undefined;
+  element?: BoxProps['element'];
   focusable?: boolean | undefined;
   children: React.ReactNode;
   variant?: Variants;
 }
 
-const HorizontalTabList: React.FC = ({children}) => (
+const HorizontalTabList: React.FC<{element?: BoxProps['element']}> = ({children, element}) => (
   <Box
     display="flex"
     borderBottomWidth="borderWidth10"
     borderBottomColor="colorBorderWeak"
     borderBottomStyle="solid"
+    element={element}
     marginBottom="space60"
   >
     {children}
   </Box>
 );
 
-const VerticalTabList: React.FC = ({children}) => (
+const VerticalTabList: React.FC<{element?: BoxProps['element']}> = ({children, element}) => (
   <Box
     borderLeftWidth="borderWidth10"
     borderLeftColor="colorBorderWeak"
     borderLeftStyle="solid"
+    element={element}
     marginRight="space110"
     minWidth="size20"
     maxWidth="size40"
@@ -38,21 +42,25 @@ const VerticalTabList: React.FC = ({children}) => (
   </Box>
 );
 
-const TabList = React.forwardRef<HTMLDivElement, TabListProps>(({children, variant, ...props}, ref) => {
-  const tab = React.useContext(TabsContext);
-  const TabListWrapper = tab.orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
-  return (
-    <TabPrimitiveList {...(tab as any)} {...props} ref={ref}>
-      <TabListWrapper>{children}</TabListWrapper>
-    </TabPrimitiveList>
-  );
-});
+const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
+  ({children, element = 'TAB_LIST', variant, ...props}, ref) => {
+    const tab = React.useContext(TabsContext);
+    const TabListWrapper = tab.orientation === 'vertical' ? VerticalTabList : HorizontalTabList;
+
+    return (
+      <TabPrimitiveList {...(tab as any)} as={Box} {...props} element={element} ref={ref}>
+        <TabListWrapper element={`${element}_CHILD`}>{children}</TabListWrapper>
+      </TabPrimitiveList>
+    );
+  }
+);
 
 if (process.env.NODE_ENV === 'development') {
   TabList.propTypes = {
     'aria-label': PropTypes.string.isRequired,
     focusable: PropTypes.bool,
     disabled: PropTypes.bool,
+    element: PropTypes.string,
   };
 }
 

--- a/packages/paste-core/components/tabs/src/TabPanel.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Box} from '@twilio-paste/box';
-import type {BoxStyleProps} from '@twilio-paste/box';
+import type {BoxStyleProps, BoxProps} from '@twilio-paste/box';
 import {TabPrimitivePanel} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
 
@@ -17,12 +17,13 @@ export interface TabPanelProps {
   id?: string | undefined;
   tabId?: string | undefined;
   children: React.ReactNode;
+  element?: BoxProps['element'];
 }
 
-const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, ...props}, ref) => {
+const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, element = 'TAB_PANEL', ...props}, ref) => {
   const tab = React.useContext(TabsContext);
   return (
-    <TabPrimitivePanel {...(tab as any)} {...tabPanelStyles} {...props} as={Box} ref={ref}>
+    <TabPrimitivePanel {...(tab as any)} {...tabPanelStyles} {...props} element={element} as={Box} ref={ref}>
       {children}
     </TabPrimitivePanel>
   );
@@ -30,6 +31,7 @@ const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, ...
 
 if (process.env.NODE_ENV === 'development') {
   TabPanel.propTypes = {
+    element: PropTypes.string,
     id: PropTypes.string,
     tabId: PropTypes.string,
   };

--- a/packages/paste-core/components/tabs/src/TabPanel.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanel.tsx
@@ -4,6 +4,7 @@ import {Box} from '@twilio-paste/box';
 import type {BoxStyleProps, BoxProps} from '@twilio-paste/box';
 import {TabPrimitivePanel} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
+import {getElementName} from './utils';
 
 export const tabPanelStyles = {
   borderRadius: 'borderRadius20',
@@ -20,18 +21,12 @@ export interface TabPanelProps {
   element?: BoxProps['element'];
 }
 
-const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, element = 'TAB_PANEL', ...props}, ref) => {
+const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, element, ...props}, ref) => {
   const tab = React.useContext(TabsContext);
+  const elementName = getElementName(tab.orientation, 'TAB_PANEL', element);
 
   return (
-    <TabPrimitivePanel
-      {...(tab as any)}
-      {...tabPanelStyles}
-      {...props}
-      element={`${tab.orientation.toUpperCase()}_${element}`}
-      as={Box}
-      ref={ref}
-    >
+    <TabPrimitivePanel {...(tab as any)} {...tabPanelStyles} {...props} element={elementName} as={Box} ref={ref}>
       {children}
     </TabPrimitivePanel>
   );

--- a/packages/paste-core/components/tabs/src/TabPanel.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanel.tsx
@@ -22,8 +22,16 @@ export interface TabPanelProps {
 
 const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(({children, element = 'TAB_PANEL', ...props}, ref) => {
   const tab = React.useContext(TabsContext);
+
   return (
-    <TabPrimitivePanel {...(tab as any)} {...tabPanelStyles} {...props} element={element} as={Box} ref={ref}>
+    <TabPrimitivePanel
+      {...(tab as any)}
+      {...tabPanelStyles}
+      {...props}
+      element={`${tab.orientation.toUpperCase()}_${element}`}
+      as={Box}
+      ref={ref}
+    >
       {children}
     </TabPrimitivePanel>
   );

--- a/packages/paste-core/components/tabs/src/TabPanels.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanels.tsx
@@ -3,6 +3,8 @@ import * as PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import type {BoxProps} from '@twilio-paste/box';
 
+import {TabsContext} from './TabsContext';
+
 export interface TabPanelsProps {
   children: React.ReactNode;
   element?: BoxProps['element'];
@@ -10,8 +12,9 @@ export interface TabPanelsProps {
 
 const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(
   ({children, element = 'TAB_PANELS', ...props}, ref) => {
+    const {orientation} = React.useContext(TabsContext);
     return (
-      <Box {...safelySpreadBoxProps(props)} element={element} width="100%" ref={ref}>
+      <Box {...safelySpreadBoxProps(props)} element={`${orientation.toUpperCase()}_${element}`} width="100%" ref={ref}>
         {children}
       </Box>
     );

--- a/packages/paste-core/components/tabs/src/TabPanels.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanels.tsx
@@ -1,17 +1,28 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BoxProps} from '@twilio-paste/box';
 
 export interface TabPanelsProps {
   children: React.ReactNode;
+  element?: BoxProps['element'];
 }
 
-const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(({children, ...props}, ref) => {
-  return (
-    <Box {...safelySpreadBoxProps(props)} width="100%" ref={ref}>
-      {children}
-    </Box>
-  );
-});
+const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(
+  ({children, element = 'TAB_PANELS', ...props}, ref) => {
+    return (
+      <Box {...safelySpreadBoxProps(props)} element={element} width="100%" ref={ref}>
+        {children}
+      </Box>
+    );
+  }
+);
+
+if (process.env.NODE_ENV === 'development') {
+  TabPanels.propTypes = {
+    element: PropTypes.string,
+  };
+}
 
 TabPanels.displayName = 'TabPanels';
 export {TabPanels};

--- a/packages/paste-core/components/tabs/src/TabPanels.tsx
+++ b/packages/paste-core/components/tabs/src/TabPanels.tsx
@@ -4,22 +4,22 @@ import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import type {BoxProps} from '@twilio-paste/box';
 
 import {TabsContext} from './TabsContext';
+import {getElementName} from './utils';
 
 export interface TabPanelsProps {
   children: React.ReactNode;
   element?: BoxProps['element'];
 }
 
-const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(
-  ({children, element = 'TAB_PANELS', ...props}, ref) => {
-    const {orientation} = React.useContext(TabsContext);
-    return (
-      <Box {...safelySpreadBoxProps(props)} element={`${orientation.toUpperCase()}_${element}`} width="100%" ref={ref}>
-        {children}
-      </Box>
-    );
-  }
-);
+const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(({children, element, ...props}, ref) => {
+  const {orientation} = React.useContext(TabsContext);
+  const elementName = getElementName(orientation, 'TAB_PANELS', element);
+  return (
+    <Box {...safelySpreadBoxProps(props)} element={elementName} width="100%" ref={ref}>
+      {children}
+    </Box>
+  );
+});
 
 if (process.env.NODE_ENV === 'development') {
   TabPanels.propTypes = {

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -23,18 +23,18 @@ export interface TabsProps extends TabPrimitiveInitialState {
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   ({children, element = 'TABS', orientation = 'horizontal', state, variant, ...initialState}, ref) => {
     const tab = state || useTabPrimitiveState({orientation, ...initialState});
-    const value = React.useMemo(() => ({...tab, variant}), [...Object.values(tab), variant]);
+    const value = React.useMemo(() => ({orientation, ...tab, variant}), [...Object.values(tab), orientation, variant]);
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
     if (tab.orientation === 'vertical') {
       return (
-        <Flex element={element} ref={ref} wrap={false} vAlignContent="stretch">
+        <Flex element={`VERTICAL_${element}`} ref={ref} wrap={false} vAlignContent="stretch">
           {returnValue}
         </Flex>
       );
     }
 
-    return <Box element={element}>{returnValue}</Box>;
+    return <Box element={`HORIZONTAL_${element}`}>{returnValue}</Box>;
   }
 );
 
@@ -42,7 +42,7 @@ if (process.env.NODE_ENV === 'development') {
   Tabs.propTypes = {
     element: PropTypes.string,
     selectedId: PropTypes.string,
-    orientation: PropTypes.oneOf(['horizontal', 'vertical', null]),
+    orientation: PropTypes.oneOf(['horizontal', 'vertical', undefined]),
     variant: PropTypes.oneOf(['fitted', null]),
   };
 }

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import type {BoxProps} from '@twilio-paste/box';
 import {Flex} from '@twilio-paste/flex';
-import {useTabPrimitiveState, TabPrimitiveInitialState, TabPrimitiveStateReturn} from '@twilio-paste/tabs-primitive';
+import {Box} from '@twilio-paste/box';
+import {useTabPrimitiveState} from '@twilio-paste/tabs-primitive';
+import type {TabPrimitiveInitialState, TabPrimitiveStateReturn} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
-import {Variants} from './types';
+import type {Variants} from './types';
 
 export interface TabStateReturn extends TabPrimitiveStateReturn {
   [key: string]: any;
@@ -11,30 +14,33 @@ export interface TabStateReturn extends TabPrimitiveStateReturn {
 
 export interface TabsProps extends TabPrimitiveInitialState {
   children?: React.ReactNode;
+  element?: BoxProps['element'];
   state?: TabStateReturn;
   variant?: Variants;
 }
 
 // Set orientation to horizontal because undefined enables all arrow key movement
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
-  ({children, orientation = 'horizontal', state, variant, ...initialState}, ref) => {
+  ({children, element = 'TABS', orientation = 'horizontal', state, variant, ...initialState}, ref) => {
     const tab = state || useTabPrimitiveState({orientation, ...initialState});
     const value = React.useMemo(() => ({...tab, variant}), [...Object.values(tab), variant]);
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
     if (tab.orientation === 'vertical') {
       return (
-        <Flex ref={ref} wrap={false} vAlignContent="stretch">
+        <Flex element={element} ref={ref} wrap={false} vAlignContent="stretch">
           {returnValue}
         </Flex>
       );
     }
-    return returnValue;
+
+    return <Box element={element}>{returnValue}</Box>;
   }
 );
 
 if (process.env.NODE_ENV === 'development') {
   Tabs.propTypes = {
+    element: PropTypes.string,
     selectedId: PropTypes.string,
     orientation: PropTypes.oneOf(['horizontal', 'vertical', null]),
     variant: PropTypes.oneOf(['fitted', null]),

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -33,7 +33,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
     ]);
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
-    if (tab.orientation === 'vertical') {
+    if (tabOrientation === 'vertical') {
       return (
         <Flex element={`VERTICAL_${element}`} ref={ref} wrap={false} vAlignContent="stretch">
           {returnValue}

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -7,6 +7,7 @@ import {useTabPrimitiveState} from '@twilio-paste/tabs-primitive';
 import type {TabPrimitiveInitialState, TabPrimitiveStateReturn} from '@twilio-paste/tabs-primitive';
 import {TabsContext} from './TabsContext';
 import type {Variants} from './types';
+import {getElementName} from './utils';
 
 export interface TabStateReturn extends TabPrimitiveStateReturn {
   [key: string]: any;
@@ -21,27 +22,27 @@ export interface TabsProps extends TabPrimitiveInitialState {
 
 // Set orientation to horizontal because undefined enables all arrow key movement
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
-  ({children, element = 'TABS', orientation = 'horizontal', state, variant, ...initialState}, ref) => {
+  ({children, element, orientation = 'horizontal', state, variant, ...initialState}, ref) => {
     // If returned state from primitive has orientation set to undefined, use the default "horizontal"
     const {orientation: tabOrientation = orientation, ...tab} =
       state || useTabPrimitiveState({orientation, ...initialState});
-
+    const elementName = getElementName(tabOrientation, 'TABS', element);
     const value = React.useMemo(() => ({...tab, orientation: tabOrientation, variant}), [
       ...Object.values(tab),
-      orientation,
+      tabOrientation,
       variant,
     ]);
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
     if (tabOrientation === 'vertical') {
       return (
-        <Flex element={`VERTICAL_${element}`} ref={ref} wrap={false} vAlignContent="stretch">
+        <Flex element={elementName} ref={ref} wrap={false} vAlignContent="stretch">
           {returnValue}
         </Flex>
       );
     }
 
-    return <Box element={`HORIZONTAL_${element}`}>{returnValue}</Box>;
+    return <Box element={elementName}>{returnValue}</Box>;
   }
 );
 

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -22,8 +22,15 @@ export interface TabsProps extends TabPrimitiveInitialState {
 // Set orientation to horizontal because undefined enables all arrow key movement
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   ({children, element = 'TABS', orientation = 'horizontal', state, variant, ...initialState}, ref) => {
-    const tab = state || useTabPrimitiveState({orientation, ...initialState});
-    const value = React.useMemo(() => ({orientation, ...tab, variant}), [...Object.values(tab), orientation, variant]);
+    // If returned state from primitive has orientation set to undefined, use the default "horizontal"
+    const {orientation: tabOrientation = orientation, ...tab} =
+      state || useTabPrimitiveState({orientation, ...initialState});
+
+    const value = React.useMemo(() => ({...tab, orientation: tabOrientation, variant}), [
+      ...Object.values(tab),
+      orientation,
+      variant,
+    ]);
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
     if (tab.orientation === 'vertical') {

--- a/packages/paste-core/components/tabs/src/TabsContext.tsx
+++ b/packages/paste-core/components/tabs/src/TabsContext.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import {TabPrimitiveState} from '@twilio-paste/tabs-primitive';
-import {Variants} from './types';
+import type {TabPrimitiveState} from '@twilio-paste/tabs-primitive';
+import type {Variants} from './types';
 
-interface TabState extends TabPrimitiveState {
+interface TabState extends Omit<TabPrimitiveState, 'orientation'> {
   variant?: Variants;
+  orientation: 'horizontal' | 'vertical';
 }
 
-const TabsContext = React.createContext<Partial<TabState>>({});
+const TabsContext = React.createContext<TabState>({} as TabState);
 
 export {TabsContext};

--- a/packages/paste-core/components/tabs/src/utils.ts
+++ b/packages/paste-core/components/tabs/src/utils.ts
@@ -1,0 +1,5 @@
+export const getElementName = (
+  orientation: 'horizontal' | 'vertical',
+  fallback: string,
+  elementName?: string | undefined
+): string => (elementName != null ? elementName : `${orientation.toUpperCase()}_${fallback}`);

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -261,6 +261,7 @@ export const CustomHorizontalTabs: React.FC = () => {
         },
         HORIZONTAL_TAB: {
           fontFamily: 'fontFamilyCode',
+          paddingLeft: 'space0',
         },
         HORIZONTAL_TAB_LIST: {
           borderColor: 'colorBorderDestructive',
@@ -282,10 +283,17 @@ export const CustomHorizontalTabs: React.FC = () => {
           marginY: 'space20',
         },
         HORIZONTAL_CUSTOM_TAB: {
+          paddingLeft: 'space40',
           color: 'colorTextWarning',
+          fontSize: 'fontSize10',
+          borderBottomStyle: 'solid',
+          borderBottomWidth: 'borderWidth30',
+          borderBottomColor: 'colorBorderPrimary',
         },
         HORIZONTAL_OTHER_TAB: {
+          paddingLeft: 'space100',
           color: 'colorText',
+          backgroundColor: 'colorBackgroundAvailable',
         },
         HORIZONTAL_DIFFERENT_PANEL: {
           fontWeight: 'fontWeightBold',
@@ -294,9 +302,9 @@ export const CustomHorizontalTabs: React.FC = () => {
     >
       <Tabs selectedId={selectedId} baseId="horizontal-tabs-example">
         <TabList aria-label="LGBTQ+ Projects">
-          <Tab element="CUSTOM_TAB">Inside Out</Tab>
+          <Tab element="HORIZONTAL_CUSTOM_TAB">Inside Out</Tab>
           <Tab>Transgender District</Tab>
-          <Tab element="OTHER_TAB" id={selectedId}>
+          <Tab element="HORIZONTAL_OTHER_TAB" id={selectedId}>
             Audre Lorde Project
           </Tab>
           <Tab disabled>Coming soon...</Tab>
@@ -314,7 +322,7 @@ export const CustomHorizontalTabs: React.FC = () => {
             </Paragraph>
             <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
           </TabPanel>
-          <TabPanel element="DIFFERENT_PANEL">
+          <TabPanel element="HORIZONTAL_DIFFERENT_PANEL">
             <Heading as="h2" variant="heading20">
               Transgender District
             </Heading>
@@ -362,12 +370,18 @@ export const CustomVerticalTabs: React.FC = () => {
         },
         VERTICAL_TAB: {
           fontFamily: 'fontFamilyCode',
+          paddingTop: 'space10',
+          fontSize: 'fontSize10',
         },
         VERTICAL_CUSTOM_TAB: {
-          color: 'colorTextWarning',
+          backgroundColor: 'colorBackgroundAvailable',
         },
         VERTICAL_OTHER_TAB: {
           color: 'colorText',
+          paddingTop: 'space100',
+          borderBottomStyle: 'solid',
+          borderBottomWidth: 'borderWidth30',
+          borderBottomColor: 'colorBorderPrimary',
         },
         VERTICAL_TAB_LIST: {
           borderColor: 'colorBorderDestructive',
@@ -384,9 +398,9 @@ export const CustomVerticalTabs: React.FC = () => {
       <Tabs orientation="vertical" selectedId={selectedId} baseId="vertical-tabs-example">
         <TabList aria-label="LGBTQ+ Projects">
           <Tab id={selectedId}>Inside Out</Tab>
-          <Tab element="CUSTOM_TAB">Transgender District</Tab>
+          <Tab element="VERTICAL_CUSTOM_TAB">Transgender District</Tab>
           <Tab>Audre Lorde Project</Tab>
-          <Tab element="OTHER_TAB" disabled>
+          <Tab element="VERTICAL_OTHER_TAB" disabled>
             Coming soon...
           </Tab>
         </TabList>
@@ -415,7 +429,99 @@ export const CustomVerticalTabs: React.FC = () => {
             </Paragraph>
             <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
           </TabPanel>
-          <TabPanel element="DIFFERENT_PANEL">
+          <TabPanel element="VERTICAL_DIFFERENT_PANEL">
+            <Heading as="h2" variant="heading20">
+              Audre Lorde Project
+            </Heading>
+            <Paragraph>
+              The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People of
+              Color center for community organizing, focusing on the New York City area. Through mobilization, education
+              and capacity-building, they work for community wellness and progressive social and economic justice.
+              Committed to struggling across differences, they seek to responsibly reflect, represent and serve their
+              various communities.
+            </Paragraph>
+            <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </CustomizationProvider>
+  );
+};
+
+// @TODO
+export const CustomFittedTabs: React.FC = () => {
+  const currentTheme = useTheme();
+  const selectedId = useUID();
+
+  return (
+    <CustomizationProvider
+      theme={currentTheme}
+      elements={{
+        HORIZONTAL_TABS: {
+          margin: 'space100',
+          padding: 'space100',
+          borderStyle: 'dashed',
+          borderWidth: 'borderWidth10',
+          borderColor: 'colorBorderPrimary',
+        },
+        HORIZONTAL_TAB: {
+          paddingTop: 'space10',
+          fontSize: 'fontSize10',
+        },
+        HORIZONTAL_CUSTOM_TAB: {
+          backgroundColor: 'colorBackgroundAvailable',
+          fontFamily: 'fontFamilyCode',
+        },
+        HORIZONTAL_OTHER_TAB: {
+          borderBottomStyle: 'dotted',
+          borderBottomWidth: 'borderWidth20',
+          borderBottomColor: 'colorBorderPrimary',
+        },
+        HORIZONTAL_TAB_LIST: {
+          borderColor: 'colorBorderDestructive',
+          marginY: 'space100',
+        },
+        HORIZONTAL_TAB_LIST_CHILD: {
+          borderColor: 'colorBorderDestructive',
+        },
+        HORIZONTAL_DIFFERENT_PANEL: {
+          fontWeight: 'fontWeightBold',
+        },
+      }}
+    >
+      <Tabs selectedId={selectedId} baseId="fitted-tabs-example" variant="fitted">
+        <TabList aria-label="LGBTQ+ Projects">
+          <Tab element="HORIZONTAL_CUSTOM_TAB">Inside Out</Tab>
+          <Tab id={selectedId}>Transgender District</Tab>
+          <Tab element="HORIZONTAL_OTHER_TAB">Audre Lorde Project</Tab>
+          <Tab disabled>Coming soon...</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Inside Out
+            </Heading>
+            <Paragraph>
+              Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
+              Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
+              youth in the community and working to make the community safer and more accepting of gender and sexual
+              orientation diversity.
+            </Paragraph>
+            <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
+          </TabPanel>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Transgender District
+            </Heading>
+            <Paragraph>
+              The mission of the Transgender District is to create an urban environment that fosters the rich history,
+              culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
+              neighborhood. The transgender district aims to stabilize and economically empower the transgender
+              community through ownership of homes, businesses, historic and cultural sites, and safe community spaces.
+            </Paragraph>
+            <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
+          </TabPanel>
+          <TabPanel>
             <Heading as="h2" variant="heading20">
               Audre Lorde Project
             </Heading>

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
+import {CustomizationProvider} from '@twilio-paste/customization';
 import {useUID} from '@twilio-paste/uid-library';
+import {Stack} from '@twilio-paste/stack';
+import {Separator} from '@twilio-paste/separator';
 import {Button} from '@twilio-paste/button';
 import {Heading} from '@twilio-paste/heading';
 import {Anchor} from '@twilio-paste/anchor';
 import {Paragraph} from '@twilio-paste/paragraph';
+import {useTheme} from '@twilio-paste/theme';
 import {useTabState, Tabs, TabList, Tab, TabPanels, TabPanel} from '../src';
 import type {TabStateReturn} from '../src';
 
@@ -245,4 +249,147 @@ CenterAlignTabTest.story = {
 export default {
   title: 'Components/Tabs',
   component: Tabs,
+};
+
+export const CustomTabs: React.FC = () => {
+  const currentTheme = useTheme();
+  const selectedId = useUID();
+
+  return (
+    <CustomizationProvider
+      theme={currentTheme}
+      elements={{
+        TABS: {
+          margin: 'space100',
+          padding: 'space100',
+          borderStyle: 'solid',
+          borderWidth: 'borderWidth30',
+          borderColor: 'colorBorderPrimary',
+        },
+        TAB_LIST: {},
+        TAB_LIST_CHILD: {
+          borderColor: 'colorBorderDestructive',
+        },
+        TAB: {
+          fontFamily: 'fontFamilyCode',
+        },
+        TAB_LIST_HORIZONTAL: {
+          borderColor: 'colorBorderDestructive',
+          marginY: 'space100',
+        },
+        TAB_LIST_HORIZONTAL_CHILD: {
+          borderColor: 'colorBorderDestructive',
+        },
+        TAB_LIST_VERTICAL: {
+          borderColor: 'colorBorderDestructive',
+          marginX: 'space100',
+        },
+        TAB_LIST_VERTICAL_CHILD: {
+          borderColor: 'colorBorderDestructive',
+        },
+      }}
+    >
+      <Stack orientation="vertical" spacing="space150">
+        <Tabs selectedId={selectedId} baseId="horizontal-tabs-example">
+          <TabList element="TAB_LIST_HORIZONTAL" aria-label="LGBTQ+ Projects">
+            <Tab>Inside Out</Tab>
+            <Tab>Transgender District</Tab>
+            <Tab id={selectedId}>Audre Lorde Project</Tab>
+            <Tab disabled>Coming soon...</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Inside Out
+              </Heading>
+              <Paragraph>
+                Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
+                Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
+                youth in the community and working to make the community safer and more accepting of gender and sexual
+                orientation diversity.
+              </Paragraph>
+              <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
+            </TabPanel>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Transgender District
+              </Heading>
+              <Paragraph>
+                The mission of the Transgender District is to create an urban environment that fosters the rich history,
+                culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
+                neighborhood. The transgender district aims to stabilize and economically empower the transgender
+                community through ownership of homes, businesses, historic and cultural sites, and safe community
+                spaces.
+              </Paragraph>
+              <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
+            </TabPanel>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Audre Lorde Project
+              </Heading>
+              <Paragraph>
+                The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People
+                of Color center for community organizing, focusing on the New York City area. Through mobilization,
+                education and capacity-building, they work for community wellness and progressive social and economic
+                justice. Committed to struggling across differences, they seek to responsibly reflect, represent and
+                serve their various communities.
+              </Paragraph>
+              <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+
+        <Separator orientation="horizontal" />
+
+        <Tabs orientation="vertical" selectedId={selectedId} baseId="vertical-tabs-example">
+          <TabList element="TAB_LIST_VERTICAL" aria-label="LGBTQ+ Projects">
+            <Tab id={selectedId}>Inside Out</Tab>
+            <Tab>Transgender District</Tab>
+            <Tab>Audre Lorde Project</Tab>
+            <Tab disabled>Coming soon...</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Inside Out
+              </Heading>
+              <Paragraph>
+                Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
+                Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
+                youth in the community and working to make the community safer and more accepting of gender and sexual
+                orientation diversity.
+              </Paragraph>
+              <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
+            </TabPanel>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Transgender District
+              </Heading>
+              <Paragraph>
+                The mission of the Transgender District is to create an urban environment that fosters the rich history,
+                culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
+                neighborhood. The transgender district aims to stabilize and economically empower the transgender
+                community through ownership of homes, businesses, historic and cultural sites, and safe community
+                spaces.
+              </Paragraph>
+              <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
+            </TabPanel>
+            <TabPanel>
+              <Heading as="h2" variant="heading20">
+                Audre Lorde Project
+              </Heading>
+              <Paragraph>
+                The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People
+                of Color center for community organizing, focusing on the New York City area. Through mobilization,
+                education and capacity-building, they work for community wellness and progressive social and economic
+                justice. Committed to struggling across differences, they seek to responsibly reflect, represent and
+                serve their various communities.
+              </Paragraph>
+              <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </Stack>
+    </CustomizationProvider>
+  );
 };

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {useUID} from '@twilio-paste/uid-library';
-import {Stack} from '@twilio-paste/stack';
-import {Separator} from '@twilio-paste/separator';
 import {Button} from '@twilio-paste/button';
 import {Heading} from '@twilio-paste/heading';
 import {Anchor} from '@twilio-paste/anchor';
@@ -192,6 +190,7 @@ const useButtonClickTabState = (): TabStateReturn => {
 
 export const StateHookTabs: React.FC = () => {
   const {...tab} = useButtonClickTabState();
+
   return (
     <Tabs state={tab}>
       <TabList aria-label="Tabs to test programmatic state handling">
@@ -251,7 +250,7 @@ export default {
   component: Tabs,
 };
 
-export const CustomTabs: React.FC = () => {
+export const CustomHorizontalTabs: React.FC = () => {
   const currentTheme = useTheme();
   const selectedId = useUID();
 
@@ -259,137 +258,162 @@ export const CustomTabs: React.FC = () => {
     <CustomizationProvider
       theme={currentTheme}
       elements={{
-        TABS: {
+        HORIZONTAL_TABS: {
           margin: 'space100',
           padding: 'space100',
           borderStyle: 'solid',
           borderWidth: 'borderWidth30',
           borderColor: 'colorBorderPrimary',
         },
-        TAB_LIST: {},
-        TAB_LIST_CHILD: {
-          borderColor: 'colorBorderDestructive',
-        },
-        TAB: {
+        HORIZONTAL_TAB: {
           fontFamily: 'fontFamilyCode',
         },
-        TAB_LIST_HORIZONTAL: {
+        HORIZONTAL_TAB_LIST: {
           borderColor: 'colorBorderDestructive',
           marginY: 'space100',
         },
-        TAB_LIST_HORIZONTAL_CHILD: {
+        HORIZONTAL_TAB_LIST_CHILD: {
           borderColor: 'colorBorderDestructive',
         },
-        TAB_LIST_VERTICAL: {
-          borderColor: 'colorBorderDestructive',
+        HORIZONTAL_TAB_PANELS: {
           marginX: 'space100',
+          borderStyle: 'solid',
+          borderWidth: 'borderWidth30',
+          borderColor: 'colorBorderPrimaryWeak',
         },
-        TAB_LIST_VERTICAL_CHILD: {
+        HORIZONTAL_TAB_PANEL: {
+          borderStyle: 'solid',
+          borderWidth: 'borderWidth30',
+          borderColor: 'colorBorderDestructiveWeak',
+          marginY: 'space20',
+        },
+      }}
+    >
+      <Tabs selectedId={selectedId} baseId="horizontal-tabs-example">
+        <TabList aria-label="LGBTQ+ Projects">
+          <Tab>Inside Out</Tab>
+          <Tab>Transgender District</Tab>
+          <Tab id={selectedId}>Audre Lorde Project</Tab>
+          <Tab disabled>Coming soon...</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Inside Out
+            </Heading>
+            <Paragraph>
+              Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
+              Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
+              youth in the community and working to make the community safer and more accepting of gender and sexual
+              orientation diversity.
+            </Paragraph>
+            <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
+          </TabPanel>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Transgender District
+            </Heading>
+            <Paragraph>
+              The mission of the Transgender District is to create an urban environment that fosters the rich history,
+              culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
+              neighborhood. The transgender district aims to stabilize and economically empower the transgender
+              community through ownership of homes, businesses, historic and cultural sites, and safe community spaces.
+            </Paragraph>
+            <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
+          </TabPanel>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Audre Lorde Project
+            </Heading>
+            <Paragraph>
+              The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People of
+              Color center for community organizing, focusing on the New York City area. Through mobilization, education
+              and capacity-building, they work for community wellness and progressive social and economic justice.
+              Committed to struggling across differences, they seek to responsibly reflect, represent and serve their
+              various communities.
+            </Paragraph>
+            <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </CustomizationProvider>
+  );
+};
+
+export const CustomVerticalTabs: React.FC = () => {
+  const currentTheme = useTheme();
+  const selectedId = useUID();
+
+  return (
+    <CustomizationProvider
+      theme={currentTheme}
+      elements={{
+        VERTICAL_TABS: {
+          margin: 'space100',
+          padding: 'space100',
+          borderStyle: 'solid',
+          borderWidth: 'borderWidth30',
+          borderColor: 'colorBorderPrimary',
+        },
+        VERTICAL_TAB: {
+          fontFamily: 'fontFamilyCode',
+        },
+        VERTICAL_TAB_LIST: {
+          borderColor: 'colorBorderDestructive',
+          marginY: 'space100',
+        },
+        VERTICAL_TAB_LIST_CHILD: {
           borderColor: 'colorBorderDestructive',
         },
       }}
     >
-      <Stack orientation="vertical" spacing="space150">
-        <Tabs selectedId={selectedId} baseId="horizontal-tabs-example">
-          <TabList element="TAB_LIST_HORIZONTAL" aria-label="LGBTQ+ Projects">
-            <Tab>Inside Out</Tab>
-            <Tab>Transgender District</Tab>
-            <Tab id={selectedId}>Audre Lorde Project</Tab>
-            <Tab disabled>Coming soon...</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Inside Out
-              </Heading>
-              <Paragraph>
-                Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
-                Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
-                youth in the community and working to make the community safer and more accepting of gender and sexual
-                orientation diversity.
-              </Paragraph>
-              <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
-            </TabPanel>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Transgender District
-              </Heading>
-              <Paragraph>
-                The mission of the Transgender District is to create an urban environment that fosters the rich history,
-                culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
-                neighborhood. The transgender district aims to stabilize and economically empower the transgender
-                community through ownership of homes, businesses, historic and cultural sites, and safe community
-                spaces.
-              </Paragraph>
-              <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
-            </TabPanel>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Audre Lorde Project
-              </Heading>
-              <Paragraph>
-                The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People
-                of Color center for community organizing, focusing on the New York City area. Through mobilization,
-                education and capacity-building, they work for community wellness and progressive social and economic
-                justice. Committed to struggling across differences, they seek to responsibly reflect, represent and
-                serve their various communities.
-              </Paragraph>
-              <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-
-        <Separator orientation="horizontal" />
-
-        <Tabs orientation="vertical" selectedId={selectedId} baseId="vertical-tabs-example">
-          <TabList element="TAB_LIST_VERTICAL" aria-label="LGBTQ+ Projects">
-            <Tab id={selectedId}>Inside Out</Tab>
-            <Tab>Transgender District</Tab>
-            <Tab>Audre Lorde Project</Tab>
-            <Tab disabled>Coming soon...</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Inside Out
-              </Heading>
-              <Paragraph>
-                Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
-                Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
-                youth in the community and working to make the community safer and more accepting of gender and sexual
-                orientation diversity.
-              </Paragraph>
-              <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
-            </TabPanel>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Transgender District
-              </Heading>
-              <Paragraph>
-                The mission of the Transgender District is to create an urban environment that fosters the rich history,
-                culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
-                neighborhood. The transgender district aims to stabilize and economically empower the transgender
-                community through ownership of homes, businesses, historic and cultural sites, and safe community
-                spaces.
-              </Paragraph>
-              <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
-            </TabPanel>
-            <TabPanel>
-              <Heading as="h2" variant="heading20">
-                Audre Lorde Project
-              </Heading>
-              <Paragraph>
-                The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People
-                of Color center for community organizing, focusing on the New York City area. Through mobilization,
-                education and capacity-building, they work for community wellness and progressive social and economic
-                justice. Committed to struggling across differences, they seek to responsibly reflect, represent and
-                serve their various communities.
-              </Paragraph>
-              <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      </Stack>
+      <Tabs orientation="vertical" selectedId={selectedId} baseId="vertical-tabs-example">
+        <TabList aria-label="LGBTQ+ Projects">
+          <Tab id={selectedId}>Inside Out</Tab>
+          <Tab>Transgender District</Tab>
+          <Tab>Audre Lorde Project</Tab>
+          <Tab disabled>Coming soon...</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Inside Out
+            </Heading>
+            <Paragraph>
+              Inside Out empowers, educates, and advocates for LGBTQ+ of youth from the Pikes Peak Region in Southern
+              Colorado. Inside Out does this by creating safe spaces, support systems and teaching life skills to all
+              youth in the community and working to make the community safer and more accepting of gender and sexual
+              orientation diversity.
+            </Paragraph>
+            <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
+          </TabPanel>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Transgender District
+            </Heading>
+            <Paragraph>
+              The mission of the Transgender District is to create an urban environment that fosters the rich history,
+              culture, legacy, and empowerment of transgender people and its deep roots in the southeastern Tenderloin
+              neighborhood. The transgender district aims to stabilize and economically empower the transgender
+              community through ownership of homes, businesses, historic and cultural sites, and safe community spaces.
+            </Paragraph>
+            <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
+          </TabPanel>
+          <TabPanel>
+            <Heading as="h2" variant="heading20">
+              Audre Lorde Project
+            </Heading>
+            <Paragraph>
+              The Audre Lorde Project is a Lesbian, Gay, Bisexual, Two Spirit, Trans and Gender Non Conforming People of
+              Color center for community organizing, focusing on the New York City area. Through mobilization, education
+              and capacity-building, they work for community wellness and progressive social and economic justice.
+              Committed to struggling across differences, they seek to responsibly reflect, represent and serve their
+              various communities.
+            </Paragraph>
+            <Anchor href="https://alp.org/">Support The Audre Lorde Project</Anchor>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </CustomizationProvider>
   );
 };

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -244,12 +244,6 @@ CenterAlignTabTest.story = {
   name: 'Testing Center Alignment',
 };
 
-// eslint-disable-next-line import/no-default-export
-export default {
-  title: 'Components/Tabs',
-  component: Tabs,
-};
-
 export const CustomHorizontalTabs: React.FC = () => {
   const currentTheme = useTheme();
   const selectedId = useUID();
@@ -438,4 +432,10 @@ export const CustomVerticalTabs: React.FC = () => {
       </Tabs>
     </CustomizationProvider>
   );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Components/Tabs',
+  component: Tabs,
 };

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -293,7 +293,7 @@ export const CustomHorizontalTabs: React.FC = () => {
         HORIZONTAL_OTHER_TAB: {
           paddingLeft: 'space100',
           color: 'colorText',
-          backgroundColor: 'colorBackgroundAvailable',
+          backgroundColor: 'colorBackgroundNeutralWeakest',
         },
         HORIZONTAL_DIFFERENT_PANEL: {
           fontWeight: 'fontWeightBold',
@@ -374,7 +374,7 @@ export const CustomVerticalTabs: React.FC = () => {
           fontSize: 'fontSize10',
         },
         VERTICAL_CUSTOM_TAB: {
-          backgroundColor: 'colorBackgroundAvailable',
+          backgroundColor: 'colorBackgroundNeutralWeakest',
         },
         VERTICAL_OTHER_TAB: {
           color: 'colorText',
@@ -469,7 +469,7 @@ export const CustomFittedTabs: React.FC = () => {
           fontSize: 'fontSize10',
         },
         HORIZONTAL_CUSTOM_TAB: {
-          backgroundColor: 'colorBackgroundAvailable',
+          backgroundColor: 'colorBackgroundNeutralWeakest',
           fontFamily: 'fontFamilyCode',
         },
         HORIZONTAL_OTHER_TAB: {

--- a/packages/paste-core/components/tabs/stories/index.stories.tsx
+++ b/packages/paste-core/components/tabs/stories/index.stories.tsx
@@ -287,13 +287,24 @@ export const CustomHorizontalTabs: React.FC = () => {
           borderColor: 'colorBorderDestructiveWeak',
           marginY: 'space20',
         },
+        HORIZONTAL_CUSTOM_TAB: {
+          color: 'colorTextWarning',
+        },
+        HORIZONTAL_OTHER_TAB: {
+          color: 'colorText',
+        },
+        HORIZONTAL_DIFFERENT_PANEL: {
+          fontWeight: 'fontWeightBold',
+        },
       }}
     >
       <Tabs selectedId={selectedId} baseId="horizontal-tabs-example">
         <TabList aria-label="LGBTQ+ Projects">
-          <Tab>Inside Out</Tab>
+          <Tab element="CUSTOM_TAB">Inside Out</Tab>
           <Tab>Transgender District</Tab>
-          <Tab id={selectedId}>Audre Lorde Project</Tab>
+          <Tab element="OTHER_TAB" id={selectedId}>
+            Audre Lorde Project
+          </Tab>
           <Tab disabled>Coming soon...</Tab>
         </TabList>
         <TabPanels>
@@ -309,7 +320,7 @@ export const CustomHorizontalTabs: React.FC = () => {
             </Paragraph>
             <Anchor href="https://insideoutys.org/">Support Inside Out</Anchor>
           </TabPanel>
-          <TabPanel>
+          <TabPanel element="DIFFERENT_PANEL">
             <Heading as="h2" variant="heading20">
               Transgender District
             </Heading>
@@ -358,6 +369,12 @@ export const CustomVerticalTabs: React.FC = () => {
         VERTICAL_TAB: {
           fontFamily: 'fontFamilyCode',
         },
+        VERTICAL_CUSTOM_TAB: {
+          color: 'colorTextWarning',
+        },
+        VERTICAL_OTHER_TAB: {
+          color: 'colorText',
+        },
         VERTICAL_TAB_LIST: {
           borderColor: 'colorBorderDestructive',
           marginY: 'space100',
@@ -365,14 +382,19 @@ export const CustomVerticalTabs: React.FC = () => {
         VERTICAL_TAB_LIST_CHILD: {
           borderColor: 'colorBorderDestructive',
         },
+        VERTICAL_DIFFERENT_PANEL: {
+          fontWeight: 'fontWeightBold',
+        },
       }}
     >
       <Tabs orientation="vertical" selectedId={selectedId} baseId="vertical-tabs-example">
         <TabList aria-label="LGBTQ+ Projects">
           <Tab id={selectedId}>Inside Out</Tab>
-          <Tab>Transgender District</Tab>
+          <Tab element="CUSTOM_TAB">Transgender District</Tab>
           <Tab>Audre Lorde Project</Tab>
-          <Tab disabled>Coming soon...</Tab>
+          <Tab element="OTHER_TAB" disabled>
+            Coming soon...
+          </Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -399,7 +421,7 @@ export const CustomVerticalTabs: React.FC = () => {
             </Paragraph>
             <Anchor href="https://www.transgenderdistrictsf.com/">Support The Transgender District</Anchor>
           </TabPanel>
-          <TabPanel>
+          <TabPanel element="DIFFERENT_PANEL">
             <Heading as="h2" variant="heading20">
               Audre Lorde Project
             </Heading>


### PR DESCRIPTION
## Description
Add `element` to the tab package components, to allow for customization.

### Summary of changes
- [x] add `element` to the table API (defaults to name of components, allow string values)
- [x] Create tests that ensure the defined custom element API remains.
- [x] Create tests that ensure each tagged element merges the custom styles.
- [x] Add stories with customization for VRT

