### PR TITLE
fix(slider-select): fix inadvertent image selection when interacting with the Image Slider

### DIFF
--- a/packages/paste-website/src/components/customization-landing-page/image-slider/ImageSlider.tsx
+++ b/packages/paste-website/src/components/customization-landing-page/image-slider/ImageSlider.tsx
@@ -85,6 +85,7 @@ export const ImageSlider: React.FC<{frontFluidObject: FluidObject; backFluidObje
       width="60%"
       zIndex="zIndex10"
       marginRight={['space0', 'space0', 'space100']}
+      userSelect="none"
     >
       <Box
         as="label"


### PR DESCRIPTION
Currently when interacting with the Image Slider component, when selection pushes past the boundaries of the container, a text selection effect will appear over the images.

This change prevents image selection while user interacts with the Image Slider component.

![image-selection](https://user-images.githubusercontent.com/36438/140330185-079bd93d-2968-4f6c-b42b-6b48e2ce8e14.gif)

