### PR TITLE
docs(website): use unbarreled imports on docs pages

### DIFF
--- a/packages/paste-website/src/pages/components/alert-dialog/index.mdx
+++ b/packages/paste-website/src/pages/components/alert-dialog/index.mdx
@@ -187,8 +187,8 @@ yarn add @twilio-paste/alert-dialog - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {AlertDialog} from '@twilio-paste/alert-dialog';
-import {Button} from '@twilio-paste/button';
+import {AlertDialog} from '@twilio-paste/core/alert-dialog';
+import {Button} from '@twilio-paste/core/button';
 
 const AlertDialogExample = () => {
   const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -360,7 +360,7 @@ yarn add @twilio-paste/alert - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Alert} from '@twilio-paste/alert';
+import {Alert} from '@twilio-paste/core/alert';
 
 const Component = () => (
   <Alert variant="error">

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -183,7 +183,7 @@ yarn add @twilio-paste/anchor - or - yarn add @twilio-paste/core
 #### Usage
 
 ```js
-import {Anchor} from '@twilio-paste/anchor';
+import {Anchor} from '@twilio-paste/core/anchor';
 
 const Component = () => <Anchor href="https://paste.twilio.design">Go to Paste</Anchor>;
 ```

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -240,7 +240,7 @@ yarn add @twilio-paste/avatar - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Avatar} from '@twilio-paste/avatar';
+import {Avatar} from '@twilio-paste/core/avatar';
 
 const AvatarExample = () => {
   return <Avatar size="sizeIcon10" name="Aayush Iyer" />;

--- a/packages/paste-website/src/pages/components/badge/index.mdx
+++ b/packages/paste-website/src/pages/components/badge/index.mdx
@@ -387,7 +387,7 @@ yarn add @twilio-paste/badge - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Badge} from '@twilio-paste/badge';
+import {Badge} from '@twilio-paste/core/badge';
 
 const BadgeExample = () => (
   <Badge variant="default" as="span">

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Button
 package: '@twilio-paste/button'
-description: A button communicates that users can trigger an action.
-slug: /components/button/
+description: A Button communicates that users can trigger an action.
+slug: /components/Button/
 ---
 
 import {graphql} from 'gatsby';
@@ -57,8 +57,8 @@ export const pageQuery = graphql`
 <ComponentHeader
   name="Button"
   categoryRoute={SidebarCategoryRoutes.COMPONENTS}
-  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/button"
-  storybookUrl="/?path=/story/components-button--primary-button"
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/Button"
+  storybookUrl="/?path=/story/components-Button--primary-Button"
   data={props.data.allPasteComponent.edges}
   packageStatus={props.data.allAirtable.edges}
 />
@@ -73,16 +73,16 @@ export const pageQuery = graphql`
 
 ## Guidelines
 
-### About buttons
+### About Buttons
 
-A button communicates that users can trigger an action. Places you’d use
-a button include:
+A Button communicates that users can trigger an action. Places you’d use
+a Button include:
 
 - Submitting a form
 - Closing a modal
 - Moving to the next step in a flow
 
-A button can contain an icon and/or text. See Composing a button below
+A Button can contain an icon and/or text. See Composing a Button below
 for more detailed guidelines.
 
 #### Button vs. Anchor (Link)
@@ -92,15 +92,15 @@ page makes sense as a whole new browser tab use an **Anchor** element.
 Everything else is a **Button**.
 
 It may not be immediately obvious but the semantic distinction between an
-anchor and button HTML element is extremely important to learn. Without
+anchor and Button HTML element is extremely important to learn. Without
 realising it the decision can cause significant usability problems due to
 the in-built behaviours, interactions and expectations that come with each.
 
 For example, an anchor element will perform its action when clicked and
-when the enter key is pressed. A button element will perform its action
+when the enter key is pressed. A Button element will perform its action
 when clicked and when the enter and spacebar keys are pressed. When
 holding the control or command key an anchor will open a new browser
-tab, a button will not.
+tab, a Button will not.
 
 You should:
 
@@ -117,16 +117,16 @@ For accessibility, the distinction becomes even more important,
 especially for those who are using Assistive Technology (A.T.) such as
 screen readers and dictation software. Here are some quick tips:
 
-- Correctly choosing between an anchor or button element will help inform A.T.
+- Correctly choosing between an anchor or Button element will help inform A.T.
   users what will happen next. Will I be taken to an entirely new page or will
   something happen on the current page?
-- Choose button text that clearly describes the action that is about to happen
-- Don’t repeat the same button text on the same page. Try not to have 20
-  “edit” buttons, add clarifying text, even if it’s visually hidden, to
+- Choose Button text that clearly describes the action that is about to happen
+- Don’t repeat the same Button text on the same page. Try not to have 20
+  “edit” Buttons, add clarifying text, even if it’s visually hidden, to
   fully describe the action. E.g. “edit home address”, “add new phone number”
-- Don’t communicate with color alone. When choosing a destructive button,
-  make sure the button text also indicates the action is destructive
-- Use anchors that look like buttons sparingly. Voice dictation users may encounter issues when trying to activate them. A user may say, “Click the read more button”, but the dictation software won’t respond since it can’t tell what the anchor looks like visually. Use an alternative where possible, such as an anchor with an icon or with a larger font size.
+- Don’t communicate with color alone. When choosing a destructive Button,
+  make sure the Button text also indicates the action is destructive
+- Use anchors that look like Buttons sparingly. Voice dictation users may encounter issues when trying to activate them. A user may say, “Click the read more Button”, but the dictation software won’t respond since it can’t tell what the anchor looks like visually. Use an alternative where possible, such as an anchor with an icon or with a larger font size.
 
 ### Examples
 
@@ -158,13 +158,13 @@ screen readers and dictation software. Here are some quick tips:
 </Stack>`}
 </LivePreview>
 
-#### Primary button
+#### Primary Button
 
-Use a primary button to indicate the most prominent action a customer would
+Use a primary Button to indicate the most prominent action a customer would
 make on a screen. It should be a safe and if possible, reversible action
 without much cost.
 
-Try to use only one primary button on a screen. Using multiple might be
+Try to use only one primary Button on a screen. Using multiple might be
 distracting.
 
 <LivePreview scope={{Button}} language="jsx">
@@ -173,11 +173,11 @@ distracting.
 </Button>`}
 </LivePreview>
 
