### PR TITLE
fix(website): broken roadmap link

### DIFF
--- a/packages/paste-website/src/components/Roadmap/Roadmap.tsx
+++ b/packages/paste-website/src/components/Roadmap/Roadmap.tsx
@@ -40,7 +40,7 @@ const Roadmap: React.FC<RoadmapProps> = ({data}) => {
     <Box width="100%">
       <Stack orientation="vertical" spacing="space190">
         {data.map((release) => {
-          const releaseSlug = slugify(release.release);
+          const releaseSlug = `#${slugify(release.release)}`;
           return (
             <Box key={useUID()} id={releaseSlug}>
               <Heading as="h2" variant="heading20">


### PR DESCRIPTION
This PR fixes broken links on the Roadmap page due to a missing `#` character that would route the user to a broken page rather than a page hash.

I also improve the broken link checker, providing the calling route to the HTTP header object so we can see from which file the error originated:
![image](https://user-images.githubusercontent.com/1592327/140554599-618d3615-1f15-4607-ae5f-b76f811540ce.png)
Additionally, I removed the contents of the IGNORE_LIST in the broken link checker since that list is now stale.