### PR TITLE
test(website): block google analytics requests in cypress test

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,6 @@
   "retries": {
     "runMode": 2,
     "openMode": 0
-  }
+  },
+  "blockHosts": "*.google-analytics.com"
 }


### PR DESCRIPTION
Prevents cypress from sending google analytics events by blocking the host.  




<img width="694" alt="image" src="https://user-images.githubusercontent.com/1592327/140576356-a0947388-9056-4357-aa16-dc711b830516.png">

In the future, we can change this to test the events are firing correctly by [stubbing or intercepting](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__google-analytics).   For now however, let's just keep our data sane.