-#### Secondary button
+#### Secondary Button
 
-The secondary button is the most frequently used button.
+The secondary Button is the most frequently used Button.
 
-Use a secondary button to indicate an action that should be easy for a customer
+Use a secondary Button to indicate an action that should be easy for a customer
 to make but isn’t the most prominent on a screen. It should be a safe and if
 possible, reversible action without much cost.
 
@@ -187,9 +187,9 @@ possible, reversible action without much cost.
 </Button>`}
 </LivePreview>
 
-#### Destructive secondary button
+#### Destructive secondary Button
 
-A destructive secondary button indicates a destructive action, such as “Delete” or
+A destructive secondary Button indicates a destructive action, such as “Delete” or
 “Remove”, that might be difficult to reverse. If possible, give users
 the ability to undo the action, or at least, confirm the action.
 
@@ -199,9 +199,9 @@ the ability to undo the action, or at least, confirm the action.
 </Button>`}
 </LivePreview>
 
-#### Destructive button
+#### Destructive Button
 
-Use a destructive primary button for the most prominent action a customer would make on a
+Use a destructive primary Button for the most prominent action a customer would make on a
 screen if that action is destructive and could be difficult to reverse.
 
 <LivePreview scope={{Button}} language="jsx">
@@ -210,9 +210,9 @@ screen if that action is destructive and could be difficult to reverse.
 </Button>`}
 </LivePreview>
 
-#### Icon-only button
+#### Icon-only Button
 
-Use icon-only buttons sparingly.
+Use icon-only Buttons sparingly.
 
 They should be used only in compact UI situations. Use an icon that can
 only convey a single action.
@@ -258,9 +258,9 @@ only convey a single action.
 </Stack>`}
 </LivePreview>
 
-#### Link-style button
+#### Link-style Button
 
-Use link-style buttons when other types of buttons may be too distracting.
+Use Link-style Buttons when other types of Buttons may be too distracting.
 
 <Callout>
   <CalloutTitle as="h4">Hot accessibility tip</CalloutTitle>
@@ -292,9 +292,9 @@ Use link-style buttons when other types of buttons may be too distracting.
 Buttons that **navigate** the user can only be represented by the `primary` and `secondary` variants.
 When this is used, it must be accompanied by an arrow pointing to the right or an external
 link icon after the text. The icons help to indicate that the action performed on click is a navigation.
