### PR TITLE
fix(data grid): make 'striped' prop work

### DIFF
--- a/.changeset/giant-ladybugs-promise.md
+++ b/.changeset/giant-ladybugs-promise.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/data-grid': patch
+'@twilio-paste/core': patch
+---
+
+[Data Grid] Fixed broken 'striped' prop so it correctly toggles zebra striping on rows.

--- a/packages/paste-core/components/data-grid/src/DataGrid.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGrid.tsx
@@ -24,133 +24,137 @@ export interface DataGridProps extends TableProps {
  * DataGrid wrapper component.
  *
  * @param {string} aria-label - for screen readers
+ * @param {boolean} striped - zebra striping on table rows
  * @param {string} element - customization element
  */
-export const DataGrid = React.forwardRef<HTMLTableElement, DataGridProps>(({element = 'DATA_GRID', ...props}, ref) => {
-  const dataGridId = `data-grid-${useUID()}`;
-  const lastFocusedElement = React.useRef<Element | null>(null);
-  const compositeState = useCompositeState({unstable_virtual: false});
-  const [actionable, setActionable] = React.useState<boolean>(false);
+export const DataGrid = React.forwardRef<HTMLTableElement, DataGridProps>(
+  ({element = 'DATA_GRID', striped = true, ...props}, ref) => {
+    const dataGridId = `data-grid-${useUID()}`;
+    const lastFocusedElement = React.useRef<Element | null>(null);
+    const compositeState = useCompositeState({unstable_virtual: false});
+    const [actionable, setActionable] = React.useState<boolean>(false);
 
-  /**
-   * Clicking into the DataGrid should unconditionally enable actionable mode
-   */
-  const handleMouseDown = React.useCallback(() => {
-    setActionable(true);
-  }, []);
+    /**
+     * Clicking into the DataGrid should unconditionally enable actionable mode
+     */
+    const handleMouseDown = React.useCallback(() => {
+      setActionable(true);
+    }, []);
 
-  /**
-   * Keep track of the last focused element. This is needed to restore tabIndex to 0
-   * when clicking out of the grid, so that we can tab back into it.
-   */
-  const handleFocus = React.useCallback((e: React.FocusEvent) => {
-    if (e.target != null) {
-      lastFocusedElement.current = e.target;
-    }
-  }, []);
-
-  /**
-   * - Reset DataGrid to navigational on blur
-   * - Sets the last focused element before blurring to be the active tab stop (line 43)
-   */
-  const handleBlur = React.useCallback(
-    (event) => {
-      const isDataGridBlurred = !event.currentTarget.contains(event.relatedTarget);
-
-      if (isDataGridBlurred) {
-        setActionable(false);
-
-        if (lastFocusedElement.current != null) {
-          const closestCell = getClosestCellFrom(lastFocusedElement.current, dataGridId);
-          if (closestCell) {
-            // TabIndex isn't resetting to 0 on escape. This makes it reset to 0 after a delay
-            // Race condition fix vs Composite code
-            delayedSetFocusable(closestCell);
-          }
-        }
+    /**
+     * Keep track of the last focused element. This is needed to restore tabIndex to 0
+     * when clicking out of the grid, so that we can tab back into it.
+     */
+    const handleFocus = React.useCallback((e: React.FocusEvent) => {
+      if (e.target != null) {
+        lastFocusedElement.current = e.target;
       }
-    },
-    [dataGridId]
-  );
+    }, []);
 
-  /**
-   * Handles Enter and Escape keypresses for swapping between actionable and navigational modes
-   */
-  const handleKeypress = React.useCallback(
-    (event: React.KeyboardEvent) => {
-      switch (event.key) {
-        // Wrapping cases in {} to avoid ESLint error
-        // https://eslint.org/docs/rules/no-case-declarations
-        case 'Enter': {
-          // Set the actionable state
-          setActionable(true);
+    /**
+     * - Reset DataGrid to navigational on blur
+     * - Sets the last focused element before blurring to be the active tab stop (line 43)
+     */
+    const handleBlur = React.useCallback(
+      (event) => {
+        const isDataGridBlurred = !event.currentTarget.contains(event.relatedTarget);
 
-          const activeElement = getActiveElement() as HTMLElement;
-          // Only if it's a DataGrid cell
-          if (isCell(activeElement)) {
-            // Get the first focusable child
-            const firstFocusableElement = getFirstFocusableIn(activeElement);
+        if (isDataGridBlurred) {
+          setActionable(false);
 
-            // If there is a focusable child focus it
-            if (firstFocusableElement) {
-              ensureFocus(firstFocusableElement as HTMLElement);
-              // First shift+tab fix upon entering actionable mode
-              activeElement.tabIndex = actionable ? 0 : -1;
+          if (lastFocusedElement.current != null) {
+            const closestCell = getClosestCellFrom(lastFocusedElement.current, dataGridId);
+            if (closestCell) {
+              // TabIndex isn't resetting to 0 on escape. This makes it reset to 0 after a delay
+              // Race condition fix vs Composite code
+              delayedSetFocusable(closestCell);
             }
           }
-          break;
         }
-        case 'Escape': {
-          // Set the actionable state
-          setActionable(false);
-          // From the current focus target, find the closest parent cell
-          const closestCell = getClosestGridCellFromCurrentFocus(dataGridId);
-          // If a cell is found, focus it
-          if (closestCell) {
-            ensureFocus(closestCell);
-            // TabIndex isn't resetting to 0 on escape. This makes it reset to 0 after a delay
-            delayedSetFocusable(closestCell);
+      },
+      [dataGridId]
+    );
+
+    /**
+     * Handles Enter and Escape keypresses for swapping between actionable and navigational modes
+     */
+    const handleKeypress = React.useCallback(
+      (event: React.KeyboardEvent) => {
+        switch (event.key) {
+          // Wrapping cases in {} to avoid ESLint error
+          // https://eslint.org/docs/rules/no-case-declarations
+          case 'Enter': {
+            // Set the actionable state
+            setActionable(true);
+
+            const activeElement = getActiveElement() as HTMLElement;
+            // Only if it's a DataGrid cell
+            if (isCell(activeElement)) {
+              // Get the first focusable child
+              const firstFocusableElement = getFirstFocusableIn(activeElement);
+
+              // If there is a focusable child focus it
+              if (firstFocusableElement) {
+                ensureFocus(firstFocusableElement as HTMLElement);
+                // First shift+tab fix upon entering actionable mode
+                activeElement.tabIndex = actionable ? 0 : -1;
+              }
+            }
+            break;
           }
-          break;
+          case 'Escape': {
+            // Set the actionable state
+            setActionable(false);
+            // From the current focus target, find the closest parent cell
+            const closestCell = getClosestGridCellFromCurrentFocus(dataGridId);
+            // If a cell is found, focus it
+            if (closestCell) {
+              ensureFocus(closestCell);
+              // TabIndex isn't resetting to 0 on escape. This makes it reset to 0 after a delay
+              delayedSetFocusable(closestCell);
+            }
+            break;
+          }
+          default:
+            break;
         }
-        default:
-          break;
-      }
-    },
-    [actionable, dataGridId]
-  );
+      },
+      [actionable, dataGridId]
+    );
 
-  const dataGridState = {
-    ...compositeState,
-    actionable,
-  };
+    const dataGridState = {
+      ...compositeState,
+      actionable,
+      striped,
+    };
 
-  return (
-    <DataGridContext.Provider value={dataGridState}>
-      <Box
-        id={dataGridId}
-        element={`${element}_WRAPPER`}
-        overflowX="auto"
-        whiteSpace="nowrap"
-        boxShadow={actionable ? 'shadowFocus' : null}
-      >
-        <Composite
-          {...props}
-          {...compositeState}
-          ref={ref}
-          as={Table}
-          element={element}
-          role="grid"
-          onKeyDown={handleKeypress}
-          onMouseDown={handleMouseDown}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          data-actionable={actionable}
-        />
-      </Box>
-    </DataGridContext.Provider>
-  );
-});
+    return (
+      <DataGridContext.Provider value={dataGridState}>
+        <Box
+          id={dataGridId}
+          element={`${element}_WRAPPER`}
+          overflowX="auto"
+          whiteSpace="nowrap"
+          boxShadow={actionable ? 'shadowFocus' : null}
+        >
+          <Composite
+            {...props}
+            {...compositeState}
+            ref={ref}
+            as={Table}
+            element={element}
+            role="grid"
+            onKeyDown={handleKeypress}
+            onMouseDown={handleMouseDown}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            data-actionable={actionable}
+          />
+        </Box>
+      </DataGridContext.Provider>
+    );
+  }
+);
 
 DataGrid.displayName = 'DataGrid';
 DataGrid.propTypes = {

--- a/packages/paste-core/components/data-grid/src/DataGrid.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGrid.tsx
@@ -28,7 +28,7 @@ export interface DataGridProps extends TableProps {
  * @param {string} element - customization element
  */
 export const DataGrid = React.forwardRef<HTMLTableElement, DataGridProps>(
-  ({element = 'DATA_GRID', striped = true, ...props}, ref) => {
+  ({element = 'DATA_GRID', striped = false, ...props}, ref) => {
     const dataGridId = `data-grid-${useUID()}`;
     const lastFocusedElement = React.useRef<Element | null>(null);
     const compositeState = useCompositeState({unstable_virtual: false});

--- a/packages/paste-core/components/data-grid/src/DataGridContext.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridContext.tsx
@@ -11,5 +11,5 @@ interface DataGridState extends Partial<CompositeStateReturn> {
  */
 export const DataGridContext = React.createContext<DataGridState>({
   actionable: false,
-  striped: true,
+  striped: false,
 });

--- a/packages/paste-core/components/data-grid/src/DataGridContext.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridContext.tsx
@@ -3,6 +3,7 @@ import type {CompositeStateReturn} from '@twilio-paste/reakit-library';
 
 interface DataGridState extends Partial<CompositeStateReturn> {
   actionable: boolean;
+  striped: boolean;
 }
 
 /**
@@ -10,4 +11,5 @@ interface DataGridState extends Partial<CompositeStateReturn> {
  */
 export const DataGridContext = React.createContext<DataGridState>({
   actionable: false,
+  striped: true,
 });

--- a/packages/paste-core/components/data-grid/src/table/Tr.tsx
+++ b/packages/paste-core/components/data-grid/src/table/Tr.tsx
@@ -5,31 +5,34 @@ import type {BoxElementProps} from '@twilio-paste/box';
 
 export interface TrProps {
   role: string;
+  striped: boolean;
   selected?: boolean;
   element?: BoxElementProps['element'];
 }
 
-export const Tr = React.forwardRef<HTMLTableRowElement, TrProps>(({element = 'DATA_GRID_TR', ...props}, ref) => {
-  return (
-    <Box
-      {...safelySpreadBoxProps(props)}
-      ref={ref}
-      element={element}
-      as="tr"
-      aria-selected={props.selected}
-      borderStyle="solid"
-      borderColor="colorBorderWeaker"
-      borderWidth="borderWidth0"
-      borderBottomWidth="borderWidth10"
-      _even={{backgroundColor: 'colorBackgroundRowStriped'}}
-      _last={{borderWidth: 'borderWidth0'}}
-      _selected={{
-        backgroundColor: 'colorBackgroundPrimaryWeakest',
-        borderColor: 'colorBorderWeak',
-      }}
-    />
-  );
-});
+export const Tr = React.forwardRef<HTMLTableRowElement, TrProps>(
+  ({element = 'DATA_GRID_TR', striped, ...props}, ref) => {
+    return (
+      <Box
+        {...safelySpreadBoxProps(props)}
+        ref={ref}
+        element={element}
+        as="tr"
+        aria-selected={props.selected}
+        borderStyle="solid"
+        borderColor="colorBorderWeaker"
+        borderWidth="borderWidth0"
+        borderBottomWidth="borderWidth10"
+        _even={{backgroundColor: striped ? 'colorBackgroundRowStriped' : 'transparent'}}
+        _last={{borderWidth: 'borderWidth0'}}
+        _selected={{
+          backgroundColor: 'colorBackgroundPrimaryWeakest',
+          borderColor: 'colorBorderWeak',
+        }}
+      />
+    );
+  }
+);
 
 Tr.displayName = 'Tr';
 Tr.propTypes = {

--- a/packages/paste-core/components/data-grid/stories/components/ComposableCellsDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/ComposableCellsDataGrid.tsx
@@ -29,7 +29,7 @@ const ActionMenu: React.FC = () => {
 export const ComposableCellsDataGrid: React.FC = () => {
   /* eslint-disable react/no-array-index-key */
   return (
-    <DataGrid aria-label="User list" data-testid="data-grid">
+    <DataGrid aria-label="User list" data-testid="data-grid" striped>
       <DataGridHead>
         <DataGridRow>
           <DataGridHeader data-testid="header-1">{TableHeaderData[0]}</DataGridHeader>

--- a/packages/paste-core/components/data-grid/stories/components/KitchenSinkDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/KitchenSinkDataGrid.tsx
@@ -249,7 +249,7 @@ export const KitchenSinkDataGrid: React.FC = () => {
   return (
     <>
       <CheckboxGroup name="items" legend="Select which user to promote">
-        <DataGrid aria-label="example grid">
+        <DataGrid aria-label="example grid" striped>
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader width="55px">

--- a/packages/paste-core/components/data-grid/stories/components/LoadingDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/LoadingDataGrid.tsx
@@ -9,7 +9,7 @@ export const LoadingDataGrid: React.FC = () => {
   const widthsLength = widths.length;
   /* eslint-disable react/no-array-index-key */
   return (
-    <DataGrid aria-label="User information table" striped={false}>
+    <DataGrid aria-label="User information table">
       <DataGridHead>
         <DataGridRow>
           <DataGridHeader>{TableHeaderData[0]}</DataGridHeader>

--- a/packages/paste-core/components/data-grid/stories/components/LoadingDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/LoadingDataGrid.tsx
@@ -9,7 +9,7 @@ export const LoadingDataGrid: React.FC = () => {
   const widthsLength = widths.length;
   /* eslint-disable react/no-array-index-key */
   return (
-    <DataGrid aria-label="User information table">
+    <DataGrid aria-label="User information table" striped={false}>
       <DataGridHead>
         <DataGridRow>
           <DataGridHeader>{TableHeaderData[0]}</DataGridHeader>

--- a/packages/paste-core/components/data-grid/stories/components/PaginatedDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/PaginatedDataGrid.tsx
@@ -194,7 +194,7 @@ export const PaginatedDataGrid: React.FC = () => {
   return (
     <>
       <CheckboxGroup name="items" legend="Select which user to promote">
-        <DataGrid aria-label="example grid">
+        <DataGrid aria-label="example grid" striped>
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader data-testid="first-cell" width="55px">

--- a/packages/paste-core/components/data-grid/stories/components/PlainDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/PlainDataGrid.tsx
@@ -13,7 +13,7 @@ export const PlainDataGrid: React.FC<{element?: BoxProps['element']}> = ({elemen
         Note: for DataGrids with no interactivity, use the{' '}
         <Anchor href="https://paste.twilio.design/components/table">Table component</Anchor> instead!
       </Paragraph>
-      <DataGrid aria-label="User information table" data-testid="data-grid" element={element}>
+      <DataGrid aria-label="User information table" data-testid="data-grid" element={element} striped>
         <DataGridHead data-testid="data-grid-head" element={`${element}_HEAD`}>
           <DataGridRow element={`${element}_ROW`}>
             <DataGridHeader data-testid="data-grid-header" element={`${element}_HEADER`}>

--- a/packages/paste-core/components/data-grid/stories/components/SelectableRowsDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/SelectableRowsDataGrid.tsx
@@ -67,7 +67,7 @@ export const SelectableRowsDataGrid: React.FC = () => {
   /* eslint-disable react/no-array-index-key */
   return (
     <CheckboxGroup name="items" legend="Select which user to promote">
-      <DataGrid aria-label="example grid">
+      <DataGrid aria-label="example grid" striped>
         <DataGridHead>
           <DataGridRow>
             <DataGridHeader width="55px">

--- a/packages/paste-core/components/data-grid/stories/components/SortableColumnsDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/SortableColumnsDataGrid.tsx
@@ -51,7 +51,7 @@ export const SortableColumnsDataGrid: React.FC = () => {
 
   /* eslint-disable react/no-array-index-key */
   return (
-    <DataGrid aria-label="User information table">
+    <DataGrid aria-label="User information table" striped>
       <DataGridHead>
         <DataGridRow>
           <DataGridHeader aria-sort={sortedColumns[0]} data-testid="header">

--- a/packages/paste-website/src/component-examples/DataGridExamples.ts
+++ b/packages/paste-website/src/component-examples/DataGridExamples.ts
@@ -21,7 +21,7 @@ export const TableBodyData = [
 export const standardDataGrid = `
 const StandardDataGrid = ({element = 'DATA_GRID'}) => {
   return (
-    <DataGrid aria-label="User information table">
+    <DataGrid aria-label="User information table" striped>
       <DataGridHead >
         <DataGridRow >
           <DataGridHeader>{TableHeaderData[0]}</DataGridHeader>

--- a/packages/paste-website/src/component-examples/DataGridExamples.ts
+++ b/packages/paste-website/src/component-examples/DataGridExamples.ts
@@ -21,7 +21,7 @@ export const TableBodyData = [
 export const standardDataGrid = `
 const StandardDataGrid = ({element = 'DATA_GRID'}) => {
   return (
-    <DataGrid aria-label="User information table" striped={false}>
+    <DataGrid aria-label="User information table">
       <DataGridHead >
         <DataGridRow >
           <DataGridHeader>{TableHeaderData[0]}</DataGridHeader>

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -337,6 +337,7 @@ const Component = () => (
 | Prop       | Type        | Description                                             | Default     |
 | ---------- | ----------- | ------------------------------------------------------- | ----------- |
 | aria-label | `string`    | Defines a string value that labels the current element. | null        |
+| striped?   | `boolean`   | Toggles row zebra striping                              | true        |
 | element?   | `string`    | Override for customization element name                 | `DATA_GRID` |
 | children?  | `ReactNode` |                                                         | null        |
 

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -286,7 +286,7 @@ import {
 } from '@twilio-paste/core/data-grid';
 
 const Component = () => (
-  <DataGrid aria-label="User information table">
+  <DataGrid aria-label="User information table" striped>
     <DataGridHead>
       <DataGridRow>
         <DataGridHeader>First Name</DataGridHeader>
@@ -337,7 +337,7 @@ const Component = () => (
 | Prop       | Type        | Description                                             | Default     |
 | ---------- | ----------- | ------------------------------------------------------- | ----------- |
 | aria-label | `string`    | Defines a string value that labels the current element. | null        |
-| striped?   | `boolean`   | Toggles row zebra striping                              | true        |
+| striped?   | `boolean`   | Toggles row zebra striping                              | false       |
 | element?   | `string`    | Override for customization element name                 | `DATA_GRID` |
 | children?  | `ReactNode` |                                                         | null        |
 


### PR DESCRIPTION
Previously the `striped` prop wasn't doing anything. This fixes the `striped` prop and updates the docs so it works correctly on Data Grid.

 Updated the Loading story to use `striped={false}` so we can VRT it on one of our existing examples.