### PR TITLE
feat(disclosure): add element customization

### DIFF
--- a/.changeset/rotten-parrots-hug.md
+++ b/.changeset/rotten-parrots-hug.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/card': patch
+'@twilio-paste/core': patch
+---
+
+[Card]: updated the props to include variant to help with customizing dependent components.

--- a/.changeset/tame-rabbits-collect.md
+++ b/.changeset/tame-rabbits-collect.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/disclosure': minor
+'@twilio-paste/core': minor
+---
+
+[Disclosure] Enable Component to respect element customizations set on the customization provider. Component now enables setting an element name on the underlying HTML element and checks the emotion theme object to determine whether it should merge in custom styles to the ones set by the component author.

--- a/packages/paste-core/components/card/src/index.tsx
+++ b/packages/paste-core/components/card/src/index.tsx
@@ -6,7 +6,10 @@ import type {PaddingProps} from '@twilio-paste/style-props';
 import {isPaddingTokenProp} from '@twilio-paste/style-props';
 
 /** element identifier from BoxProps for customization */
-export interface CardProps extends React.HTMLAttributes<HTMLElement>, PaddingProps, Pick<BoxProps, 'element'> {}
+export interface CardProps
+  extends React.HTMLAttributes<HTMLElement>,
+    PaddingProps,
+    Pick<BoxProps, 'element' | 'variant'> {}
 
 const Card = React.forwardRef<HTMLElement, CardProps>(
   (

--- a/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
+++ b/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
@@ -232,6 +232,8 @@ describe('Disclosure', () => {
       render(
         <CustomizationProvider
           baseTheme="default"
+          // @ts-expect-error global test variable
+          theme={TestTheme}
           elements={{
             DISCLOSURE: {padding: 'space100'},
             DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
@@ -256,6 +258,8 @@ describe('Disclosure', () => {
       render(
         <CustomizationProvider
           baseTheme="default"
+          // @ts-expect-error global test variable
+          theme={TestTheme}
           elements={{
             MY_DISCLOSURE: {padding: 'space100'},
             MY_DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},

--- a/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
+++ b/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
+import {CustomizationProvider} from '@twilio-paste/customization';
+import {matchers} from 'jest-emotion';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Disclosure, DisclosureContent, DisclosureHeading, useDisclosureState} from '../src';
 import type {DisclosureHeadingProps, DisclosureProps, DisclosureStateReturn} from '../src';
 import {getIconHoverStyles} from '../src/utils';
+
+expect.extend(matchers);
 
 const MockDisclosure: React.FC<{
   visible?: DisclosureProps['visible'];
@@ -21,6 +25,33 @@ const MockDisclosure: React.FC<{
         <DisclosureContent data-testid="disclosure">Disclosure content</DisclosureContent>
       </Disclosure>
     </Theme.Provider>
+  );
+};
+
+const MockDefaultElementDisclosure: React.FC = () => {
+  return (
+    <Disclosure data-testid="disclosure">
+      <DisclosureHeading as="h1" data-testid="disclosure-heading" variant="heading10">
+        Clickable heading
+      </DisclosureHeading>
+      <DisclosureContent data-testid="disclosure-content">Disclosure content</DisclosureContent>
+    </Disclosure>
+  );
+};
+
+const MockCustomElementDisclosure: React.FC = () => {
+  return (
+    <Disclosure element="MY_DISCLOSURE" data-testid="disclosure" visible>
+      <DisclosureHeading element="MY_DISCLOSURE_HEADING" as="h2" variant="heading20" data-testid="disclosure-heading">
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam.
+      </DisclosureHeading>
+      <DisclosureContent element="MY_DISCLOSURE_CONTENT" data-testid="disclosure-content">
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac cursus
+        commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a
+        pharetra augue.
+      </DisclosureContent>
+    </Disclosure>
   );
 };
 
@@ -161,6 +192,87 @@ describe('Disclosure', () => {
       expect(renderedDisclosureButton.getAttribute('aria-expanded')).toEqual('true');
       fireEvent.click(renderedDisclosureButton);
       expect(renderedDisclosureButton.getAttribute('aria-expanded')).toEqual('false');
+    });
+  });
+
+  describe('Customization', () => {
+    it('should set an element data attribute for Disclosure components', () => {
+      render(
+        <Theme.Provider theme="default">
+          <MockDefaultElementDisclosure />
+        </Theme.Provider>
+      );
+
+      const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosure = screen.getByTestId('disclosure');
+      const renderedDisclosureContent = screen.getByTestId('disclosure-content');
+
+      expect(renderedDisclosure.getAttribute('data-paste-element')).toEqual('DISCLOSURE');
+      expect(renderedDisclosureHeading.getAttribute('data-paste-element')).toEqual('DISCLOSURE_HEADING');
+      expect(renderedDisclosureContent.getAttribute('data-paste-element')).toEqual('DISCLOSURE_CONTENT');
+    });
+
+    it('should set a custom element data attribute for custom named Disclosure components', () => {
+      render(
+        <Theme.Provider theme="default">
+          <MockCustomElementDisclosure />
+        </Theme.Provider>
+      );
+
+      const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosure = screen.getByTestId('disclosure');
+      const renderedDisclosureContent = screen.getByTestId('disclosure-content');
+
+      expect(renderedDisclosure.getAttribute('data-paste-element')).toEqual('MY_DISCLOSURE');
+      expect(renderedDisclosureHeading.getAttribute('data-paste-element')).toEqual('MY_DISCLOSURE_HEADING');
+      expect(renderedDisclosureContent.getAttribute('data-paste-element')).toEqual('MY_DISCLOSURE_CONTENT');
+    });
+
+    it('should add custom styles to Disclosure components', () => {
+      render(
+        <CustomizationProvider
+          baseTheme="default"
+          elements={{
+            DISCLOSURE: {padding: 'space100'},
+            DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
+            DISCLOSURE_HEADING: {color: 'colorTextWeakest', backgroundColor: 'colorBackgroundDestructiveStrong'},
+          }}
+        >
+          <MockDefaultElementDisclosure />
+        </CustomizationProvider>
+      );
+
+      const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosure = screen.getByTestId('disclosure');
+      const renderedDisclosureContent = screen.getByTestId('disclosure-content');
+
+      expect(renderedDisclosure).toHaveStyleRule('padding', '2.25rem');
+      expect(renderedDisclosureHeading).toHaveStyleRule('color', 'rgb(255,255,255)');
+      expect(renderedDisclosureHeading).toHaveStyleRule('background-color', 'rgb(117,12,12)');
+      expect(renderedDisclosureContent).toHaveStyleRule('color', 'rgb(173,17,17)');
+    });
+
+    it('should add custom styles to custom named Disclosure components', () => {
+      render(
+        <CustomizationProvider
+          baseTheme="default"
+          elements={{
+            MY_DISCLOSURE: {padding: 'space100'},
+            MY_DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
+            MY_DISCLOSURE_HEADING: {color: 'colorTextWeakest', backgroundColor: 'colorBackgroundDestructiveStrong'},
+          }}
+        >
+          <MockCustomElementDisclosure />
+        </CustomizationProvider>
+      );
+      const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosure = screen.getByTestId('disclosure');
+      const renderedDisclosureContent = screen.getByTestId('disclosure-content');
+
+      expect(renderedDisclosure).toHaveStyleRule('padding', '2.25rem');
+      expect(renderedDisclosureHeading).toHaveStyleRule('color', 'rgb(255,255,255)');
+      expect(renderedDisclosureHeading).toHaveStyleRule('background-color', 'rgb(117,12,12)');
+      expect(renderedDisclosureContent).toHaveStyleRule('color', 'rgb(173,17,17)');
     });
   });
 

--- a/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
+++ b/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
@@ -238,6 +238,7 @@ describe('Disclosure', () => {
             DISCLOSURE: {padding: 'space100'},
             DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
             DISCLOSURE_HEADING: {color: 'colorTextWeakest', backgroundColor: 'colorBackgroundDestructiveStrong'},
+            DISCLOSURE_HEADING_ICON: {color: 'colorTextIconError'},
           }}
         >
           <MockDefaultElementDisclosure />
@@ -245,12 +246,14 @@ describe('Disclosure', () => {
       );
 
       const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosureHeadingIcon = renderedDisclosureHeading.firstChild;
       const renderedDisclosure = screen.getByTestId('disclosure');
       const renderedDisclosureContent = screen.getByTestId('disclosure-content');
 
       expect(renderedDisclosure).toHaveStyleRule('padding', '2.25rem');
       expect(renderedDisclosureHeading).toHaveStyleRule('color', 'rgb(255,255,255)');
       expect(renderedDisclosureHeading).toHaveStyleRule('background-color', 'rgb(117,12,12)');
+      expect(renderedDisclosureHeadingIcon).toHaveStyleRule('color', 'rgb(214,31,31)');
       expect(renderedDisclosureContent).toHaveStyleRule('color', 'rgb(173,17,17)');
     });
 
@@ -264,18 +267,21 @@ describe('Disclosure', () => {
             MY_DISCLOSURE: {padding: 'space100'},
             MY_DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
             MY_DISCLOSURE_HEADING: {color: 'colorTextWeakest', backgroundColor: 'colorBackgroundDestructiveStrong'},
+            MY_DISCLOSURE_HEADING_ICON: {color: 'colorTextIconError'},
           }}
         >
           <MockCustomElementDisclosure />
         </CustomizationProvider>
       );
       const renderedDisclosureHeading = screen.getByTestId('disclosure-heading');
+      const renderedDisclosureHeadingIcon = renderedDisclosureHeading.firstChild;
       const renderedDisclosure = screen.getByTestId('disclosure');
       const renderedDisclosureContent = screen.getByTestId('disclosure-content');
 
       expect(renderedDisclosure).toHaveStyleRule('padding', '2.25rem');
       expect(renderedDisclosureHeading).toHaveStyleRule('color', 'rgb(255,255,255)');
       expect(renderedDisclosureHeading).toHaveStyleRule('background-color', 'rgb(117,12,12)');
+      expect(renderedDisclosureHeadingIcon).toHaveStyleRule('color', 'rgb(214,31,31)');
       expect(renderedDisclosureContent).toHaveStyleRule('color', 'rgb(173,17,17)');
     });
   });

--- a/packages/paste-core/components/disclosure/src/Disclosure.tsx
+++ b/packages/paste-core/components/disclosure/src/Disclosure.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {useDisclosurePrimitiveState} from '@twilio-paste/disclosure-primitive';
-import {Box} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
 import {DisclosureContext} from './DisclosureContext';
 import type {DisclosureProps} from './types';
 import {DisclosurePropTypes} from './PropTypes';
 
 const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>(
-  ({children, variant = 'default', state, ...props}, ref) => {
+  ({children, element = 'DISCLOSURE', variant = 'default', state, ...props}, ref) => {
     const disclosure = state || useDisclosurePrimitiveState({animated: true, ...props});
     const disclosureContext = {
       disclosure,
@@ -17,7 +17,7 @@ const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>(
     if (variant === 'contained') {
       return (
         <DisclosureContext.Provider value={disclosureContext}>
-          <Card padding="space0" ref={ref}>
+          <Card {...props} variant={variant} element={element} padding="space0" ref={ref}>
             {children}
           </Card>
         </DisclosureContext.Provider>
@@ -26,7 +26,9 @@ const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>(
 
     return (
       <DisclosureContext.Provider value={disclosureContext}>
-        <Box ref={ref}>{children}</Box>
+        <Box {...safelySpreadBoxProps(props)} variant={variant} element={element} ref={ref}>
+          {children}
+        </Box>
       </DisclosureContext.Provider>
     );
   }

--- a/packages/paste-core/components/disclosure/src/DisclosureContent.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureContent.tsx
@@ -9,7 +9,7 @@ import {DisclosureContentPropTypes} from './PropTypes';
 export const AnimatedDisclosureContent = animated(Box);
 
 const DisclosureContent = React.forwardRef<HTMLDivElement, DisclosureContentProps>(
-  ({children, visible, ...props}, ref) => {
+  ({children, element = 'DISCLOSURE_CONTENT', visible, ...props}, ref) => {
     const {disclosure} = React.useContext(DisclosureContext);
     const {opacity} = useSpring({
       opacity: disclosure.visible ? 1 : 0,
@@ -27,6 +27,7 @@ const DisclosureContent = React.forwardRef<HTMLDivElement, DisclosureContentProp
         {...disclosure}
         {...safelySpreadBoxProps(props)}
         as={AnimatedDisclosureContent}
+        element={element}
         backgroundColor="colorBackgroundBody"
         padding="space50"
         ref={ref}

--- a/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
@@ -60,6 +60,7 @@ const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosur
         >
           <Box
             as="span"
+            element={`${element}_ICON`}
             display="flex"
             height={IconSizeFromHeading[variant] || 'sizeIcon20'}
             width={IconSizeFromHeading[variant] || 'sizeIcon20'}

--- a/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
+++ b/packages/paste-core/components/disclosure/src/DisclosureHeading.tsx
@@ -11,7 +11,10 @@ import {useHover, getIconHoverStyles} from './utils';
 import {IconSizeFromHeading} from './constants';
 
 const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosureHeadingProps>(
-  ({children, marginBottom, renderAs, disclosureVariant, customDisabled, customFocusable, variant, ...props}, ref) => {
+  (
+    {children, element, marginBottom, renderAs, disclosureVariant, customDisabled, customFocusable, variant, ...props},
+    ref
+  ) => {
     const theme = useTheme();
     const hoverRef = React.useRef(null);
     const isHovered = useHover(hoverRef);
@@ -35,6 +38,7 @@ const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosur
           borderBottomRightRadius={bottomBorderRadius}
           cursor="pointer"
           display="flex"
+          element={element}
           outline="none"
           padding="space30"
           position="relative"
@@ -74,7 +78,14 @@ const StyledDisclosureHeading = React.forwardRef<HTMLDivElement, StyledDisclosur
   }
 );
 
-const DisclosureHeading: React.FC<DisclosureHeadingProps> = ({children, as, disabled, focusable, ...props}) => {
+const DisclosureHeading: React.FC<DisclosureHeadingProps> = ({
+  children,
+  as,
+  element = 'DISCLOSURE_HEADING',
+  disabled,
+  focusable,
+  ...props
+}) => {
   const {disclosure, variant} = React.useContext(DisclosureContext);
   return (
     <DisclosurePrimitive
@@ -85,6 +96,7 @@ const DisclosureHeading: React.FC<DisclosureHeadingProps> = ({children, as, disa
       customFocusable={focusable}
       disabled={disabled}
       disclosureVariant={variant}
+      element={element}
       focusable={focusable}
       renderAs={as}
     >

--- a/packages/paste-core/components/disclosure/src/PropTypes.ts
+++ b/packages/paste-core/components/disclosure/src/PropTypes.ts
@@ -3,9 +3,11 @@ import type {DisclosureVariants} from './types';
 
 export const DisclosurePropTypes = {
   children: PropTypes.node.isRequired,
+  element: PropTypes.string,
   variant: PropTypes.oneOf(['default', 'contained'] as DisclosureVariants[]),
 };
 
 export const DisclosureContentPropTypes = {
   children: PropTypes.node.isRequired,
+  element: PropTypes.string,
 };

--- a/packages/paste-core/components/disclosure/src/types.ts
+++ b/packages/paste-core/components/disclosure/src/types.ts
@@ -40,6 +40,7 @@ export interface StyledDisclosureHeadingProps extends Omit<DisclosureHeadingProp
   customDisabled?: boolean;
   customFocusable?: boolean;
   disclosureVariant: DisclosureVariants;
+  element: string;
 }
 
 export interface DisclosureContentProps

--- a/packages/paste-core/components/disclosure/src/types.ts
+++ b/packages/paste-core/components/disclosure/src/types.ts
@@ -1,4 +1,4 @@
-import type {BoxStyleProps} from '@twilio-paste/box';
+import type {BoxProps, BoxStyleProps} from '@twilio-paste/box';
 import type {HeadingProps} from '@twilio-paste/heading';
 import type {
   DisclosurePrimitiveInitialState,
@@ -20,27 +20,30 @@ export interface DisclosureStateReturn extends DisclosurePrimitveStateReturn {
 
 export type {DisclosurePrimitiveInitialState as DisclosureInitialState};
 
-export interface DisclosureProps extends DisclosurePrimitiveInitialState {
+export interface DisclosureProps extends DisclosurePrimitiveInitialState, Pick<BoxProps, 'element'> {
   children: NonNullable<React.ReactNode>;
   state?: DisclosureStateReturn;
   variant?: DisclosureVariants;
 }
 
 export interface DisclosureHeadingProps
-  extends Omit<DisclosurePrimitiveProps, 'baseId' | 'toggle' | keyof BoxStyleProps> {
+  extends Omit<DisclosurePrimitiveProps, 'baseId' | 'toggle' | keyof BoxStyleProps>,
+    Pick<BoxProps, 'element'> {
   children: NonNullable<React.ReactNode>;
   as: HeadingProps['as'];
   marginBottom?: HeadingProps['marginBottom'];
   variant: HeadingProps['variant'];
 }
 
-export interface StyledDisclosureHeadingProps extends Omit<DisclosureHeadingProps, 'as'> {
+export interface StyledDisclosureHeadingProps extends Omit<DisclosureHeadingProps, 'as'>, Pick<BoxProps, 'element'> {
   renderAs: HeadingProps['as'];
   customDisabled?: boolean;
   customFocusable?: boolean;
   disclosureVariant: DisclosureVariants;
 }
 
-export interface DisclosureContentProps extends Omit<DisclosurePrimitiveContentProps, keyof BoxStyleProps> {
+export interface DisclosureContentProps
+  extends Omit<DisclosurePrimitiveContentProps, keyof BoxStyleProps>,
+    Pick<BoxProps, 'element'> {
   children: NonNullable<React.ReactNode>;
 }

--- a/packages/paste-core/components/disclosure/stories/index.stories.tsx
+++ b/packages/paste-core/components/disclosure/stories/index.stories.tsx
@@ -335,12 +335,15 @@ export const Customization = (): React.ReactNode => {
     <CustomizationProvider
       baseTheme="default"
       elements={{
-        DISCLOSURE: {padding: 'space100', variants: {contained: {borderColor: 'colorBorderError'}}},
+        DISCLOSURE: {padding: 'space30', variants: {contained: {borderColor: 'colorBorderError'}}},
         DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
         DISCLOSURE_HEADING: {
-          color: 'colorTextNeutral',
-          backgroundColor: 'colorBackgroundDestructiveWeakest',
-          ':hover': {backgroundColor: 'colorBackgroundNeutralWeakest'},
+          color: 'colorText',
+          backgroundColor: 'colorBackgroundErrorWeakest',
+          ':hover': {backgroundColor: 'colorBackgroundErrorWeak'},
+        },
+        DISCLOSURE_HEADING_ICON: {
+          color: 'colorTextIconError',
         },
       }}
     >

--- a/packages/paste-core/components/disclosure/stories/index.stories.tsx
+++ b/packages/paste-core/components/disclosure/stories/index.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CustomizationProvider} from '@twilio-paste/customization';
 import {Box} from '@twilio-paste/box';
 import {Stack} from '@twilio-paste/stack';
 import {Truncate} from '@twilio-paste/truncate';
@@ -327,4 +328,72 @@ export const StateHook = (): React.ReactNode => {
 
 StateHook.story = {
   name: 'State hook',
+};
+
+export const Customization = (): React.ReactNode => {
+  return (
+    <CustomizationProvider
+      baseTheme="default"
+      elements={{
+        DISCLOSURE: {padding: 'space100', variants: {contained: {borderColor: 'colorBorderError'}}},
+        DISCLOSURE_CONTENT: {color: 'colorTextErrorStrong'},
+        DISCLOSURE_HEADING: {
+          color: 'colorTextNeutral',
+          backgroundColor: 'colorBackgroundDestructiveWeakest',
+          ':hover': {backgroundColor: 'colorBackgroundNeutralWeakest'},
+        },
+      }}
+    >
+      <Stack orientation="vertical" spacing="space70">
+        <Disclosure visible>
+          <DisclosureHeading as="h2" variant="heading20">
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam.
+          </DisclosureHeading>
+          <DisclosureContent>
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae
+            elit libero, a pharetra augue.
+          </DisclosureContent>
+        </Disclosure>
+        <Disclosure>
+          <DisclosureHeading as="h2" variant="heading20">
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam.
+            <br />
+            Ut fermentum massa justo sit amet risus.
+          </DisclosureHeading>
+          <DisclosureContent>
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae
+            elit libero, a pharetra augue.
+          </DisclosureContent>
+        </Disclosure>
+        <Disclosure visible variant="contained">
+          <DisclosureHeading as="h2" variant="heading20">
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam.
+          </DisclosureHeading>
+          <DisclosureContent>
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae
+            elit libero, a pharetra augue.
+          </DisclosureContent>
+        </Disclosure>
+        <Disclosure variant="contained">
+          <DisclosureHeading as="h2" variant="heading20">
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam.
+            <br />
+            Ut fermentum massa justo sit amet risus.
+          </DisclosureHeading>
+          <DisclosureContent>
+            Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae
+            elit libero, a pharetra augue.
+          </DisclosureContent>
+        </Disclosure>
+      </Stack>
+    </CustomizationProvider>
+  );
 };


### PR DESCRIPTION
Added customization capability to the disclosure package. Lingering question of why testing for backgroundColor doesn't seem to be working, which is commented out of the test file. 