-These button types do not have `disabled` or `loading` states, as anchors cannot be in those states.
+These Button types do not have `disabled` or `loading` states, as anchors cannot be in those states.
 
-To create a button-styled anchor, use the Button component and add the `as="a"` prop so that it is rendered as an anchor semantically, while maintaining button styling.
+To create a Button-styled anchor, use the Button component and add the `as="a"` prop so that it is rendered as an anchor semantically, while maintaining Button styling.
 
 **Note:** The same guidance applies for any action deemed "primary"; use only one per page.
 
@@ -309,10 +309,10 @@ To create a button-styled anchor, use the Button component and add the `as="a"` 
 </Stack>`}
 </LivePreview>
 
-#### Small button
+#### Small Button
 
-Use small buttons sparingly, only when needed for vertical density.
-Guidelines for using variants in small buttons are the same as in
+Use small Buttons sparingly, only when needed for vertical density.
+Guidelines for using variants in small Buttons are the same as in
 their default size.
 
 <LivePreview scope={{Button, Stack}} language="jsx">
@@ -332,12 +332,12 @@ their default size.
 </Stack>`}
 </LivePreview>
 
-#### Reset button styles
+#### Reset Button styles
 
-The reset button is basically a primitive button. The button styles are
+The reset Button is basically a primitive Button. The Button styles are
 reset, so styles won't interfere with any child elements. This allows you to
-create your own buttons using the Paste. This reset variant only resets
-styles. No other button functionality is reset.
+create your own Buttons using the Paste. This reset variant only resets
+styles. No other Button functionality is reset.
 
 <LivePreview scope={{Button}} language="jsx">
   {`<Button variant="reset" size="reset">
@@ -350,7 +350,7 @@ styles. No other button functionality is reset.
 #### Loading
 
 Use the loading state if the action doesn’t happen instantly.
-The button is also disabled in this state.
+The Button is also disabled in this state.
 
 However, the loading state may make an action appear to take longer
 than it does and doesn’t communicate what’s preventing the action
@@ -398,10 +398,10 @@ from completing. Use it when you can’t move the user to the next state.
 
 Use the disabled state sparingly.
 
-The customer shouldn't have to guess why a button is disabled.
-It should be immediately obvious to the customer why a button
+The customer shouldn't have to guess why a Button is disabled.
+It should be immediately obvious to the customer why a Button
 might be disabled (_e.g._, if it follows a single empty text
-field). Otherwise, show the button in its default state, then
+field). Otherwise, show the Button in its default state, then
 provide helpful error text after it's pressed.
 
 <LivePreview scope={{Button, Stack}} language="jsx">
@@ -442,9 +442,9 @@ provide helpful error text after it's pressed.
 </Stack>`}
 </LivePreview>
 
-### Composing a button
+### Composing a Button
 
-In most cases, you’ll use a text-only button.
+In most cases, you’ll use a text-only Button.
 
 Button text should:
 
@@ -454,42 +454,42 @@ Button text should:
 - Be concise without sacrificing clarity and user confidence.
 
 Pair text with an icon only if the icon clarifies the meaning of
-the button. Use no more than one icon before text and one icon after text.
+the Button. Use no more than one icon before text and one icon after text.
 
-### When to use a button
+### When to use a Button
 
-Use a button to indicate that users can trigger an action.
+Use a Button to indicate that users can trigger an action.
 
