### PR TITLE
docs(website): add keyboard interaction notes

### DIFF
--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -104,6 +104,13 @@ Combobox allows a user to make a selection from a styled list box of options. Ea
 _e.g._ text paired with an icon. It can also be set up with autocomplete/typeahead functionality so users can easily find a
 specific option.
 
+### Accessibility
+
+When the user is focused on a Combobox, the following keyboard interactions apply:
+
+- Up and down arrows move the user between the options
+- Enter selects the currently active option
+
 ## Examples
 
 #### Basic Combobox

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -103,6 +103,14 @@ Each menu item can only perform a single action.
   </CalloutText>
 </Callout>
 
+### Accessibility
+
+When the user is focused on a menu trigger, the following keyboard interactions apply:
+
+- Enter and space open the menu and select the current menu item
+- Up and down arrows move the user between the menu items
+  - Disabled menu items, separators, and group labels are never focused
+
 ## Examples
 
 ### Basic menu

--- a/packages/paste-website/src/pages/components/radio-group/index.mdx
+++ b/packages/paste-website/src/pages/components/radio-group/index.mdx
@@ -112,6 +112,7 @@ Radio groups should:
   - Display a required indicator
   - Ensure the radio label text includes wording that successfully describes the requirement to the user that they should select the radio
 - When in an error state, display an inline error message below the offending radio group that clearly describes the error.
+- Radio groups act as a single tab stop. When focused on a radio, use the arrow keys to navigate to the other radios.
 
 ## Layout Examples
 

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -94,6 +94,14 @@ export const pageQuery = graphql`
 
 The Tabs component allows a user to flip through multiple views within the same page.
 
+### Accessibility
+
+When the user is focused on a tab in a TabList, the following keyboard interactions apply:
+
+- Right and left arrow move the user between tabs and opens the currently focused tab's panel
+  - If the tabs are vertical, up and down arrows move between tabs instead of right and left
+  - If the currently focused tab is disabled, the tab panel does not open
+
 ## Examples
 
 ### Horizontal Tabs

--- a/packages/paste-website/src/pages/components/tooltip/index.mdx
+++ b/packages/paste-website/src/pages/components/tooltip/index.mdx
@@ -108,6 +108,8 @@ If your tooltip wraps a natively focusable HTML element that includes only an ic
 give the icon a title. The title of the icon should be the accessible name for the button action, like "Delete phone number". The tooltip provides the additional context, like "You can delete phone numbers every 7 days".
 This ensures the icon and tooltip are accessible to screen readers. Refer to the [focusable element example](#focusable-element) for implementation.
 
+When the user focuses an element with a tooltip, their focus stays on the element. Focus never goes inside the tooltip.
+
 ## Examples
 
 ### Basic Tooltip


### PR DESCRIPTION
Adds notes on how to use the following components with a keyboard:
* Combobox
* Menu
* RadioGroup
* Tabs
* Tooltip

Components that already have notes:
* FormPillGroup
* Modal
* AlertDialog
* Popover

Won't add because we rely on the browser:
* Timepicker
* Datepicker

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
