### PR TITLE
feat(button): add icon-specific variants

### DIFF
--- a/.changeset/little-meals-thank.md
+++ b/.changeset/little-meals-thank.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/button': minor
+'@twilio-paste/core': minor
+---
+
+[Button] Add variants to be used specifically with icons.

--- a/packages/paste-core/components/button/__tests__/button.test.tsx
+++ b/packages/paste-core/components/button/__tests__/button.test.tsx
@@ -87,6 +87,42 @@ describe('Button', () => {
       expect(results).toHaveNoViolations();
     });
 
+    it('Primary Icon button has no accessibility violations', async () => {
+      const {container} = testRender(
+        <Theme.Provider theme="default">
+          <Button variant="primary_icon" size="reset" onClick={NOOP}>
+            <PlusIcon decorative={false} title="add more" />
+          </Button>
+        </Theme.Provider>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('Secondary Icon button has no accessibility violations', async () => {
+      const {container} = testRender(
+        <Theme.Provider theme="default">
+          <Button variant="secondary_icon" size="reset" onClick={NOOP}>
+            <PlusIcon decorative={false} title="add more" />
+          </Button>
+        </Theme.Provider>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('Destructive Icon button has no accessibility violations', async () => {
+      const {container} = testRender(
+        <Theme.Provider theme="default">
+          <Button variant="destructive_icon" size="reset" onClick={NOOP}>
+            <PlusIcon decorative={false} title="add more" />
+          </Button>
+        </Theme.Provider>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
     it('Loading states have no accessibility violations', async () => {
       const {container} = testRender(
         <Theme.Provider theme="console">
@@ -409,6 +445,19 @@ describe('Button', () => {
       expect(getByText('Primary')).toHaveStyleRule('justify-content', 'center');
     });
 
+    it('should have the correct styles for the primary_icon variant', () => {
+      const {getByTestId} = testRender(
+        <Button variant="primary_icon" data-testid="primary-icon-styles" size="reset" onClick={NOOP}>
+          <PlusIcon decorative={false} title="add more" />
+        </Button>
+      );
+
+      const button = getByTestId('primary-icon-styles');
+
+      expect(button).not.toHaveStyleRule('text-align', 'left');
+      expect(button).toHaveStyleRule('color', 'colorTextLink');
+    });
+
     it('should have the correct styles for the secondary variant', () => {
       const {getByTestId, getByText} = testRender(
         <Button variant="secondary" data-testid="secondary-styles">
@@ -426,6 +475,19 @@ describe('Button', () => {
       expect(getByText('Secondary')).toHaveStyleRule('justify-content', 'center');
     });
 
+    it('should have the correct styles for the secondary_icon variant', () => {
+      const {getByTestId} = testRender(
+        <Button variant="secondary_icon" data-testid="secondary-icon-styles" size="reset" onClick={NOOP}>
+          <PlusIcon decorative={false} title="add more" />
+        </Button>
+      );
+
+      const button = getByTestId('secondary-icon-styles');
+
+      expect(button).not.toHaveStyleRule('text-align', 'left');
+      expect(button).toHaveStyleRule('color', 'colorTextIcon');
+    });
+
     it('should have the correct styles for the destructive variant', () => {
       const {getByTestId, getByText} = testRender(
         <Button variant="destructive" data-testid="destructive-styles">
@@ -441,6 +503,19 @@ describe('Button', () => {
       expect(button).toHaveStyleRule('box-shadow', 'shadowBorderDestructive');
 
       expect(getByText('Destructive')).toHaveStyleRule('justify-content', 'center');
+    });
+
+    it('should have the correct styles for the destructive_icon variant', () => {
+      const {getByTestId} = testRender(
+        <Button variant="destructive_icon" data-testid="destructive-icon-styles" size="reset" onClick={NOOP}>
+          <PlusIcon decorative={false} title="add more" />
+        </Button>
+      );
+
+      const button = getByTestId('destructive-icon-styles');
+
+      expect(button).not.toHaveStyleRule('text-align', 'left');
+      expect(button).toHaveStyleRule('color', 'colorTextLinkDestructive');
     });
 
     it('should have the correct styles for the destructive_secondary variant', () => {

--- a/packages/paste-core/components/button/src/DestructiveIconButton.tsx
+++ b/packages/paste-core/components/button/src/DestructiveIconButton.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import type {BoxStyleProps} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import {SizeStyles, BaseStyles} from './styles';
+import type {DirectButtonProps} from './types';
+import {DirectButtonPropTypes} from './proptypes';
+
+// This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
+const merge = require('deepmerge');
+
+/*
+ * defensively resetting 'color' on pseudostyles from over zealous
+ * legacy global styles "a {...}" when button is set as an anchor
+ */
+const defaultStyles: BoxStyleProps = merge(BaseStyles.default, {
+  color: 'colorTextLinkDestructive',
+  _hover: {
+    color: 'colorTextLinkDestructiveStronger',
+  },
+  _focus: {
+    color: 'colorTextLinkDestructiveStronger',
+  },
+  _active: {
+    color: 'colorTextLinkDestructiveStrongest',
+  },
+});
+
+const loadingStyles: BoxStyleProps = merge(BaseStyles.loading, {
+  color: 'colorTextLinkDestructiveStronger',
+});
+
+const disabledStyles = merge(BaseStyles.disabled, {
+  color: 'colorTextLinkDestructiveWeak',
+});
+
+const ButtonStyleMapping = {
+  default: defaultStyles,
+  loading: loadingStyles,
+  disabled: disabledStyles,
+};
+
+const DestructiveIconButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
+  ({size, buttonState, fullWidth, ...props}, ref) => {
+    // Must spread size styles after button styles
+    return (
+      <Box
+        ref={ref}
+        width={fullWidth ? '100%' : 'auto'}
+        {...safelySpreadBoxProps(props)}
+        {...ButtonStyleMapping[buttonState]}
+        {...SizeStyles[size]}
+      />
+    );
+  }
+);
+DestructiveIconButton.defaultProps = {
+  as: 'button',
+};
+if (process.env.NODE_ENV === 'development') {
+  DestructiveIconButton.propTypes = DirectButtonPropTypes;
+}
+DestructiveIconButton.displayName = 'DestructiveIconButton';
+
+export {DestructiveIconButton};

--- a/packages/paste-core/components/button/src/PrimaryIconButton.tsx
+++ b/packages/paste-core/components/button/src/PrimaryIconButton.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import type {BoxStyleProps} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import {SizeStyles, BaseStyles} from './styles';
+import type {DirectButtonProps} from './types';
+import {DirectButtonPropTypes} from './proptypes';
+
+// This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
+const merge = require('deepmerge');
+
+/*
+ * defensively resetting 'color' on pseudostyles from over zealous
+ * legacy global styles "a {...}" when button is set as an anchor
+ */
+const defaultStyles: BoxStyleProps = merge(BaseStyles.default, {
+  color: 'colorTextLink',
+  _hover: {
+    color: 'colorTextLinkStronger',
+  },
+  _focus: {
+    color: 'colorTextLinkStronger',
+  },
+  _active: {
+    color: 'colorTextLinkStrongest',
+  },
+});
+
+const loadingStyles: BoxStyleProps = merge(BaseStyles.loading, {
+  color: 'colorTextLinkStronger',
+});
+
+const disabledStyles = merge(BaseStyles.disabled, {
+  color: 'colorTextLinkWeak',
+});
+
+const ButtonStyleMapping = {
+  default: defaultStyles,
+  loading: loadingStyles,
+  disabled: disabledStyles,
+};
+
+const PrimaryIconButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
+  ({size, buttonState, fullWidth, ...props}, ref) => {
+    // Must spread size styles after button styles
+    return (
+      <Box
+        ref={ref}
+        width={fullWidth ? '100%' : 'auto'}
+        {...safelySpreadBoxProps(props)}
+        {...ButtonStyleMapping[buttonState]}
+        {...SizeStyles[size]}
+      />
+    );
+  }
+);
+PrimaryIconButton.defaultProps = {
+  as: 'button',
+};
+if (process.env.NODE_ENV === 'development') {
+  PrimaryIconButton.propTypes = DirectButtonPropTypes;
+}
+PrimaryIconButton.displayName = 'PrimaryIconButton';
+
+export {PrimaryIconButton};

--- a/packages/paste-core/components/button/src/SecondaryIconButton.tsx
+++ b/packages/paste-core/components/button/src/SecondaryIconButton.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import type {BoxStyleProps} from '@twilio-paste/box';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import {SizeStyles, BaseStyles} from './styles';
+import type {DirectButtonProps} from './types';
+import {DirectButtonPropTypes} from './proptypes';
+
+// This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
+const merge = require('deepmerge');
+
+/*
+ * defensively resetting 'color' on pseudostyles from over zealous
+ * legacy global styles "a {...}" when button is set as an anchor
+ */
+const defaultStyles: BoxStyleProps = merge(BaseStyles.default, {
+  color: 'colorTextIcon',
+  _hover: {
+    color: 'colorText',
+  },
+  _focus: {
+    color: 'colorText',
+  },
+  _active: {
+    color: 'colorText',
+  },
+});
+
+const loadingStyles: BoxStyleProps = merge(BaseStyles.loading, {
+  color: 'colorText',
+});
+
+const disabledStyles = merge(BaseStyles.disabled, {
+  color: 'colorTextWeaker',
+});
+
+const ButtonStyleMapping = {
+  default: defaultStyles,
+  loading: loadingStyles,
+  disabled: disabledStyles,
+};
+
+const SecondaryIconButton = React.forwardRef<HTMLButtonElement, DirectButtonProps>(
+  ({size, buttonState, fullWidth, ...props}, ref) => {
+    // Must spread size styles after button styles
+    return (
+      <Box
+        ref={ref}
+        width={fullWidth ? '100%' : 'auto'}
+        {...safelySpreadBoxProps(props)}
+        {...ButtonStyleMapping[buttonState]}
+        {...SizeStyles[size]}
+      />
+    );
+  }
+);
+SecondaryIconButton.defaultProps = {
+  as: 'button',
+};
+if (process.env.NODE_ENV === 'development') {
+  SecondaryIconButton.propTypes = DirectButtonPropTypes;
+}
+SecondaryIconButton.displayName = 'SecondaryIconButton';
+
+export {SecondaryIconButton};

--- a/packages/paste-core/components/button/src/index.tsx
+++ b/packages/paste-core/components/button/src/index.tsx
@@ -15,8 +15,11 @@ import type {
 } from './types';
 import {ButtonPropTypes} from './proptypes';
 import {PrimaryButton} from './PrimaryButton';
+import {PrimaryIconButton} from './PrimaryIconButton';
 import {SecondaryButton} from './SecondaryButton';
+import {SecondaryIconButton} from './SecondaryIconButton';
 import {DestructiveButton} from './DestructiveButton';
+import {DestructiveIconButton} from './DestructiveIconButton';
 import {DestructiveLinkButton} from './DestructiveLinkButton';
 import {DestructiveSecondaryButton} from './DestructiveSecondaryButton';
 import {LinkButton} from './LinkButton';
@@ -152,10 +155,16 @@ const ButtonContents: React.FC<ButtonContentsProps> = ({buttonState, children, s
 
 const getButtonComponent = (variant: ButtonVariants): React.FunctionComponent<DirectButtonProps> => {
   switch (variant) {
+    case 'primary_icon':
+      return PrimaryIconButton;
     case 'secondary':
       return SecondaryButton;
+    case 'secondary_icon':
+      return SecondaryIconButton;
     case 'destructive':
       return DestructiveButton;
+    case 'destructive_icon':
+      return DestructiveIconButton;
     case 'destructive_secondary':
       return DestructiveSecondaryButton;
     case 'link':

--- a/packages/paste-core/components/button/src/proptypes.ts
+++ b/packages/paste-core/components/button/src/proptypes.ts
@@ -19,6 +19,9 @@ export const DirectButtonPropTypes = {
     'inverse_link',
     'inverse',
     'reset',
+    'primary_icon',
+    'secondary_icon',
+    'destructive_icon',
   ]) as any,
 };
 
@@ -42,5 +45,8 @@ export const ButtonPropTypes = {
     'inverse_link',
     'inverse',
     'reset',
+    'primary_icon',
+    'secondary_icon',
+    'destructive_icon',
   ]).isRequired as any,
 };

--- a/packages/paste-core/components/button/src/types.ts
+++ b/packages/paste-core/components/button/src/types.ts
@@ -4,8 +4,11 @@ type ButtonTypes = 'submit' | 'button' | 'reset';
 export type ButtonSizes = 'small' | 'default' | 'icon' | 'icon_small' | 'reset';
 export type ButtonVariants =
   | 'primary'
+  | 'primary_icon'
   | 'secondary'
+  | 'secondary_icon'
   | 'destructive'
+  | 'destructive_icon'
   | 'destructive_link'
   | 'destructive_secondary'
   | 'link'

--- a/packages/paste-core/components/button/stories/index.stories.tsx
+++ b/packages/paste-core/components/button/stories/index.stories.tsx
@@ -3,6 +3,7 @@ import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
 import {Box} from '@twilio-paste/box';
 import {Heading} from '@twilio-paste/heading';
 import {Stack} from '@twilio-paste/stack';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {isRenderingOnServer} from '@twilio-paste/animation-library';
 import {Button} from '../src';
@@ -169,3 +170,62 @@ export const ButtonAsAnchor = (): React.ReactNode => {
     </>
   );
 };
+
+const IconSizeOptions: React.FC<{variant: ButtonVariants}> = ({variant}) => {
+  return (
+    <Stack orientation="vertical" spacing="space60">
+      <Box>
+        <Heading as="h2" variant="heading40">
+          Using size=&quot;reset&quot;
+        </Heading>
+        <Stack orientation="horizontal" spacing="space60">
+          <Button variant={variant} size="reset">
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="reset" loading>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="reset" disabled>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+        </Stack>
+      </Box>
+      <Box>
+        <Heading as="h2" variant="heading40">
+          Using size=&quot;icon_small&quot;
+        </Heading>
+        <Stack orientation="horizontal" spacing="space60">
+          <Button variant={variant} size="icon_small">
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="icon_small" loading>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="icon_small" disabled>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+        </Stack>
+      </Box>
+      <Box>
+        <Heading as="h2" variant="heading40">
+          Using size=&quot;icon&quot;
+        </Heading>
+        <Stack orientation="horizontal" spacing="space60">
+          <Button variant={variant} size="icon">
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="icon" loading>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+          <Button variant={variant} size="icon" disabled>
+            <CloseIcon decorative={false} title="close" />
+          </Button>
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};
+
+export const PrimaryIconButton = (): React.ReactNode => <IconSizeOptions variant="primary_icon" />;
+export const SecondaryIconButton = (): React.ReactNode => <IconSizeOptions variant="secondary_icon" />;
+export const DestructiveIconButton = (): React.ReactNode => <IconSizeOptions variant="destructive_icon" />;

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -10,6 +10,8 @@ import {Button} from '@twilio-paste/button';
 import {Stack} from '@twilio-paste/stack';
 import Changelog from '@twilio-paste/button/CHANGELOG.md';
 import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
+import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
+import {MinusIcon} from '@twilio-paste/icons/esm/MinusIcon';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 import {SidebarCategoryRoutes} from '../../../constants';
@@ -130,7 +132,7 @@ screen readers and dictation software. Here are some quick tips:
 
 ### Examples
 
-<LivePreview scope={{Button, Stack}} language="jsx">
+<LivePreview scope={{Button, Stack, PlusIcon}} language="jsx">
   {`<Stack orientation="horizontal" spacing="space30">
   <Button variant="primary">
     ✊ Action
@@ -154,6 +156,15 @@ screen readers and dictation software. Here are some quick tips:
   <Button variant="destructive_link">Action</Button>
   <Button variant="reset" size="reset">
     Action
+  </Button>
+  <Button variant="primary_icon" size="reset">
+    <PlusIcon decorative={false}  title="Add to cart" />
+  </Button>
+  <Button variant="secondary_icon" size="reset">
+    <PlusIcon decorative={false} title="close" />
+  </Button>
+  <Button variant="destructive_icon" size="reset">
+    <PlusIcon decorative={false} title="remove" />
   </Button>
 </Stack>`}
 </LivePreview>
@@ -208,54 +219,6 @@ screen if that action is destructive and could be difficult to reverse.
   {`<Button variant="destructive">
   Delete
 </Button>`}
-</LivePreview>
-
-#### Icon-only Button
-
-Use icon-only Buttons sparingly.
-
-They should be used only in compact UI situations. Use an icon that can
-only convey a single action.
-
-<LivePreview scope={{Button, Stack, PlusIcon}} language="jsx">
-  {`<Stack orientation="horizontal" spacing="space30">
-  <Button variant="primary" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="secondary" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="link" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive_secondary" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive_link" size="icon">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="primary" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="secondary" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="link" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive_secondary" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-  <Button variant="destructive_link" size="icon_small">
-    <PlusIcon decorative={false} title="Add to cart" />
-  </Button>
-</Stack>`}
 </LivePreview>
 
 #### Link-style Button
@@ -343,6 +306,65 @@ styles. No other Button functionality is reset.
   {`<Button variant="reset" size="reset">
   Edit
 </Button>`}
+</LivePreview>
+
+#### Icon Buttons
+
+Use primary icon, secondary icon, and destructive icon Button variants for buttons
+that, for a specific reason and purpose, can only have an icon in them, such as in
+compact UI situations. These variants do not have any border nor background color.
+When using these variants, use `size="reset"` in the Button component to remove
+any unnecessary padding. To change the size of an icon button, change the size of the Icon component itself.
+
+Use an icon that can only convey a single action.
+
+You can also create icon Buttons from other variants that have background colors and borders,
+like primary and secondary, by using that variant and changing the size of the Button
+component to `size="icon"` or `size="icon_small"`.
+
+Use icon-only Buttons sparingly. If there is any text in a button, do not use these icon-specific variants or sizes.
+
+<LivePreview scope={{Button, Stack, PlusIcon, MinusIcon, CloseIcon}} language="jsx">
+  {`
+<Stack orientation="vertical" spacing="space60">
+  <Stack orientation="horizontal" spacing="space60">
+    <Button variant="primary_icon" size="reset">
+      <PlusIcon decorative={false} size="sizeIcon10" title="Add to cart" />
+    </Button>
+    <Button variant="secondary_icon" size="reset">
+      <CloseIcon decorative={false} size="sizeIcon40" title="close" />
+    </Button>
+    <Button variant="destructive_icon" size="reset">
+      <MinusIcon decorative={false} size="sizeIcon80" title="remove" />
+    </Button>
+  </Stack>
+  <Stack orientation="horizontal" spacing="space60">
+    <Button variant="primary" size="icon">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="secondary" size="icon">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="destructive" size="icon">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="destructive_secondary" size="icon">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="primary" size="icon_small">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="secondary" size="icon_small">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="destructive" size="icon_small">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+    <Button variant="destructive_secondary" size="icon_small">
+      <PlusIcon decorative={false} title="Add to cart" />
+    </Button>
+  </Stack>
+</Stack>`}
 </LivePreview>
 
 ### States
@@ -522,23 +544,23 @@ const Component = () => (
 
 All the valid HTML attributes for `Button` are supported including the following props:
 
-| Prop          | Type                                     | Description                                                                                                                    | Default   |
-| ------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------- |
-| as?           | `string`                                 | The HTML tag to replace the default `<button>` tag.                                                                            | 'button'  |
-| disabled?     | `boolean`                                | Prevent actions from firing on this Button                                                                                     | false     |
-| fullWidth     | `boolean`                                | Sets the Button width to 100% of the parent container.                                                                         | false     |
-| href?         | `string`                                 | A URL to route to. Must use `as="a"` for this prop to work.                                                                    | null      |
-| loading?      | `boolean`                                | Prevent actions and show a loading spinner                                                                                     | false     |
-| size?         | `ButtonSizes`                            | 'default', 'small', 'icon', 'icon_small', 'reset'                                                                              | 'default' |
-| type?         | `ButtonTypes`                            | 'button', 'submit', 'reset'. If the Button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default).               | 'button'  |
-| variant?      | `ButtonVariants`                         | 'primary', 'secondary', 'inverse', 'destructive', 'destructive_secondary', 'destructive_link', 'link', 'inverse_link', 'reset' | 'primary' |
-| onClick?      | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onMouseDown?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onMouseUp?    | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onMouseEnter? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onMouseLeave? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onFocus?      | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                | null      |
-| onBlur?       | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                | null      |
+| Prop          | Type                                     | Description                                                                                                                                                                          | Default   |
+| ------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| as?           | `string`                                 | The HTML tag to replace the default `<button>` tag.                                                                                                                                  | 'button'  |
+| disabled?     | `boolean`                                | Prevent actions from firing on this Button                                                                                                                                           | false     |
+| fullWidth     | `boolean`                                | Sets the Button width to 100% of the parent container.                                                                                                                               | false     |
+| href?         | `string`                                 | A URL to route to. Must use `as="a"` for this prop to work.                                                                                                                          | null      |
+| loading?      | `boolean`                                | Prevent actions and show a loading spinner                                                                                                                                           | false     |
+| size?         | `ButtonSizes`                            | 'default', 'small', 'icon', 'icon_small', 'reset'                                                                                                                                    | 'default' |
+| type?         | `ButtonTypes`                            | 'button', 'submit', 'reset'. If the Button is inside a `<form>`: use 'submit'. Otherwise use 'button' (default).                                                                     | 'button'  |
+| variant?      | `ButtonVariants`                         | 'primary', 'secondary', 'inverse', 'destructive', 'destructive_secondary', 'destructive_link', 'link', 'inverse_link', 'reset', 'primary_icon', 'secondary_icon', 'destructive_icon' | 'primary' |
+| onClick?      | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onMouseDown?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onMouseUp?    | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onMouseEnter? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onMouseLeave? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onFocus?      | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
+| onBlur?       | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                                                                      | null      |
 
 <ChangelogRevealer>
   <Changelog />


### PR DESCRIPTION
Added icon-specific variants. Working on the docs changes now.

- [x] Colors are as specified[ in this table](https://docs.google.com/spreadsheets/d/14ZwZHgYKFK0-xht_4l_zIODLEfJLnHiMZthehkZ4dj4/edit#gid=0)
- [x] docs will specify to use `size="reset"` to eliminate padding for use in things like close buttons, and that changing the size of the icon itself will change the size of the button.
