### PR TITLE
fix: typo in prerelease script in ci

### DIFF
--- a/.github/workflows/on_merge_to_main.yml
+++ b/.github/workflows/on_merge_to_main.yml
@@ -49,7 +49,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Run prerelease
-        run: yarn prerelase
+        run: yarn prerelease
 
       - name: Store build artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Merges to main were failing, looks like a typo in the recent changes