-In general, align buttons to the direction of the text (_e.g._,
+In general, align Buttons to the direction of the text (_e.g._,
 left-aligned in English) for easy scannability.
 
-When moving customers through a sequence, place the primary button in
-the direction of the movement (e.g., a “Next” button goes on the
+When moving customers through a sequence, place the primary Button in
+the direction of the movement (e.g., a “Next” Button goes on the
 right in an English-language flow).
 
 <DoDont>
   <Do
     title="Do"
-    body="Prioritize actions on a screen. Only one primary button should be used on each screen so users are clear about what the intended action is."
+    body="Prioritize actions on a screen. Only one primary Button should be used on each screen so users are clear about what the intended action is."
     preview={false}
   />
-  <Dont title="Don't" body="Don’t use many primary buttons on a screen, which may distract users." preview={false} />
+  <Dont title="Don't" body="Don’t use many primary Buttons on a screen, which may distract users." preview={false} />
 </DoDont>
 
 <DoDont>
   <Do title="Do" body="Use the right variant to communicate meaning and hierarchy." preview={false} />
-  <Dont title="Don't" body="Don’t use a button variant for an action it’s not intended for." preview={false} />
+  <Dont title="Don't" body="Don’t use a Button variant for an action it’s not intended for." preview={false} />
 </DoDont>
 
 <DoDont>
   <Do
     title="Do"
-    body="Write button text that is clear, starts with a verb, and helps users confidently trigger an action."
+    body="Write Button text that is clear, starts with a verb, and helps users confidently trigger an action."
     preview={false}
   />
   <Dont
     title="Don't"
-    body="Don’t use product or brand icons in buttons since they don’t communicate action."
+    body="Don’t use product or brand icons in Buttons since they don’t communicate action."
     preview={false}
   />
 </DoDont>
@@ -509,7 +509,7 @@ yarn add @twilio-paste/button - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Button} from '@twilio-paste/button';
+import {Button} from '@twilio-paste/core/button';
 
 const Component = () => (
   <Button variant="secondary" size="small" onClick={() => {}}>
@@ -520,17 +520,17 @@ const Component = () => (
 
 #### Props
 
-All the valid HTML attributes for `button` are supported including the following props:
+All the valid HTML attributes for `Button` are supported including the following props:
 
 | Prop          | Type                                     | Description                                                                                                                    | Default   |
 | ------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------- |
 | as?           | `string`                                 | The HTML tag to replace the default `<button>` tag.                                                                            | 'button'  |
-| disabled?     | `boolean`                                | Prevent actions from firing on this button                                                                                     | false     |
-| fullWidth     | `boolean`                                | Sets the button width to 100% of the parent container.                                                                         | false     |
+| disabled?     | `boolean`                                | Prevent actions from firing on this Button                                                                                     | false     |
+| fullWidth     | `boolean`                                | Sets the Button width to 100% of the parent container.                                                                         | false     |
 | href?         | `string`                                 | A URL to route to. Must use `as="a"` for this prop to work.                                                                    | null      |
 | loading?      | `boolean`                                | Prevent actions and show a loading spinner                                                                                     | false     |
 | size?         | `ButtonSizes`                            | 'default', 'small', 'icon', 'icon_small', 'reset'                                                                              | 'default' |
-| type?         | `ButtonTypes`                            | 'button', 'submit', 'reset'. If the button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default).               | 'button'  |
+| type?         | `ButtonTypes`                            | 'button', 'submit', 'reset'. If the Button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default).               | 'button'  |
 | variant?      | `ButtonVariants`                         | 'primary', 'secondary', 'inverse', 'destructive', 'destructive_secondary', 'destructive_link', 'link', 'inverse_link', 'reset' | 'primary' |
 | onClick?      | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
 | onMouseDown?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |

--- a/packages/paste-website/src/pages/components/card/index.mdx
+++ b/packages/paste-website/src/pages/components/card/index.mdx
@@ -270,13 +270,23 @@ Ultimately, Card is a very flexible component that can fit a variety of needs. I
 
 ## Usage Guide
 
-### Installation
+### API
+
+#### Installation
 
 ```bash
 yarn add @twilio-paste/card - or - yarn add @twilio-paste/core
 ```
 
-### API
+#### Usage
+
+```jsx
+import {Card} from '@twilio-paste/core/card';
+
+const Card = () => <Card>Hello world</Card>;
+```
+
+#### Props
 
 | Prop            | Type            | Description                              | Default   |
 | --------------- | --------------- | ---------------------------------------- | --------- |

--- a/packages/paste-website/src/pages/components/checkbox/index.mdx
+++ b/packages/paste-website/src/pages/components/checkbox/index.mdx
@@ -388,7 +388,7 @@ yarn add @twilio-paste/checkbox - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Checkbox, CheckboxGroup} from '@twilio-paste/checkbox';
+import {Checkbox, CheckboxGroup} from '@twilio-paste/core/checkbox';
 
 const Component = () => (
   <CheckboxGroup name="foo" legend="foo">

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -375,7 +375,7 @@ yarn add @twilio-paste/combobox - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Combobox} from '@twilio-paste/combobox';
+import {Combobox} from '@twilio-paste/core/combobox';
 
 const Component = () => <Combobox autocomplete items={foo} labelText="Foo" helpText="Bar" />;
 ```

--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -443,7 +443,7 @@ yarn add @twilio-paste/disclosure - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Disclosure, DisclosureHeading, DisclosureContent} from '@twilio-paste/disclosure';
+import {Disclosure, DisclosureHeading, DisclosureContent} from '@twilio-paste/core/disclosure';
 
 const PopoverExample: React.FC = () => {
   return (

--- a/packages/paste-website/src/pages/components/display-pill-group/index.mdx
+++ b/packages/paste-website/src/pages/components/display-pill-group/index.mdx
@@ -169,7 +169,7 @@ yarn add @twilio-paste/display-pill-group - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {DisplayPillGroup, DisplayPill} from '@twilio-paste/display-pill-group';
+import {DisplayPillGroup, DisplayPill} from '@twilio-paste/core/display-pill-group';
 
 export const Basic = () => {
   return (

--- a/packages/paste-website/src/pages/components/form-pill-group/index.mdx
+++ b/packages/paste-website/src/pages/components/form-pill-group/index.mdx
@@ -221,7 +221,7 @@ yarn add @twilio-paste/form-pill-group - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {useFormPillState, FormPillGroup, FormPill} from '@twilio-paste/form-pill-group';
+import {useFormPillState, FormPillGroup, FormPill} from '@twilio-paste/core/form-pill-group';
 
 export const Basic = () => {
   const pillState = useFormPillState();

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -212,7 +212,7 @@ yarn add @twilio-paste/heading - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Heading} from '@twilio-paste/heading';
+import {Heading} from '@twilio-paste/core/heading';
 
 const Component = () => (
   <Heading as="h2" variant="heading20">

--- a/packages/paste-website/src/pages/components/help-text/index.mdx
+++ b/packages/paste-website/src/pages/components/help-text/index.mdx
@@ -342,7 +342,9 @@ yarn add @twilio-paste/help-text - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Input, Label, HelpText} from '@twilio-paste/core';
+import {Input} from '@twilio-paste/core/input';
+import {Label} from '@twilio-paste/core/label';
+import {HelpText} from '@twilio-paste/core/help-text';
 
 const Component = () => (
   <>

--- a/packages/paste-website/src/pages/components/input/index.mdx
+++ b/packages/paste-website/src/pages/components/input/index.mdx
@@ -677,7 +677,9 @@ yarn add @twilio-paste/input - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Input, Label, HelpText} from '@twilio-paste/core';
+import {Input} from '@twilio-paste/core/input';
+import {Label} from '@twilio-paste/core/label';
+import {HelpText} from '@twilio-paste/core/help-text';
 
 const Component = () => (
   <>

--- a/packages/paste-website/src/pages/components/label/index.mdx
+++ b/packages/paste-website/src/pages/components/label/index.mdx
@@ -319,7 +319,9 @@ yarn add @twilio-paste/label - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Input, Label, HelpText} from '@twilio-paste/core';
+import {Input} from '@twilio-paste/core/input';
+import {Label} from '@twilio-paste/core/label';
+import {HelpText} from '@twilio-paste/core/help-text';
 
 const Component = () => (
   <>

--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -328,7 +328,7 @@ yarn add @twilio-paste/list - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {OrderedList, UnorderedList, ListItem} from '@twilio-paste/list';
+import {OrderedList, UnorderedList, ListItem} from '@twilio-paste/core/list';
 
 const Component = () => (
   <UnorderedList>

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -319,7 +319,7 @@ yarn add @twilio-paste/menu - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Menu, MenuButton, MenuItem, MenuSeparator, useMenuState} from '@twilio-paste/menu';
+import {Menu, MenuButton, MenuItem, MenuSeparator, useMenuState} from '@twilio-paste/core/menu';
 import {ChevronDownIcon} from '@twilio-paste/icons/esm/ChevronDownIcon';
 
 const PreferencesMenu = () => {

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -373,9 +373,9 @@ yarn add @twilio-paste/modal - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {useUID} from '@twilio-paste/uid-library';
-import {Button} from '@twilio-paste/button';
-import {Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading} from '@twilio-paste/modal';
+import {useUID} from '@twilio-paste/core/uid-library';
+import {Button} from '@twilio-paste/core/button';
+import {Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading} from '@twilio-paste/core/modal';
 
 const ModalTrigger = () => {
   const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/paste-website/src/pages/components/pagination/index.mdx
+++ b/packages/paste-website/src/pages/components/pagination/index.mdx
@@ -584,7 +584,7 @@ import {
   PaginationNumbers,
   PaginationNumber,
   PaginationEllipsis,
-} from '@twilio-paste/pagination';
+} from '@twilio-paste/core/pagination';
 
 const Component = () => {
   return (

--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -231,7 +231,7 @@ yarn add @twilio-paste/paragraph - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Paragraph} from '@twilio-paste/paragraph';
+import {Paragraph} from '@twilio-paste/core/paragraph';
 
 const Component = () => (
   <Paragraph>

--- a/packages/paste-website/src/pages/components/popover/index.mdx
+++ b/packages/paste-website/src/pages/components/popover/index.mdx
@@ -217,7 +217,7 @@ yarn add @twilio-paste/popover - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Popover, PopoverContainer, PopoverButton} from '@twilio-paste/popover';
+import {Popover, PopoverContainer, PopoverButton} from '@twilio-paste/core/popover';
 
 const PopoverExample: React.FC = () => {
   return (

--- a/packages/paste-website/src/pages/components/radio-group/index.mdx
+++ b/packages/paste-website/src/pages/components/radio-group/index.mdx
@@ -251,7 +251,7 @@ yarn add @twilio-paste/radio-group - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Radio, RadioGroup} from '@twilio-paste/radio-group';
+import {Radio, RadioGroup} from '@twilio-paste/core/radio-group';
 
 const Component = () => (
   <RadioGroup name="foo" value="foo" legend="foo" onChange={NOOP}>

--- a/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
+++ b/packages/paste-website/src/pages/components/screen-reader-only/index.mdx
@@ -205,7 +205,7 @@ yarn add @twilio-paste/screen-reader-only - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
+import {ScreenReaderOnly} from '@twilio-paste/core/screen-reader-only';
 
 const Component = () => (
   <Button variant="secondary" size="small">

--- a/packages/paste-website/src/pages/components/select/index.mdx
+++ b/packages/paste-website/src/pages/components/select/index.mdx
@@ -856,7 +856,9 @@ yarn add @twilio-paste/select
 #### Usage
 
 ```jsx
