### PR TITLE
chore(jest): add jest emotion matcher to jest global config

### DIFF
--- a/.jest/setupFilesAfterEnv.js
+++ b/.jest/setupFilesAfterEnv.js
@@ -1,8 +1,10 @@
 const Enzyme = require('enzyme');
 const TestingLibrary = require('@testing-library/react');
+const {matchers: jestEmotionMatchers} = require('jest-emotion');
 const Adapter = require('enzyme-adapter-react-16');
 require('@testing-library/jest-dom');
 const {toHaveNoViolations} = require('jest-axe');
 expect.extend(toHaveNoViolations);
+expect.extend(jestEmotionMatchers);
 TestingLibrary.configure({computedStyleSupportsPseudoElements: false});
 Enzyme.configure({adapter: new Adapter()});

--- a/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {AlertDialogWithTwoActions, DestructiveAlertDialog} from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('Alert Dialog', () => {
   it('Should render an alert dialog box', () => {

--- a/packages/paste-core/components/alert/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert/__tests__/index.spec.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import renderer from 'react-test-renderer';
 import {render, screen} from '@testing-library/react';
 import {ReactWrapper, mount} from 'enzyme';
-import {matchers} from 'jest-emotion';
+
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore
 import axe from '../../../../../.jest/axe-helper';
 import {Alert} from '../src';
-
-expect.extend(matchers);
 
 const onDismissMock: jest.Mock = jest.fn();
 

--- a/packages/paste-core/components/anchor/__tests__/anchor.test.tsx
+++ b/packages/paste-core/components/anchor/__tests__/anchor.test.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Anchor} from '../src';
-
-expect.extend(matchers);
 
 describe('Anchor', () => {
   it('should render an external anchor', () => {

--- a/packages/paste-core/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/paste-core/components/avatar/__tests__/avatar.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react';
 import {UserIcon} from '@twilio-paste/icons/esm/UserIcon';
 import {Box} from '@twilio-paste/box';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {matchers} from 'jest-emotion';
+
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Avatar} from '../src';
@@ -14,8 +14,6 @@ import {
   getComputedTokenNames,
   getInitialsFromName,
 } from '../src/utils';
-
-expect.extend(matchers);
 
 describe('Avatar', () => {
   describe('Utils', () => {

--- a/packages/paste-core/components/badge/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/badge/__tests__/index.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {render, fireEvent} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
-import {matchers} from 'jest-emotion';
 
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -11,8 +10,6 @@ import {Badge} from '../src';
 import type {NamedChild} from '../src/types';
 import {getVariantStyles, hasValidButtonVariantProps, hasValidAnchorVariantProps} from '../src/utils';
 import {useFocusableVariants, useResizeChildIcons} from '../src/hooks';
-
-expect.extend(matchers);
 
 describe('Badge', () => {
   describe('Utils', () => {

--- a/packages/paste-core/components/base-radio-checkbox/__tests__/base-radio-checkbox.test.tsx
+++ b/packages/paste-core/components/base-radio-checkbox/__tests__/base-radio-checkbox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {CheckboxCheckIcon} from '@twilio-paste/icons/esm/CheckboxCheckIcon';
@@ -9,8 +9,6 @@ import {
   BaseRadioCheckboxLabelText,
   BaseRadioCheckboxHelpText,
 } from '../src/BaseRadioCheckbox';
-
-expect.extend(matchers);
 
 describe('Base radio checkbox HTML attributes', () => {
   it('should set element data attribute on base radio checkbox components', () => {

--- a/packages/paste-core/components/breadcrumb/__tests__/breadcrumb.spec.tsx
+++ b/packages/paste-core/components/breadcrumb/__tests__/breadcrumb.spec.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Breadcrumb, BreadcrumbItem} from '../src';
-
-expect.extend(matchers);
 
 describe('Breadcrumb', () => {
   const BreadcrumbExample: React.FC = () => {

--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from 'react-dom';
 import {render as testRender} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
@@ -9,8 +9,6 @@ import {shallow, mount} from 'enzyme';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Button} from '../src';
-
-expect.extend(matchers);
 
 const NOOP = (): void => {};
 const HREF = 'https://twilio.paste.design';

--- a/packages/paste-core/components/button/__tests__/customization.test.tsx
+++ b/packages/paste-core/components/button/__tests__/customization.test.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {PasteCustomCSS} from '@twilio-paste/customization';
 import {AnyButton} from '../stories/customization.stories';
-
-expect.extend(matchers);
 
 const customButtonStyles = {
   backgroundColor: 'colorBackgroundBusy',

--- a/packages/paste-core/components/card/__test__/card.test.tsx
+++ b/packages/paste-core/components/card/__test__/card.test.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Card} from '../src';
-
-expect.extend(matchers);
 
 describe('Card', () => {
   it('should render', (): void => {

--- a/packages/paste-core/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/paste-core/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import {render} from 'react-dom';
-import {matchers} from 'jest-emotion';
+
 import {render as testRender, fireEvent, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {PasteCustomCSS} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Checkbox, CheckboxGroup} from '../src';
-
-expect.extend(matchers);
 
 const getCustomizationStyles = (element = 'CHECKBOX'): {[key: string]: PasteCustomCSS} => ({
   [`${element}_GROUP`]: {padding: 'space60'},

--- a/packages/paste-core/components/checkbox/__tests__/checkboxdisclaimer.test.tsx
+++ b/packages/paste-core/components/checkbox/__tests__/checkboxdisclaimer.test.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import {render} from 'react-dom';
-import {matchers} from 'jest-emotion';
+
 import {render as testRender} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {CheckboxDisclaimer} from '../src';
-
-expect.extend(matchers);
 
 const defaultProps = {
   id: 'foo',

--- a/packages/paste-core/components/combobox/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/combobox/__tests__/customization.spec.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
 import type {RenderOptions} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {PasteCustomCSS} from '@twilio-paste/customization';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {Text} from '@twilio-paste/text';
 import {Combobox} from '../src';
-
-expect.extend(matchers);
 
 const getStyles = (element = 'COMBOBOX'): {[key: string]: PasteCustomCSS} => ({
   [`${element}_WRAPPER`]: {backgroundColor: 'colorBackgroundDark', fontFamily: 'fontFamilyCode'},

--- a/packages/paste-core/components/data-grid/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/data-grid/__tests__/customization.spec.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {render} from '@testing-library/react';
 import {PlainDataGrid} from '../stories/components/PlainDataGrid';
 import {customElementStyles} from '../stories/components/CustomizableDataGrid';
-
-expect.extend(matchers);
 
 describe('Data Grid Customization', () => {
   it('can be customized generically', () => {

--- a/packages/paste-core/components/date-picker/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/date-picker/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {render, screen} from '@testing-library/react';
 // @ts-ignore typescript doesn't like js imports
@@ -12,8 +12,6 @@ import {
   InverseDatePicker,
   ReadonlyDatePicker,
 } from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('formatReturnDate()', () => {
   const TEST_DATE = '2021-02-14';

--- a/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
+++ b/packages/paste-core/components/disclosure/__tests__/disclosure.test.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {matchers} from 'jest-emotion';
+
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Disclosure, DisclosureContent, DisclosureHeading, useDisclosureState} from '../src';
 import type {DisclosureHeadingProps, DisclosureProps, DisclosureStateReturn} from '../src';
 import {getIconHoverStyles} from '../src/utils';
-
-expect.extend(matchers);
 
 const MockDisclosure: React.FC<{
   visible?: DisclosureProps['visible'];

--- a/packages/paste-core/components/display-pill-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/display-pill-group/__tests__/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import {render} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {DisplayPillGroup, DisplayPill} from '../src';
 import {Basic, CustomDisplayPillGroup} from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('DisplayPillGroup', () => {
   // Verifies that the correct aria attributes and semantics are met

--- a/packages/paste-core/components/form-pill-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/form-pill-group/__tests__/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import {render, fireEvent} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {useFormPillState, FormPillGroup, FormPill} from '../src';
 import {Basic, SelectableAndRemovable, CustomFormPillGroup} from '../stories/index.stories';
-
-expect.extend(matchers);
 
 const CustomElementFormPillGroup: React.FC = () => {
   const pillState = useFormPillState();

--- a/packages/paste-core/components/heading/__tests__/heading.test.tsx
+++ b/packages/paste-core/components/heading/__tests__/heading.test.tsx
@@ -2,12 +2,10 @@ import * as React from 'react';
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {matchers} from 'jest-emotion';
+
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Heading} from '../src';
-
-expect.extend(matchers);
 
 describe('Heading', () => {
   describe('Render', () => {

--- a/packages/paste-core/components/help-text/__tests__/helptext.test.tsx
+++ b/packages/paste-core/components/help-text/__tests__/helptext.test.tsx
@@ -2,10 +2,8 @@ import * as React from 'react';
 import {shallow} from 'enzyme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
-import {HelpText} from '../src';
 
-expect.extend(matchers);
+import {HelpText} from '../src';
 
 describe('HelpText variant prop', () => {
   const container = shallow(<HelpText variant="error" />);

--- a/packages/paste-core/components/inline-control-group/__tests__/inlineControlGroup.test.tsx
+++ b/packages/paste-core/components/inline-control-group/__tests__/inlineControlGroup.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import {render as testRender, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {InlineControlGroup} from '../src';
-
-expect.extend(matchers);
 
 const defaultGroupProps = {
   legend: 'This is a group legend',

--- a/packages/paste-core/components/input-box/__tests__/input-box.test.tsx
+++ b/packages/paste-core/components/input-box/__tests__/input-box.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {InputBox} from '../src';
-
-expect.extend(matchers);
 
 describe('HTML attributes', () => {
   it('should set a element data attribute for InputBox', () => {

--- a/packages/paste-core/components/input-box/__tests__/input-chevron-wrapper.test.tsx
+++ b/packages/paste-core/components/input-box/__tests__/input-chevron-wrapper.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {InputChevronWrapper} from '../src';
-
-expect.extend(matchers);
 
 describe('HTML attributes', () => {
   it('should set a element data attribute for InputChevronWrapper', () => {

--- a/packages/paste-core/components/input-box/__tests__/prefix.test.tsx
+++ b/packages/paste-core/components/input-box/__tests__/prefix.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Prefix} from '../src';
-
-expect.extend(matchers);
 
 describe('HTML attributes', () => {
   it('should set a element data attribute for Prefix', () => {

--- a/packages/paste-core/components/input-box/__tests__/suffix.test.tsx
+++ b/packages/paste-core/components/input-box/__tests__/suffix.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Suffix} from '../src';
-
-expect.extend(matchers);
 
 describe('HTML attributes', () => {
   it('should set a element data attribute for Suffix', () => {

--- a/packages/paste-core/components/input/__tests__/input.test.tsx
+++ b/packages/paste-core/components/input/__tests__/input.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Theme} from '@twilio-paste/theme';
@@ -9,8 +9,6 @@ import {HelpText} from '@twilio-paste/help-text';
 import axe from '../../../../../.jest/axe-helper';
 import {Input} from '../src';
 import type {InputTypes} from '../src';
-
-expect.extend(matchers);
 
 const NOOP = (): void => {};
 

--- a/packages/paste-core/components/label/__tests__/label.test.tsx
+++ b/packages/paste-core/components/label/__tests__/label.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {Customized} from '../stories/label.stories';
 import {Label} from '../src';
-
-expect.extend(matchers);
 
 describe('Label for prop', () => {
   const initialProps = {

--- a/packages/paste-core/components/list/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/list/__tests__/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {OrderedList, UnorderedList, ListItem} from '../src';
-
-expect.extend(matchers);
 
 describe('Ordered List', () => {
   describe('Render', () => {

--- a/packages/paste-core/components/menu/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/menu/__tests__/customization.spec.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import type {RenderOptions} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 
 import {initStyles, BaseMenu} from '../stories/customization.stories';
-
-expect.extend(matchers);
 
 const PASTE_ELEMENT = 'data-paste-element';
 

--- a/packages/paste-core/components/modal/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/modal/__tests__/customization.spec.tsx
@@ -2,11 +2,8 @@ import * as React from 'react';
 
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {matchers} from 'jest-emotion';
 
 import {BaseModal, initStyles} from '../stories/customization.stories';
-
-expect.extend(matchers);
 
 jest.mock('@twilio-paste/modal-dialog-primitive', () => {
   // Mocking the portal as a div so it renders within the body of the rendered test fragment, rather than using Portal behavior.

--- a/packages/paste-core/components/pagination/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/pagination/__tests__/customization.spec.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {PasteCustomCSS} from '@twilio-paste/customization';
 import {WrapperAndArrows, NumbersAndLabel} from '../stories/customization.stories';
-
-expect.extend(matchers);
 
 const paginationStyles = {fontSize: 'fontSize60', fontWeight: 'fontWeightBold'} as PasteCustomCSS;
 const getCustomizedStyles = (prefix = 'PAGINATION'): {[key: string]: any} => ({

--- a/packages/paste-core/components/pagination/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/pagination/__tests__/index.spec.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, fireEvent} from '@testing-library/react';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {PaginationArrow, PaginationNumber} from '../src';
 import {ArrowsPageLabelExample, NumbersExample, NumbersPageLabelExample} from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('Pagination', () => {
   it('should render a list of pagination numbers with a page label', () => {

--- a/packages/paste-core/components/paragraph/__tests__/paragraph.test.tsx
+++ b/packages/paste-core/components/paragraph/__tests__/paragraph.test.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {matchers} from 'jest-emotion';
+
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Paragraph} from '../src';
-
-expect.extend(matchers);
 
 describe('General', () => {
   it('should render', (): void => {

--- a/packages/paste-core/components/popover/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/popover/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, screen, waitFor} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Text} from '@twilio-paste/text';
@@ -8,8 +8,6 @@ import {Text} from '@twilio-paste/text';
 import axe from '../../../../../.jest/axe-helper';
 import {PopoverTop, StateHookExample} from '../stories/index.stories';
 import {Popover, PopoverContainer, PopoverButton} from '../src';
-
-expect.extend(matchers);
 
 describe('Popover', () => {
   describe('Render', () => {

--- a/packages/paste-core/components/select/__tests__/option.test.tsx
+++ b/packages/paste-core/components/select/__tests__/option.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render} from 'react-dom';
-import {matchers} from 'jest-emotion';
+
 import {render as testRender, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
@@ -8,8 +8,6 @@ import axe from '../../../../../.jest/axe-helper';
 import {Option} from '../src';
 import type {OptionProps} from '../src';
 import {createAttributeMap} from '../test-utils';
-
-expect.extend(matchers);
 
 interface ExampleOptionProps extends OptionProps {
   suffix?: string;

--- a/packages/paste-core/components/select/__tests__/optiongroup.test.tsx
+++ b/packages/paste-core/components/select/__tests__/optiongroup.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render} from 'react-dom';
-import {matchers} from 'jest-emotion';
+
 import {render as testRender, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
@@ -8,8 +8,6 @@ import axe from '../../../../../.jest/axe-helper';
 import {OptionGroup, Option} from '../src';
 import type {OptionGroupProps} from '../src';
 import {createAttributeMap} from '../test-utils';
-
-expect.extend(matchers);
 
 interface ExampleOptionGroupProps extends Omit<OptionGroupProps, 'children' | 'label'> {
   groupSuffix?: string;

--- a/packages/paste-core/components/select/__tests__/select.test.tsx
+++ b/packages/paste-core/components/select/__tests__/select.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from 'react-dom';
 import {render as testRender, fireEvent, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
@@ -11,8 +11,6 @@ import axe from '../../../../../.jest/axe-helper';
 import {Select, Option, SelectElement} from '../src';
 import type {SelectProps} from '../src';
 import {createAttributeMap} from '../test-utils';
-
-expect.extend(matchers);
 
 const onChangeMock: jest.Mock = jest.fn();
 

--- a/packages/paste-core/components/separator/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/separator/__tests__/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Separator} from '../src';
-
-expect.extend(matchers);
 
 describe('Separator', () => {
   describe('Render', () => {

--- a/packages/paste-core/components/skeleton-loader/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/skeleton-loader/__tests__/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {SkeletonLoader} from '../src';
 import {Default} from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('SkeletonLoader', () => {
   it('should render', () => {

--- a/packages/paste-core/components/spinner/__tests__/index.test.tsx
+++ b/packages/paste-core/components/spinner/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {Theme} from '@twilio-paste/theme';
 import {render, screen} from '@testing-library/react';
 import type {RenderOptions} from '@testing-library/react';
@@ -8,8 +8,6 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import {Spinner} from '../src';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
-
-expect.extend(matchers);
 
 const TestWrapper = (elements?: Record<string, any>): RenderOptions['wrapper'] => ({children}) => (
   <CustomizationProvider

--- a/packages/paste-core/components/table/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/table/__tests__/index.spec.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {Table, THead, TBody, TFoot, Td, Tr, Th} from '../src';
-
-expect.extend(matchers);
 
 describe('Table', () => {
   it('should render a default table', (): void => {

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -8,8 +8,6 @@ import axe from '../../../../../.jest/axe-helper';
 import {HorizontalTabs, StateHookTabs} from '../stories/index.stories';
 import {Tabs, Tab, TabList, TabPanels, TabPanel} from '../src';
 import {getElementName} from '../src/utils';
-
-expect.extend(matchers);
 
 describe('Tabs', () => {
   describe('Utils', () => {

--- a/packages/paste-core/components/textarea/__tests__/textarea.test.tsx
+++ b/packages/paste-core/components/textarea/__tests__/textarea.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen, fireEvent} from '@testing-library/react';
 import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
@@ -7,8 +7,6 @@ import {HelpText} from '@twilio-paste/help-text';
 import axe from '../../../../../.jest/axe-helper';
 import {TextArea} from '../src';
 import {CustomizedTextarea} from '../stories/textarea.stories';
-
-expect.extend(matchers);
 
 const NOOP = (): void => {};
 

--- a/packages/paste-core/components/time-picker/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/time-picker/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
@@ -12,8 +12,6 @@ import {
   InverseTimePicker,
   ReadonlyTimePicker,
 } from '../stories/index.stories';
-
-expect.extend(matchers);
 
 describe('formatReturnTime()', () => {
   const TEST_TIME = '13:30:04';

--- a/packages/paste-core/components/tooltip/__test__/index.spec.tsx
+++ b/packages/paste-core/components/tooltip/__test__/index.spec.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import {act, fireEvent, render, screen} from '@testing-library/react';
 import {Button} from '@twilio-paste/button';
 import {Theme} from '@twilio-paste/theme';
-import {matchers} from 'jest-emotion';
+
 import {CustomizationProvider} from '@twilio-paste/customization';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 import {StateHookExample} from '../stories/index.stories';
 import {Tooltip} from '../src';
-
-expect.extend(matchers);
 
 const TooltipWithoutTheme: React.FC<{elementName?: string}> = ({elementName}) => {
   return (

--- a/packages/paste-core/layout/flex/__tests__/flex.test.tsx
+++ b/packages/paste-core/layout/flex/__tests__/flex.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {
@@ -15,8 +15,6 @@ import {
 } from '../src/helpers';
 import {Flex} from '../src';
 import type {FlexProps} from '../src/types';
-
-expect.extend(matchers);
 
 describe('Flex Unit Tests', () => {
   it('should return grow: 1', (): void => {

--- a/packages/paste-core/layout/grid/__tests__/grid.test.tsx
+++ b/packages/paste-core/layout/grid/__tests__/grid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Column, Grid} from '../src';
@@ -12,8 +12,6 @@ import {
   getSpacing,
   getResponsiveSpacing,
 } from '../src/utils';
-
-expect.extend(matchers);
 
 describe('Grid', () => {
   const BASE_PADDING = {

--- a/packages/paste-core/layout/media-object/__tests__/index.spec.tsx
+++ b/packages/paste-core/layout/media-object/__tests__/index.spec.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {MediaObject, MediaFigure, MediaBody} from '../src';
-
-expect.extend(matchers);
 
 describe('MediaObject', () => {
   it('should render', (): void => {

--- a/packages/paste-core/layout/stack/__tests__/stack.test.tsx
+++ b/packages/paste-core/layout/stack/__tests__/stack.test.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
-import {matchers} from 'jest-emotion';
+
 import {Card} from '@twilio-paste/card';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {StackOrientation} from '../src';
 import {getStackDisplay, getStackStyles, getStackChildMargins, Stack} from '../src';
-
-expect.extend(matchers);
 
 describe('Stack Unit Tests', () => {
   const mockHorizontalOrientation = 'horizontal';

--- a/packages/paste-core/primitives/box/__tests__/box.test.tsx
+++ b/packages/paste-core/primitives/box/__tests__/box.test.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Box} from '../src';
 import {CustomizableBoxExample} from '../__fixtures__/CustomizableBox';
-
-expect.extend(matchers);
 
 describe('Backgrounds', () => {
   it('should render single values', (): void => {

--- a/packages/paste-core/primitives/sibling-box/__tests__/siblingBox.test.tsx
+++ b/packages/paste-core/primitives/sibling-box/__tests__/siblingBox.test.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {SiblingBox} from '../src';
-
-expect.extend(matchers);
 
 describe('SiblingBox render', () => {
   it('should render', (): void => {

--- a/packages/paste-core/primitives/text/__tests__/text.spec.tsx
+++ b/packages/paste-core/primitives/text/__tests__/text.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import {matchers} from 'jest-emotion';
+
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Text} from '../src';
 import {CustomizableTextExample} from '../__fixtures__/CustomizableText';
-
-expect.extend(matchers);
 
 describe('as', () => {
   it('should render as a provided HTML element', (): void => {

--- a/packages/paste-icons/__test__/icons.spec.tsx
+++ b/packages/paste-icons/__test__/icons.spec.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {matchers} from 'jest-emotion';
+
 import {render} from '@testing-library/react';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {AgentIcon} from '../src/AgentIcon';
-
-expect.extend(matchers);
 
 describe('Icons', () => {
   describe('HTML attributes', () => {


### PR DESCRIPTION
## Description

We have been using [additional jest styling matchers provided by `jest-emotion`](https://emotion.sh/docs/@emotion/jest#custom-matchers) in all of our test files for a while, so we should add them to our jest configuration that runs after the test environment is set up.

This will allow us to use those matchers (e.g. `.toHaveStyleRule`) without having to import the package and manually extend `expect` in each test suite.

### Summary of changes
- [x] import matchers from `jest-emotion` and extend `expect` in our [setup file](https://github.com/twilio-labs/paste/blob/main/.jest/setupFilesAfterEnv.js)
- [x] remove imports of `jest-emotion` in all test files
- [x] remove extension of `expect` in all test files, since it is now redundant