### PR TITLE
chore(tokens): change color-text-icon in Dark mode

### DIFF
--- a/.changeset/nine-pugs-work.md
+++ b/.changeset/nine-pugs-work.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/design-tokens': patch
+'@twilio-paste/core': patch
+---
+
+[design-tokens] Changed the alias that Dark mode's color-text-icon points to from gray-10 to gray-60

--- a/packages/paste-design-tokens/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/paste-design-tokens/__tests__/__snapshots__/index.test.tsx.snap
@@ -646,7 +646,7 @@ exports[`Design Tokens matches the Dark theme 1`] = `
   \\"color-text-icon-brand-inverse\\": \\"rgb(255, 255, 255)\\",
   \\"color-text-success\\": \\"rgb(123, 234, 165)\\",
   \\"color-text-weak\\": \\"rgb(202, 205, 216)\\",
-  \\"color-text-icon\\": \\"rgb(244, 244, 246)\\",
+  \\"color-text-icon\\": \\"rgb(96, 107, 133)\\",
   \\"color-text-link\\": \\"rgb(0, 140, 255)\\",
   \\"color-text-icon-brand-highlight\\": \\"rgb(242, 47, 70)\\",
   \\"color-text-neutral\\": \\"rgb(102, 179, 255)\\",

--- a/packages/paste-design-tokens/tokens/themes/dark/global/text-color.yml
+++ b/packages/paste-design-tokens/tokens/themes/dark/global/text-color.yml
@@ -95,7 +95,7 @@ props:
 
     #icon
   color-text-icon:
-    value: "{!palette-gray-10}"
+    value: "{!palette-gray-60}"
     comment: Default icon color.
   color-text-icon-available:
     value: "{!palette-green-50}"


### PR DESCRIPTION
Changed the alias that Dark mode's color-text-icon points to from gray-10 to gray-60 to allow for hover state differentiation when used concurrently w/ color-text.