-import {Select, Option, Label, HelpText} from '@twilio-paste/core';
+import {Select, Option} from '@twilio-paste/core/select';
+import {Label} from '@twilio-paste/core/label';
+import {HelpText} from '@twilio-paste/core/help-text';
 
 <Label htmlFor="foo" required>Foo</Label>
 <Select id="foo" name="foo" onChange={FOO} required>

--- a/packages/paste-website/src/pages/components/separator/index.mdx
+++ b/packages/paste-website/src/pages/components/separator/index.mdx
@@ -176,7 +176,7 @@ yarn add @twilio-paste/separator - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Separator} from '@twilio-paste/separator';
+import {Separator} from '@twilio-paste/core/separator';
 
 const Component = () => <Separator orientation="horizontal" />;
 ```

--- a/packages/paste-website/src/pages/components/skeleton-loader/index.mdx
+++ b/packages/paste-website/src/pages/components/skeleton-loader/index.mdx
@@ -198,8 +198,8 @@ yarn add @twilio-paste/skeleton-loader - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {SkeletonLoader} from '@twilio-paste/skeleton-loader';
-import {Text} from '@twilio-paste/text';
+import {SkeletonLoader} from '@twilio-paste/core/skeleton-loader';
+import {Text} from '@twilio-paste/core/text';
 
 const SkeletonLoaderExample = () => {
   const [loaded] = React.useState(false);

--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -160,7 +160,7 @@ yarn add @twilio-paste/spinner - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Spinner} from '@twilio-paste/spinner';
+import {Spinner} from '@twilio-paste/core/spinner';
 
 const Component = () => {
   return <Spinner decorative={false} title="Loading" />;

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -1074,7 +1074,7 @@ yarn add @twilio-paste/table - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Table} from ‘@twilio-paste/table';
+import {Table} from ‘@twilio-paste/core/table';
 
 const TableExample: React.FC = () => {
   return (

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -292,7 +292,7 @@ yarn add @twilio-paste/tabs - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Tabs, TabList, Tab, TabPanels, TabPanel} from '@twilio-paste/tabs';
+import {Tabs, TabList, Tab, TabPanels, TabPanel} from '@twilio-paste/core/tabs';
 
 const HorizontalTabsExample: React.FC = () => {
   const selectedId = useUID();

--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -615,7 +615,9 @@ yarn add @twilio-paste/textarea - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {TextArea, Label, HelpText} from '@twilio-paste/core';
+import {TextArea} from '@twilio-paste/core/textarea';
+import {Label} from '@twilio-paste/core/label';
+import {HelpText} from '@twilio-paste/core/help-text';
 
 const Component = () => (
   <>

--- a/packages/paste-website/src/pages/components/toast/index.mdx
+++ b/packages/paste-website/src/pages/components/toast/index.mdx
@@ -431,7 +431,7 @@ yarn add @twilio-paste/toast - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Toast, Toaster} from '@twilio-paste/toast';
+import {Toast, Toaster} from '@twilio-paste/core/toast';
 
 const Component = () => {
   const toaster = useToaster();

--- a/packages/paste-website/src/pages/components/tooltip/index.mdx
+++ b/packages/paste-website/src/pages/components/tooltip/index.mdx
@@ -248,7 +248,7 @@ yarn add @twilio-paste/tooltip - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Tooltip} from '@twilio-paste/tooltip';
+import {Tooltip} from '@twilio-paste/core/tooltip';
 
 const PopoverExample: React.FC = () => {
   return (

--- a/packages/paste-website/src/pages/components/truncate/index.mdx
+++ b/packages/paste-website/src/pages/components/truncate/index.mdx
@@ -178,7 +178,7 @@ yarn add @twilio-paste/truncate - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Truncate} from '@twilio-paste/truncate';
+import {Truncate} from '@twilio-paste/core/truncate';
 
 const Component: React.FC = () => {
   return (

--- a/packages/paste-website/src/pages/layout/flex/index.mdx
+++ b/packages/paste-website/src/pages/layout/flex/index.mdx
@@ -315,7 +315,7 @@ yarn add @twilio-paste/flex - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Flex} from '@twilio-paste/flex';
+import {Flex} from '@twilio-paste/core/flex';
 
 const Component = () => <Flex>Foo</Flex>;
 ```

