### PR TITLE
fix(anchor): improved wrapping and underline fix in FF

### DIFF
--- a/.changeset/light-goats-laugh.md
+++ b/.changeset/light-goats-laugh.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/anchor': patch
+'@twilio-paste/core': patch
+---
+
+[Anchor] Fixed the missing underline in Firefox. Also improved how external anchors wrap with their icons.

--- a/packages/paste-core/components/anchor/src/index.tsx
+++ b/packages/paste-core/components/anchor/src/index.tsx
@@ -94,9 +94,11 @@ const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
         verticalAlign={verticalAlign}
       >
         {showExternal ? (
-          <Box as="span" display="inline-flex" alignItems="center">
+          <Box as="span">
             {props.children}
-            <LinkExternalIcon decorative={false} title="link takes you to an external page" />
+            <Box as="span" display="inline-block" flexShrink={0} verticalAlign="middle">
+              <LinkExternalIcon decorative={false} title="link takes you to an external page" />
+            </Box>
           </Box>
         ) : (
           props.children


### PR DESCRIPTION
Fixes https://github.com/twilio-labs/paste/issues/1913, https://github.com/twilio-labs/paste/discussions/1968 and https://github.com/twilio-labs/paste/discussions/1533

Makes `showExternal` Anchors inline rather than flex, which solves responsive wrapping, outline, and underline in FF.
