### PR TITLE
fix: changeset publish script needs to commit lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
       - name: "Create Pull Request or Publish to npm"
         uses: changesets/action@master
         with:
+          version: yarn version
           publish: yarn release
           commit: "chore(release): version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "prerelease": "yarn build && yarn lint && yarn test",
     "release": "yarn prerelease && yarn changeset publish",
     "release:next": "yarn lerna publish -m 'chore(release): pre release' --conventional-commits --canary --preid beta --dist-tag next",
-    "version": "node ./tools/build/version.js",
+    "version": "yarn changeset version && yarn install --mode=update-lockfile",
+    "sync-internal-peer-dependencies": "node ./tools/build/version.js",
     "clean": "node ./tools/build/clean-repo.js && lerna clean --yes && lerna run clean && yarn",
     "clean:full": "node ./tools/build/clean-repo.js && lerna clean --yes && lerna run clean && rm -rf node_modules/ && yarn",
     "clean:core": "yarn workspace @twilio-paste/core clean",
@@ -222,5 +223,5 @@
       "pre-push": "if git-branch-is main; then yarn pre-push; fi"
     }
   },
-  "packageManager": "yarn@3.0.2"
+  "packageManager": "yarn@3.1.0"
 }


### PR DESCRIPTION
Yarn 3 has a slightly different lockfile behaviour where internal peer dependencies are now listed in the lockfile.

So when `changset version` runs and bumps the version numbers of packages based on the changes, the lockfile is now out of date. This means any `yarn install --immutable` will fail in all CI runs after you merge in the "version" PR and prevent the release from happening.

This adds a custom version command, which after versioning the packages, runs `yarn install --mode=update-lockfile` which will only update the lockfile. Which can then be committed in the Versions PR.

Also bumped Yarn to latest version, because why not. 🤷🏼 