--- a/packages/paste-website/src/pages/layout/grid/index.mdx
+++ b/packages/paste-website/src/pages/layout/grid/index.mdx
@@ -640,7 +640,7 @@ yarn add @twilio-paste/grid - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Grid, Column} from '@twilio-paste/grid';
+import {Grid, Column} from '@twilio-paste/core/grid';
 
 const Component = () => (
   <Grid>

--- a/packages/paste-website/src/pages/layout/media-object/index.mdx
+++ b/packages/paste-website/src/pages/layout/media-object/index.mdx
@@ -315,7 +315,7 @@ yarn add @twilio-paste/media-object
 ### Usage
 
 ```jsx
-import {MediaObject, MediaFigure, MediaBody} from '@twilio-paste/media-object';
+import {MediaObject, MediaFigure, MediaBody} from '@twilio-paste/core/media-object';
 
 const Component = (props) => (
   <MediaObject verticalAlign="center">

--- a/packages/paste-website/src/pages/layout/stack/index.mdx
+++ b/packages/paste-website/src/pages/layout/stack/index.mdx
@@ -160,7 +160,7 @@ yarn add @twilio-paste/stack
 #### Usage
 
 ```jsx
-import {Stack} from '@twilio-paste/stack';
+import {Stack} from '@twilio-paste/core/stack';
 
 <Stack orientation="vertical" spacing="space40">
   Foo

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -234,7 +234,7 @@ yarn add @twilio-paste/box - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Box} from '@twilio-paste/box';
+import {Box} from '@twilio-paste/core/box';
 
 const Component = () => (
   <Box

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -344,4 +344,3 @@ All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including 
 </content>
 
 </contentwrapper>
-```


### PR DESCRIPTION
I found everywhere I could that was using barreled imports, but it is possible that I missed some places. Ticket: https://issues.corp.twilio.com/secure/RapidBoard.jspa?rapidView=748&projectKey=DSYS&view=detail&selectedIssue=DSYS-2379

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
