### PR TITLE
fix(button): remove extra padding for invisible children

### DIFF
--- a/.changeset/hip-actors-listen.md
+++ b/.changeset/hip-actors-listen.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/button': patch
+'@twilio-paste/core': patch
+---
+
+[Button]: Fix bug that was adding extra padding when Screen Reader Only was passed as a child.

--- a/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/paste-core/components/alert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -124,14 +124,6 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
   display: flex;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  display: flex;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  opacity: 1;
-}
-
 .emotion-9 {
   color: rgb(40,42,43);
   font-size: 0.875rem;
@@ -214,6 +206,16 @@ exports[`Alert Variant error Should render an error alert with dismiss button 1`
   text-decoration: underline;
   box-shadow: none;
   color: rgb(3,44,94);
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  display: flex;
+  -webkit-text-decoration: inherit;
+  text-decoration: inherit;
+  opacity: 1;
+  -webkit-column-gap: 0.25rem;
+  column-gap: 0.25rem;
 }
 
 .emotion-3 {
@@ -487,14 +489,6 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
   display: flex;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  display: flex;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  opacity: 1;
-}
-
 .emotion-9 {
   color: rgb(40,42,43);
   font-size: 0.875rem;
@@ -598,6 +592,16 @@ exports[`Alert Variant neutral Should render a neutral alert with dismiss button
   text-decoration: underline;
   box-shadow: none;
   color: rgb(3,44,94);
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  display: flex;
+  -webkit-text-decoration: inherit;
+  text-decoration: inherit;
+  opacity: 1;
+  -webkit-column-gap: 0.25rem;
+  column-gap: 0.25rem;
 }
 
 .emotion-3 {
@@ -852,14 +856,6 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
   display: flex;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  display: flex;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  opacity: 1;
-}
-
 .emotion-9 {
   color: rgb(40,42,43);
   font-size: 0.875rem;
@@ -942,6 +938,16 @@ exports[`Alert Variant warning Should render an warning alert with dismiss butto
   text-decoration: underline;
   box-shadow: none;
   color: rgb(3,44,94);
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  display: flex;
+  -webkit-text-decoration: inherit;
+  text-decoration: inherit;
+  opacity: 1;
+  -webkit-column-gap: 0.25rem;
+  column-gap: 0.25rem;
 }
 
 .emotion-3 {

--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {render} from 'react-dom';
 import {render as testRender} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
+import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
 import type {ReactWrapper} from 'enzyme';
 import {shallow, mount} from 'enzyme';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -342,6 +343,22 @@ describe('Button', () => {
         </Button>
       );
       expect(getByTestId('button-margin')).toHaveStyleRule('margin', 'space0');
+    });
+  });
+
+  describe('Button inner padding', () => {
+    it('should not set padding for buttons with only one child', () => {
+      const {getByText} = testRender(<Button variant="primary">Hello</Button>);
+      expect(getByText('Hello')).not.toHaveStyleRule('padding', 'undefined');
+    });
+    it('should set padding between rendered children', () => {
+      const {getByText} = testRender(
+        <Button variant="primary">
+          Hello
+          <PlusIcon decorative />
+        </Button>
+      );
+      expect(getByText('Hello')).toHaveStyleRule('column-gap', 'space20');
     });
   });
 

--- a/packages/paste-core/components/button/src/index.tsx
+++ b/packages/paste-core/components/button/src/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
-import {Stack} from '@twilio-paste/stack';
 import {Spinner} from '@twilio-paste/spinner';
 import {secureExternalLink} from '@twilio-paste/anchor';
 import {useSpring, animated} from '@twilio-paste/animation-library';
@@ -126,14 +125,9 @@ const ButtonContents: React.FC<ButtonContentsProps> = ({buttonState, children, s
         opacity={buttonState === 'loading' ? '0' : '1'}
         aria-hidden={buttonState === 'loading' ? 'true' : 'false'}
         justifyContent={buttonVariantHasBoundingBox ? null : 'center'}
+        columnGap="space20"
       >
-        {React.Children.count(children) > 1 ? (
-          <Stack as="span" orientation="horizontal" spacing="space20">
-            {children}
-          </Stack>
-        ) : (
-          children
-        )}
+        {children}
       </Box>
       {showLoading ? (
         <Box

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -3,6 +3,7 @@ import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
 import {Box} from '@twilio-paste/box';
 import {Heading} from '@twilio-paste/heading';
 import {Stack} from '@twilio-paste/stack';
+import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {isRenderingOnServer} from '@twilio-paste/animation-library';
 import {Button} from '../src';
 import type {ButtonVariants, ButtonSizes} from '../src/types';
@@ -102,6 +103,16 @@ export const DestructiveSecondaryButton = (): React.ReactNode => <AllSizeOptions
 export const DestructiveLinkButton = (): React.ReactNode => <AllSizeOptions variant="destructive_link" />;
 export const LinkButton = (): React.ReactNode => <AllSizeOptions variant="link" />;
 export const InverseLinkButton = (): React.ReactNode => <AllSizeOptions variant="inverse_link" />;
+// This story is for VRT to ensure that non-visual elements don't add padding within the Button
+export const NoExtraPaddingButton = (): React.ReactNode => (
+  <Stack orientation="vertical" spacing="space50">
+    <Button variant="primary">Adding a `ScreenReaderOnly` should not give me extra padding</Button>
+    <Button variant="primary">
+      Adding a `ScreenReaderOnly` should not give me extra padding
+      <ScreenReaderOnly>I am the `ScreenReaderOnly`</ScreenReaderOnly>
+    </Button>
+  </Stack>
+);
 
 export const Reset = (): React.ReactNode => (
   <>


### PR DESCRIPTION
No longer using a Stack to space multiple Button children. Now the parent element has a `columnGap` property, so non-visual components (like Screen Reader Only) don't add unwanted padding. Also added tests and a story for VRT. [Ticket](https://issues.corp.twilio.com/secure/RapidBoard.jspa?rapidView=748&projectKey=DSYS&view=detail&selectedIssue=DSYS-2188)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
