### PR TITLE
Button/icon only variant

### DIFF
--- a/.changeset/twenty-boxes-ring.md
+++ b/.changeset/twenty-boxes-ring.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/button': minor
+'@twilio-paste/core': minor
+---
+
+[Button]: add 'icon-only' variant for consistency when using only a single icon child. Mainly for use with close Buttons in Modals, Alerts, etc.

--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -237,6 +237,17 @@ describe('Button', () => {
       ).toThrow();
     });
 
+    it('Throws an error when using multiple children with variant="icon-only', () => {
+      expect(() =>
+        shallow(
+          <Button variant="icon_only">
+            <PlusIcon decorative />
+            <PlusIcon decorative />
+          </Button>
+        )
+      ).toThrow();
+    });
+
     it('Throws an error when using fullWidth with an icon_small sizing', () => {
       expect(() =>
         shallow(
@@ -512,6 +523,17 @@ describe('Button', () => {
 
       expect(getByText('Reset')).not.toHaveStyleRule('justify-content', 'center');
       expect(getByTestId('reset-styles')).not.toHaveStyleRule('text-align', 'left');
+    });
+
+    it('should have the correct styles for the icon_only variant', () => {
+      const {getByTestId} = testRender(
+        <Button variant="icon_only" data-testid="icon_only-styles">
+          <PlusIcon decorative />
+        </Button>
+      );
+
+      expect(getByTestId('icon_only-styles')).toHaveStyleRule('color', 'SOMETHING');
+      expect(getByTestId('icon_only-styles')).toHaveStyleRule('color', 'SOMETHING', {target: ':hover'});
     });
 
     it('should have the correct styles for a link button in loading state', () => {

--- a/packages/paste-core/components/button/src/DestructiveButton.tsx
+++ b/packages/paste-core/components/button/src/DestructiveButton.tsx
@@ -68,9 +68,8 @@ const DestructiveButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>
 DestructiveButton.defaultProps = {
   as: 'button',
 };
-if (process.env.NODE_ENV === 'development') {
-  DestructiveButton.propTypes = DirectButtonPropTypes;
-}
+DestructiveButton.propTypes = DirectButtonPropTypes;
+
 DestructiveButton.displayName = 'DestructiveButton';
 
 export {DestructiveButton};

--- a/packages/paste-core/components/button/src/DestructiveLinkButton.tsx
+++ b/packages/paste-core/components/button/src/DestructiveLinkButton.tsx
@@ -56,9 +56,8 @@ const DestructiveLinkButton = React.forwardRef<HTMLButtonElement, DirectButtonPr
 DestructiveLinkButton.defaultProps = {
   as: 'a' as keyof JSX.IntrinsicElements,
 };
-if (process.env.NODE_ENV === 'development') {
-  DestructiveLinkButton.propTypes = DirectButtonPropTypes;
-}
+DestructiveLinkButton.propTypes = DirectButtonPropTypes;
+
 DestructiveLinkButton.displayName = 'DestructiveLinkButton';
 
 export {DestructiveLinkButton};

--- a/packages/paste-core/components/button/src/DestructiveSecondaryButton.tsx
+++ b/packages/paste-core/components/button/src/DestructiveSecondaryButton.tsx
@@ -82,9 +82,8 @@ const DestructiveSecondaryButton = React.forwardRef<HTMLButtonElement, DirectBut
 DestructiveSecondaryButton.defaultProps = {
   as: 'button',
 };
-if (process.env.NODE_ENV === 'development') {
-  DestructiveSecondaryButton.propTypes = DirectButtonPropTypes;
-}
+DestructiveSecondaryButton.propTypes = DirectButtonPropTypes;
+
 DestructiveSecondaryButton.displayName = 'DestructiveSecondaryButton';
 
 export {DestructiveSecondaryButton};

--- a/packages/paste-core/components/button/src/IconOnlyButton.tsx
+++ b/packages/paste-core/components/button/src/IconOnlyButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {Box, BoxStyleProps, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BoxStyleProps} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import {SizeStyles, BaseStyles} from './styles';
 import type {DirectButtonProps} from './types';
 import {DirectButtonPropTypes} from './proptypes';
@@ -7,10 +8,29 @@ import {DirectButtonPropTypes} from './proptypes';
 // This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
 const merge = require('deepmerge');
 
+/*
+ * defensively resetting interaction color from over zealous legacy
+ * global styles "a {...}" when button is set as an anchor
+ */
 const defaultStyles: BoxStyleProps = merge(BaseStyles.default, {
-  fontSize: 'inherit',
-  fontWeight: 'inherit',
-  color: 'inherit',
+  color: 'colorTextIcon',
+  backgroundColor: 'colorBackgroundBody',
+  boxShadow: 'shadowBorder',
+  _hover: {
+    color: 'colorText',
+    backgroundColor: 'colorBackgroundPrimaryWeakest',
+    boxShadow: 'shadowBorderPrimaryStronger',
+  },
+  _focus: {
+    color: 'colorTextLinkStronger',
+    backgroundColor: 'colorBackgroundPrimaryWeakest',
+    boxShadow: 'shadowFocus',
+  },
+  _active: {
+    color: 'colorTextLinkStronger',
+    backgroundColor: 'colorBackgroundPrimaryWeaker',
+    boxShadow: 'shadowBorderPrimaryStronger',
+  },
 });
 
 const loadingStyles: BoxStyleProps = merge(BaseStyles.loading, {fontSize: 'inherit', fontWeight: 'inherit'});
@@ -23,7 +43,7 @@ const ButtonStyleMapping = {
   disabled: disabledStyles,
 };
 
-const ResetButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
+const IconOnlyButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
   ({size, buttonState, fullWidth, ...props}, ref) => {
     // Must spread size styles after button styles
     return (
@@ -37,11 +57,11 @@ const ResetButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
     );
   }
 );
-ResetButton.defaultProps = {
+IconOnlyButton.defaultProps = {
   as: 'button',
 };
-ResetButton.propTypes = DirectButtonPropTypes;
+IconOnlyButton.propTypes = DirectButtonPropTypes;
 
-ResetButton.displayName = 'ResetButton';
+IconOnlyButton.displayName = 'IconOnlyButton';
 
-export {ResetButton};
+export {IconOnlyButton};

--- a/packages/paste-core/components/button/src/InverseButton.tsx
+++ b/packages/paste-core/components/button/src/InverseButton.tsx
@@ -73,9 +73,8 @@ const InverseButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
 InverseButton.defaultProps = {
   as: 'button',
 };
-if (process.env.NODE_ENV === 'development') {
-  InverseButton.propTypes = DirectButtonPropTypes;
-}
+InverseButton.propTypes = DirectButtonPropTypes;
+
 InverseButton.displayName = 'InverseButton';
 
 export {InverseButton};

--- a/packages/paste-core/components/button/src/InverseLinkButton.tsx
+++ b/packages/paste-core/components/button/src/InverseLinkButton.tsx
@@ -49,9 +49,8 @@ const InverseLinkButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>
 InverseLinkButton.defaultProps = {
   as: 'a',
 };
-if (process.env.NODE_ENV === 'development') {
-  InverseLinkButton.propTypes = DirectButtonPropTypes;
-}
+InverseLinkButton.propTypes = DirectButtonPropTypes;
+
 InverseLinkButton.displayName = 'InverseLinkButton';
 
 export {InverseLinkButton};

--- a/packages/paste-core/components/button/src/LinkButton.tsx
+++ b/packages/paste-core/components/button/src/LinkButton.tsx
@@ -50,9 +50,8 @@ const LinkButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
 LinkButton.defaultProps = {
   as: 'a',
 };
-if (process.env.NODE_ENV === 'development') {
-  LinkButton.propTypes = DirectButtonPropTypes;
-}
+LinkButton.propTypes = DirectButtonPropTypes;
+
 LinkButton.displayName = 'LinkButton';
 
 export {LinkButton};

--- a/packages/paste-core/components/button/src/PrimaryButton.tsx
+++ b/packages/paste-core/components/button/src/PrimaryButton.tsx
@@ -68,9 +68,8 @@ const PrimaryButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
 PrimaryButton.defaultProps = {
   as: 'button',
 };
-if (process.env.NODE_ENV === 'development') {
-  PrimaryButton.propTypes = DirectButtonPropTypes;
-}
+PrimaryButton.propTypes = DirectButtonPropTypes;
+
 PrimaryButton.displayName = 'PrimaryButton';
 
 export {PrimaryButton};

--- a/packages/paste-core/components/button/src/SecondaryButton.tsx
+++ b/packages/paste-core/components/button/src/SecondaryButton.tsx
@@ -82,9 +82,8 @@ const SecondaryButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
 SecondaryButton.defaultProps = {
   as: 'button',
 };
-if (process.env.NODE_ENV === 'development') {
-  SecondaryButton.propTypes = DirectButtonPropTypes;
-}
+SecondaryButton.propTypes = DirectButtonPropTypes;
+
 SecondaryButton.displayName = 'SecondaryButton';
 
 export {SecondaryButton};

--- a/packages/paste-core/components/button/src/index.tsx
+++ b/packages/paste-core/components/button/src/index.tsx
@@ -23,6 +23,7 @@ import {LinkButton} from './LinkButton';
 import {InverseButton} from './InverseButton';
 import {InverseLinkButton} from './InverseLinkButton';
 import {ResetButton} from './ResetButton';
+import {IconOnlyButton} from './IconOnlyButton';
 
 const AnimatedBox = animated(Box);
 
@@ -34,7 +35,9 @@ const getButtonSize = (variant: ButtonVariants, children: React.ReactNode, size?
   let smartSize: ButtonSizes = 'default';
   if (size != null) {
     smartSize = size;
-  } else if (variant === 'link' || variant === 'destructive_link' || variant === 'reset') {
+    // per slack thread: https://twilio.slack.com/archives/GGQD89JRL/p1599762114086200
+    // icon-only variant size will either be 'reset' or 'icon' size
+  } else if (variant === 'link' || variant === 'destructive_link' || variant === 'reset' || variant === 'icon_only') {
     smartSize = 'reset';
   } else if (React.Children.count(children) === 1) {
     React.Children.forEach(children, (child) => {
@@ -101,6 +104,9 @@ const handlePropValidation = ({
   if ((size === 'icon' || size === 'icon_small') && fullWidth) {
     throw new Error('[Paste: Button] Icon buttons should not be fullWidth.');
   }
+  if (variant === 'icon_only' && React.Children.count(children) > 1) {
+    throw new Error('[Paste: Button] Icon-only Buttons can only have one icon child.');
+  }
 
   // Button validation
   if (children == null) {
@@ -111,6 +117,7 @@ const handlePropValidation = ({
   }
 };
 
+// not sure yet whether icon-only should go in here (because I'm not sure what this does)
 const variantsWithoutBoundingBox = new Set(['link', 'destructive_link', 'inverse_link', 'reset']);
 
 const ButtonContents: React.FC<ButtonContentsProps> = ({buttonState, children, showLoading, variant}) => {
@@ -167,6 +174,8 @@ const getButtonComponent = (variant: ButtonVariants): React.FunctionComponent<Di
       return InverseButton;
     case 'inverse_link':
       return InverseLinkButton;
+    case 'icon_only':
+      return IconOnlyButton;
     case 'primary':
     default:
       return PrimaryButton;

--- a/packages/paste-core/components/button/src/types.ts
+++ b/packages/paste-core/components/button/src/types.ts
@@ -8,6 +8,7 @@ export type ButtonVariants =
   | 'destructive'
   | 'destructive_link'
   | 'destructive_secondary'
+  | 'icon_only'
   | 'link'
   | 'inverse_link'
   | 'inverse'

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -5,6 +5,7 @@ import {Heading} from '@twilio-paste/heading';
 import {Stack} from '@twilio-paste/stack';
 import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {isRenderingOnServer} from '@twilio-paste/animation-library';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {Button} from '../src';
 import type {ButtonVariants, ButtonSizes} from '../src/types';
 
@@ -103,6 +104,13 @@ export const DestructiveSecondaryButton = (): React.ReactNode => <AllSizeOptions
 export const DestructiveLinkButton = (): React.ReactNode => <AllSizeOptions variant="destructive_link" />;
 export const LinkButton = (): React.ReactNode => <AllSizeOptions variant="link" />;
 export const InverseLinkButton = (): React.ReactNode => <AllSizeOptions variant="inverse_link" />;
+
+export const IconOnlyButton = (): React.ReactNode => (
+  <Button variant="icon_only">
+    <CloseIcon decorative={false} title="Close modal button" />
+  </Button>
+);
+
 // This story is for VRT to ensure that non-visual elements don't add padding within the Button
 export const NoExtraPaddingButton = (): React.ReactNode => (
   <Stack orientation="vertical" spacing="space50">

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -10,6 +10,7 @@ import {Button} from '@twilio-paste/button';
 import {Stack} from '@twilio-paste/stack';
 import Changelog from '@twilio-paste/button/CHANGELOG.md';
 import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 import {SidebarCategoryRoutes} from '../../../constants';
@@ -210,9 +211,9 @@ screen if that action is destructive and could be difficult to reverse.
 </Button>`}
 </LivePreview>
 
-#### Icon-only button
+#### Single-action Button
 
-Use icon-only buttons sparingly.
+Use single-action Buttons sparingly.
 
 They should be used only in compact UI situations. Use an icon that can
 only convey a single action.
@@ -256,6 +257,19 @@ only convey a single action.
     <PlusIcon decorative={false} title="Add to cart" />
   </Button>
 </Stack>`}
+</LivePreview>
+
+#### Icon-only Button
+
+Use icon-only Buttons sparingly.
+
+The `icon_only` variant can be used as the close button in Modals, Alerts and Popvers. Only pass a single icon child.
+
+<LivePreview scope={{Button, CloseIcon}} language="jsx">
+  {`<Button variant="icon_only">
+      <CloseIcon decorative={false} title="Close Modal" />
+    </Button>
+  `}
 </LivePreview>
 
 #### Link-style button


### PR DESCRIPTION
Will convert from draft to full PR once design tokens are finalized.

Add `icon_only` variant to Button for use as close buttons in Modal, Alert, Popover, etc. Ticket: https://issues.corp.twilio.com/browse/DSYS-1780

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
