### PR TITLE
feat(data-grid): add textAlign prop to DataGridCell

### DIFF
--- a/.changeset/eight-cars-breathe.md
+++ b/.changeset/eight-cars-breathe.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/data-grid': minor
+'@twilio-paste/core': minor
+---
+
+[Data-Grid] Add `textAlign` prop to `DataGridCell` for aligning cells and columns to the right.

--- a/packages/paste-core/components/data-grid/src/DataGridCell.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridCell.tsx
@@ -7,12 +7,13 @@ import {DataGridContext} from './DataGridContext';
 import {updateTabIndexForActionable, isCell, ensureFocus} from './utils';
 import {Td} from './table/Td';
 import {Th} from './table/Th';
+import type {TdProps} from './table/Td';
 
 // This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export
 const isElement = require('lodash.iselement');
 
 type CellType = 'th' | 'td';
-export interface DataGridCellProps {
+export interface DataGridCellProps extends Pick<TdProps, 'textAlign'> {
   as?: CellType;
   element?: BoxElementProps['element'];
 }

--- a/packages/paste-core/components/data-grid/stories/components/PlainDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/PlainDataGrid.tsx
@@ -22,7 +22,9 @@ export const PlainDataGrid: React.FC<{element?: BoxProps['element']}> = ({elemen
             <DataGridHeader element={`${element}_HEADER`}>{TableHeaderData[1]}</DataGridHeader>
             <DataGridHeader element={`${element}_HEADER`}>{TableHeaderData[2]}</DataGridHeader>
             <DataGridHeader element={`${element}_HEADER`}>{TableHeaderData[3]}</DataGridHeader>
-            <DataGridHeader element={`${element}_HEADER`}>{TableHeaderData[4]}</DataGridHeader>
+            <DataGridHeader element={`${element}_HEADER`} textAlign="right">
+              {TableHeaderData[4]}
+            </DataGridHeader>
           </DataGridRow>
         </DataGridHead>
         <DataGridBody data-testid="data-grid-body" element={`${element}_BODY`}>
@@ -37,6 +39,7 @@ export const PlainDataGrid: React.FC<{element?: BoxProps['element']}> = ({elemen
                   element={`${element}_CELL`}
                   key={`col-${colIndex}`}
                   data-testid={rowIndex === 0 && colIndex === 0 ? 'data-grid-cell' : null}
+                  textAlign={colIndex === 4 ? 'right' : 'left'}
                 >
                   {col}
                 </DataGridCell>
@@ -50,7 +53,9 @@ export const PlainDataGrid: React.FC<{element?: BoxProps['element']}> = ({elemen
             <DataGridCell element={`${element}_CELL`}>{TableHeaderData[1]}</DataGridCell>
             <DataGridCell element={`${element}_CELL`}>{TableHeaderData[2]}</DataGridCell>
             <DataGridCell element={`${element}_CELL`}>{TableHeaderData[3]}</DataGridCell>
-            <DataGridCell element={`${element}_CELL`}>{TableHeaderData[4]}</DataGridCell>
+            <DataGridCell element={`${element}_CELL`} textAlign="right">
+              {TableHeaderData[4]}
+            </DataGridCell>
           </DataGridRow>
         </DataGridFoot>
       </DataGrid>

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -389,11 +389,12 @@ const Component = () => (
 
 #### DataGridCell Props
 
-| Prop      | Type        | Description                                             | Default          |
-| --------- | ----------- | ------------------------------------------------------- | ---------------- |
-| as?       | "th", "td"  | Cells can either be th or td, so rows can have headers. | `td`             |
-| element?  | `string`    | Override for customization element name                 | `DATA_GRID_CELL` |
-| children? | `ReactNode` |                                                         | null             |
+| Prop       | Type        | Description                                             | Default          |
+| ---------- | ----------- | ------------------------------------------------------- | ---------------- |
+| as?        | "th", "td"  | Cells can either be th or td, so rows can have headers. | `td`             |
+| textAlign? | `string`    | CSS text align for this cell                            | `left`           |
+| element?   | `string`    | Override for customization element name                 | `DATA_GRID_CELL` |
+| children?  | `ReactNode` |                                                         | null             |
 
 <ChangelogRevealer>
   <Changelog />


### PR DESCRIPTION
Fixing inability to right-align data grid cells from https://github.com/twilio-labs/paste/discussions/2019

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
