### PR TITLE
fix: only prevent chromatic running on version merge commits

### DIFF
--- a/.github/workflows/on_merge_to_main.yml
+++ b/.github/workflows/on_merge_to_main.yml
@@ -11,7 +11,6 @@ jobs:
   prerelease:
     name: Prerelease test and build
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'chore(release): version packages')"
 
     steps:
       - name: Checkout Repo
@@ -129,6 +128,7 @@ jobs:
     name: Chromatic baseline update
     needs: prerelease
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'chore(release): version packages')"
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Was overly protective on the merge to main workflow steps. We actually only want to prevent versioning merge commits running Chromatic. 

The other steps should still run.