### PR TITLE
Badge ref fix

### DIFF
--- a/.changeset/perfect-countries-speak.md
+++ b/.changeset/perfect-countries-speak.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/badge': patch
+---
+
+Export the BadgeProps type and correctly pass the ref to the wrapper element when the Badge is focusable.

--- a/.changeset/perfect-countries-speak.md
+++ b/.changeset/perfect-countries-speak.md
@@ -1,5 +1,6 @@
 ---
 '@twilio-paste/badge': patch
+'@twilio-paste/core': patch
 ---
 
 Export the BadgeProps type and correctly pass the ref to the wrapper element when the Badge is focusable.

--- a/packages/paste-core/components/badge/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/badge/__tests__/index.spec.tsx
@@ -64,11 +64,41 @@ describe('Badge', () => {
           useResizeChildIcons(['test', <InformationIcon size="sizeIcon40" decorative />])
         );
 
-        const icon = result.current[1];
+        const icon = (result.current as ArrayLike<NamedChild>)[1];
 
         expect(icon.type.displayName).toEqual('InformationIcon');
         expect(icon.props.size).toEqual('sizeIcon10');
       });
+    });
+  });
+
+  describe('Refs', () => {
+    it('should set ref to a span element when rendered as a "span"', () => {
+      const badgeRef = React.createRef<HTMLElement>();
+      render(
+        <Badge as="span" variant="default" ref={badgeRef}>
+          Default
+        </Badge>
+      );
+      expect(badgeRef?.current?.tagName).toEqual('SPAN');
+    });
+    it('should set ref to a button element when rendered as a "button"', () => {
+      const badgeRef = React.createRef<HTMLElement>();
+      render(
+        <Badge as="button" onClick={() => {}} variant="default" ref={badgeRef}>
+          Default
+        </Badge>
+      );
+      expect(badgeRef?.current?.tagName).toEqual('BUTTON');
+    });
+    it('should set ref to an anchor element when rendered as a "a"', () => {
+      const badgeRef = React.createRef<HTMLElement>();
+      render(
+        <Badge as="a" href="#" variant="default" ref={badgeRef}>
+          Default
+        </Badge>
+      );
+      expect(badgeRef?.current?.tagName).toEqual('A');
     });
   });
 

--- a/packages/paste-core/components/badge/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/badge/__tests__/index.spec.tsx
@@ -8,163 +8,47 @@ import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import axe from '../../../../../.jest/axe-helper';
 import {Badge} from '../src';
 import type {NamedChild} from '../src/types';
-import {getVariantStyles, hasValidButtonVariantProps, hasValidAnchorVariantProps} from '../src/utils';
-import {useFocusableVariants, useResizeChildIcons} from '../src/hooks';
+import {isFocusableElement, getBadgeSpanProps} from '../src/utils';
+import {useResizeChildIcons} from '../src/hooks';
 
 describe('Badge', () => {
   describe('Utils', () => {
-    describe('getVariantStyles', () => {
-      it('should return the correct tokens when variant is "success"', () => {
-        expect(getVariantStyles('success')).toEqual({
-          backgroundColor: 'colorBackgroundSuccessWeakest',
-          color: 'colorTextSuccess',
-        });
+    describe('isFocusableElement', () => {
+      it('should return true for a button', () => {
+        expect(isFocusableElement({as: 'button'})).toBeTruthy();
       });
-
-      it('should return the correct tokens when variant is "info"', () => {
-        expect(getVariantStyles('info')).toEqual({
-          backgroundColor: 'colorBackgroundNeutralWeakest',
-          color: 'colorTextNeutral',
-        });
+      it('should return true for an anchor', () => {
+        expect(isFocusableElement({as: 'a'})).toBeTruthy();
       });
-
-      it('should return the correct tokens when variant is "error"', () => {
-        expect(getVariantStyles('error')).toEqual({
-          backgroundColor: 'colorBackgroundErrorWeakest',
-          color: 'colorTextError',
-        });
-      });
-
-      it('should return the correct tokens when variant is "warning"', () => {
-        expect(getVariantStyles('warning')).toEqual({
-          backgroundColor: 'colorBackgroundWarningWeakest',
-          color: 'colorTextWarningStrong',
-        });
-      });
-
-      it('should return the correct tokens when variant is "new"', () => {
-        expect(getVariantStyles('new')).toEqual({
-          backgroundColor: 'colorBackgroundNew',
-          color: 'colorTextNew',
-        });
-      });
-
-      it('should return the correct tokens when variant is "default"', () => {
-        expect(getVariantStyles('default')).toEqual({
-          backgroundColor: 'colorBackground',
-          color: 'colorTextWeak',
-        });
+      it('should return false for a span', () => {
+        expect(isFocusableElement({as: 'span'})).toBeFalsy();
       });
     });
 
-    describe('hasValidButtonVariantProps', () => {
-      it('should return "true" if props.as is "button" and the props.onClick is a function', () => {
-        expect(hasValidButtonVariantProps({as: 'button', onClick: () => null})).toBe(true);
+    describe('getBadgeSpanProps', () => {
+      it('should return safe props to spread on the badge span when it is a span element', () => {
+        expect(
+          // @ts-expect-error can't pass style props in typescript but you can in JS and we need to prove they get removed
+          getBadgeSpanProps({as: 'span', 'aria-labelledby': 'some-id', backgroundColor: 'colorBackgroundSuccess'})
+        ).toEqual({
+          'aria-labelledby': 'some-id',
+          as: 'span',
+        });
       });
-      it('should return "false" if props.as is not "button" and the props.onClick is a function', () => {
-        expect(hasValidButtonVariantProps({as: 'a', onClick: () => null})).toBe(false);
-        expect(hasValidButtonVariantProps({as: 'span', onClick: () => null})).toBe(false);
-      });
-      it('should return "false" if props.as is "button" and the props.onClick is not a function', () => {
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'button', onClick: true})).toBe(false);
-        expect(hasValidButtonVariantProps({as: 'button', onClick: undefined})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'button', onClick: {}})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'button', onClick: 'test'})).toBe(false);
-      });
-      it('should return "false" if props.as is not "button" and the props.onClick is not a function', () => {
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'a', onClick: true})).toBe(false);
-        expect(hasValidButtonVariantProps({as: 'span', onClick: undefined})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'span', onClick: {}})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidButtonVariantProps({as: 'a', onClick: 'test'})).toBe(false);
-      });
-    });
-
-    describe('hasValidAnchorVariantProps', () => {
-      it('should return "true" if props.as is "a" and the props.href is a string', () => {
-        expect(hasValidAnchorVariantProps({as: 'a', href: '#test'})).toBe(true);
-      });
-      it('should return "false" if props.as is not "a" and the props.href is a string', () => {
-        expect(hasValidAnchorVariantProps({as: 'button', href: '#test'})).toBe(false);
-        expect(hasValidAnchorVariantProps({as: 'span', href: '#test'})).toBe(false);
-      });
-      it('should return "false" if props.as is "a" and the props.href is not a string', () => {
-        expect(hasValidAnchorVariantProps({as: 'a', href: undefined})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidAnchorVariantProps({as: 'a', href: () => null})).toBe(false);
-        // @ts-expect-error testing incorrectly typed inputs
-        expect(hasValidAnchorVariantProps({as: 'a', href: true})).toBe(false);
-      });
-      it('should return "false" if props.as is not "a" and the props.href is not a string', () => {
-        expect(hasValidAnchorVariantProps({as: 'button', href: undefined})).toBe(false);
-        expect(hasValidAnchorVariantProps({as: 'span', href: undefined})).toBe(false);
+      it('should return no props to spread on the badge span when it is a button or anchor element as they should be spread on the parent', () => {
+        expect(
+          // @ts-expect-error can't pass style props in typescript but you can in JS and we need to prove they get removed
+          getBadgeSpanProps({as: 'button', 'aria-labelledby': 'some-id', backgroundColor: 'colorBackgroundSuccess'})
+        ).toEqual({});
+        expect(
+          // @ts-expect-error can't pass style props in typescript but you can in JS and we need to prove they get removed
+          getBadgeSpanProps({as: 'a', 'aria-labelledby': 'some-id', backgroundColor: 'colorBackgroundSuccess'})
+        ).toEqual({});
       });
     });
   });
 
   describe('Hooks', () => {
-    describe('useFocusableVariants', () => {
-      it('should return the focusable variant style props, no span props, and a button wrapper when "as" is "button" and "onClick" is a function', () => {
-        const {result} = renderHook(() => useFocusableVariants({as: 'button', onClick: () => null}));
-
-        const {wrapper: Wrapper, ...rest} = result.current;
-        expect(rest).toEqual({
-          styleProps: {
-            textDecoration: 'underline',
-            cursor: 'pointer',
-            _hover: {textDecoration: 'none'},
-            _focus: {boxShadow: 'shadowFocus', textDecoration: 'none'},
-          },
-          spanProps: {},
-        });
-
-        const {getByRole, getByText} = render(<Wrapper>Test</Wrapper>);
-        expect(getByRole('button')).toBeInTheDocument();
-        expect(getByText('Test')).toBeInTheDocument();
-      });
-
-      it('should return the focusable variant style props, no span props, and an anchor wrapper when "as" is "a" and "href" is a string', () => {
-        const {result} = renderHook(() => useFocusableVariants({as: 'a', href: '#test', onClick: () => null}));
-
-        const {wrapper: Wrapper, ...rest} = result.current;
-        expect(rest).toEqual({
-          styleProps: {
-            textDecoration: 'underline',
-            cursor: 'pointer',
-            _hover: {textDecoration: 'none'},
-            _focus: {boxShadow: 'shadowFocus', textDecoration: 'none'},
-          },
-          spanProps: {},
-        });
-
-        const {getByRole, getByText} = render(<Wrapper>Test</Wrapper>);
-
-        expect(getByRole('link')).toBeInTheDocument();
-        expect(getByText('Test')).toBeInTheDocument();
-      });
-
-      it('should return an props as span props, an empty style props object, and an react fragment wrapper by default', () => {
-        const {result} = renderHook(() => useFocusableVariants({as: 'span'}));
-
-        const {wrapper: Wrapper, ...rest} = result.current;
-        expect(rest).toEqual({
-          styleProps: {},
-          spanProps: {as: 'span'},
-        });
-
-        const {queryByRole, getByText} = render(<Wrapper>Test</Wrapper>);
-
-        expect(queryByRole('link')).not.toBeInTheDocument();
-        expect(queryByRole('a')).not.toBeInTheDocument();
-        expect(getByText('Test')).toBeInTheDocument();
-      });
-    });
-
     describe('useResizeChildIcons', () => {
       it('should return return no modifications when child icon size is default', () => {
         const {result} = renderHook(() => useResizeChildIcons(['test', <InformationIcon decorative />]));
@@ -180,7 +64,7 @@ describe('Badge', () => {
           useResizeChildIcons(['test', <InformationIcon size="sizeIcon40" decorative />])
         );
 
-        const icon = (result.current as ArrayLike<NamedChild>)[1];
+        const icon = result.current[1];
 
         expect(icon.type.displayName).toEqual('InformationIcon');
         expect(icon.props.size).toEqual('sizeIcon10');
@@ -296,29 +180,7 @@ describe('Badge', () => {
     });
 
     describe('Render', () => {
-      it('should not render badge as button if "as" is equal to "button", but "onClick" is "undefined"', () => {
-        const {queryByRole} = render(
-          <Badge as="button" variant="success">
-            Not button
-          </Badge>
-        );
-        const buttonQueryResult = queryByRole('button');
-
-        expect(buttonQueryResult).not.toBeInTheDocument();
-      });
-
-      it('should not render badge as button if "onClick" is defined as a function, but "as" is not equal to "button"', () => {
-        const {queryByRole} = render(
-          <Badge as="span" onClick={() => null} variant="success">
-            Not button
-          </Badge>
-        );
-        const buttonQueryResult = queryByRole('button');
-
-        expect(buttonQueryResult).not.toBeInTheDocument();
-      });
-
-      it('should render badge as button only if "onClick" is defined as a function and "as" is "button"', () => {
+      it('should render badge as button if "as" is "button"', () => {
         const {getByRole} = render(
           <Badge as="button" onClick={() => null} variant="success">
             Button
@@ -349,21 +211,6 @@ describe('Badge', () => {
 
   describe('Badge as anchor', () => {
     describe('Event handlers', () => {
-      it('should handle onclick event', () => {
-        const onClickMock: jest.Mock = jest.fn();
-        const {getByRole} = render(
-          <Badge as="a" href="#" onClick={onClickMock} variant="success">
-            Anchor
-          </Badge>
-        );
-
-        const anchor = getByRole('link');
-
-        fireEvent.click(anchor);
-
-        expect(onClickMock).toBeCalledTimes(1);
-      });
-
       it('should handle mouseup event', () => {
         const onMouseUpMock: jest.Mock = jest.fn();
         const {getByRole} = render(
@@ -440,29 +287,7 @@ describe('Badge', () => {
     });
 
     describe('Render', () => {
-      it('should not render badge as anchor if "as" is "a" but "href" is not present', () => {
-        const {queryByRole} = render(
-          <Badge as="a" data-testid="invalid-anchor-1" variant="success">
-            Not anchor
-          </Badge>
-        );
-        const anchorQueryResult = queryByRole('link');
-
-        expect(anchorQueryResult).not.toBeInTheDocument();
-      });
-
-      it('should not render badge as anchor if "href" is present but "as" is not "a"', () => {
-        const {queryByRole} = render(
-          <Badge as="span" href="#test" variant="success">
-            Not anchor
-          </Badge>
-        );
-        const anchorQueryResult = queryByRole('link');
-
-        expect(anchorQueryResult).not.toBeInTheDocument();
-      });
-
-      it('should render badge as anchor only "href" is a string and "as" is "anchor"', () => {
+      it('should render badge as anchor if "as" is "anchor"', () => {
         const {getByRole} = render(
           <Badge as="a" href="#test" variant="success">
             Anchor
@@ -492,76 +317,15 @@ describe('Badge', () => {
 
   describe('Badge as span', () => {
     describe('Render', () => {
-      it('should render correctly when variant is "default"', () => {
+      it('should render as a span element if as is "span"', () => {
         const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-1" variant="default">
-            test
-          </Badge>
-        );
-        const badgeElement = getByTestId('badge-1');
-
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextWeak');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackground');
-      });
-
-      it('should render correctly when variant is "new"', () => {
-        const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-2" variant="new">
-            test
-          </Badge>
-        );
-        const badgeElement = getByTestId('badge-2');
-
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextNew');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackgroundNew');
-      });
-
-      it('should render correctly when variant is "info"', () => {
-        const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-3" variant="info">
-            test
-          </Badge>
-        );
-        const badgeElement = getByTestId('badge-3');
-
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextNeutral');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackgroundNeutralWeakest');
-      });
-
-      it('should render correctly when variant is "warning"', () => {
-        const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-4" variant="warning">
-            test
-          </Badge>
-        );
-        const badgeElement = getByTestId('badge-4');
-
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextWarningStrong');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackgroundWarningWeakest');
-      });
-
-      it('should render correctly when variant is "error"', () => {
-        const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-5" variant="error">
-            test
-          </Badge>
-        );
-        const badgeElement = getByTestId('badge-5');
-
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextError');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackgroundErrorWeakest');
-      });
-
-      it('should render correctly when variant is "success"', () => {
-        const {getByTestId} = render(
-          <Badge as="span" data-testid="badge-6" variant="success">
+          <Badge as="span" variant="default" data-testid="badge-6">
             test
           </Badge>
         );
         const badgeElement = getByTestId('badge-6');
 
-        expect(badgeElement).toHaveStyleRule('color', 'colorTextSuccess');
-        expect(badgeElement).toHaveStyleRule('background-color', 'colorBackgroundSuccessWeakest');
+        expect(badgeElement.tagName).toEqual('SPAN');
       });
     });
   });
@@ -569,9 +333,64 @@ describe('Badge', () => {
   describe('Accessibility', () => {
     it('Should have no accessibility violations', async () => {
       const {container} = render(
-        <Badge as="span" data-testid="badge-1" variant="default">
-          test
-        </Badge>
+        <>
+          <Badge as="span" data-testid="badge-1" variant="default">
+            test
+          </Badge>
+          <Badge as="span" data-testid="badge-1" variant="success">
+            test
+          </Badge>
+          <Badge as="span" data-testid="badge-1" variant="warning">
+            test
+          </Badge>
+          <Badge as="span" data-testid="badge-1" variant="error">
+            test
+          </Badge>
+          <Badge as="span" data-testid="badge-1" variant="info">
+            test
+          </Badge>
+          <Badge as="span" data-testid="badge-1" variant="new">
+            test
+          </Badge>
+
+          <Badge as="a" href="#" data-testid="badge-1" variant="default">
+            test
+          </Badge>
+          <Badge as="a" href="#" data-testid="badge-1" variant="success">
+            test
+          </Badge>
+          <Badge as="a" href="#" data-testid="badge-1" variant="warning">
+            test
+          </Badge>
+          <Badge as="a" href="#" data-testid="badge-1" variant="error">
+            test
+          </Badge>
+          <Badge as="a" href="#" data-testid="badge-1" variant="info">
+            test
+          </Badge>
+          <Badge as="a" href="#" data-testid="badge-1" variant="new">
+            test
+          </Badge>
+
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="default">
+            test
+          </Badge>
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="success">
+            test
+          </Badge>
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="warning">
+            test
+          </Badge>
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="error">
+            test
+          </Badge>
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="info">
+            test
+          </Badge>
+          <Badge as="button" onClick={() => null} data-testid="badge-1" variant="new">
+            test
+          </Badge>
+        </>
       );
       const results = await axe(container);
       expect(results).toHaveNoViolations();

--- a/packages/paste-core/components/badge/src/BadgeWrapper.tsx
+++ b/packages/paste-core/components/badge/src/BadgeWrapper.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {safelySpreadBoxProps} from '@twilio-paste/box';
+import {Button} from '@twilio-paste/button';
+
+import type {BadgeProps} from './types';
+
+export const BadgeWrapper = React.forwardRef<HTMLButtonElement, BadgeProps>(({children, as, ...props}, ref) => {
+  const propsMinusStyles = safelySpreadBoxProps(props);
+  if (as === 'button') {
+    return (
+      <Button {...propsMinusStyles} variant="reset" size="reset" type="button" ref={ref}>
+        {children}
+      </Button>
+    );
+  }
+  if (as === 'a') {
+    return (
+      <Button {...propsMinusStyles} variant="reset" size="reset" as="a" ref={ref}>
+        {children}
+      </Button>
+    );
+  }
+  return <>{children}</>;
+});
+BadgeWrapper.displayName = 'BadgeWrapper';

--- a/packages/paste-core/components/badge/src/hooks.tsx
+++ b/packages/paste-core/components/badge/src/hooks.tsx
@@ -1,75 +1,9 @@
 import * as React from 'react';
-import {Button} from '@twilio-paste/button';
-import type {ButtonProps} from '@twilio-paste/button';
-import {safelySpreadBoxProps} from '@twilio-paste/box';
 import {useUIDSeed} from '@twilio-paste/uid-library';
 
-import type {BadgeProps, BadgeChildren} from './types';
-import {hasValidAnchorVariantProps, hasValidButtonVariantProps, safelySpreadProps} from './utils';
-
-const BUTTON_DENY_LIST = ['fullWidth', 'as', 'size', 'type', 'variant', 'href'];
-const ANCHOR_DENY_LIST = ['variant', 'as', 'onHover'];
+import type {BadgeChildren} from './types';
 
 const DEFAULT_ICON_SIZE = 'sizeIcon10';
-const FOCUSABLE_STYLES = {
-  textDecoration: 'underline',
-  cursor: 'pointer',
-  _hover: {textDecoration: 'none'},
-  _focus: {boxShadow: 'shadowFocus', textDecoration: 'none'},
-};
-
-export type FocusableStyleProps = {
-  textDecoration: 'underline';
-  cursor: 'pointer';
-  _hover: {textDecoration: 'none'};
-  _focus: {boxShadow: 'shadowFocus'; textDecoration: 'none'};
-};
-export type Wrapper = React.FC<{children: React.ReactNode}>;
-export type StyleProps = FocusableStyleProps | Record<string, never>;
-
-export const useFocusableVariants = (
-  props: Omit<BadgeProps, 'variant' | 'children'>
-): {
-  wrapper: Wrapper;
-  styleProps: StyleProps;
-  spanProps: Partial<Omit<BadgeProps, 'variant' | 'children'>> | Omit<BadgeProps, 'variant' | 'children'>;
-} => {
-  const redactedProps = safelySpreadBoxProps(props);
-
-  if (hasValidButtonVariantProps(props)) {
-    const buttonProps = safelySpreadProps(redactedProps, BUTTON_DENY_LIST);
-    return {
-      styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
-      // eslint-disable-next-line react/display-name
-      wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" ref={buttonProps.ref} {...buttonProps}>
-          {children}
-        </Button>
-      ),
-      spanProps: {},
-    };
-  }
-  if (hasValidAnchorVariantProps(props)) {
-    const anchorProps = safelySpreadProps(redactedProps, ANCHOR_DENY_LIST);
-    return {
-      styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
-      // eslint-disable-next-line react/display-name
-      wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" as="a" ref={anchorProps.ref} {...anchorProps}>
-          {children}
-        </Button>
-      ),
-      spanProps: {},
-    };
-  }
-
-  return {
-    styleProps: {},
-    // eslint-disable-next-line react/display-name
-    wrapper: ({children}) => <>{children}</>,
-    spanProps: redactedProps,
-  };
-};
 
 export const useResizeChildIcons = (children: BadgeChildren): BadgeChildren => {
   const seed = useUIDSeed();

--- a/packages/paste-core/components/badge/src/hooks.tsx
+++ b/packages/paste-core/components/badge/src/hooks.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Button} from '@twilio-paste/button';
+import type {ButtonProps} from '@twilio-paste/button';
 import {safelySpreadBoxProps} from '@twilio-paste/box';
 import {useUIDSeed} from '@twilio-paste/uid-library';
 
@@ -41,7 +42,7 @@ export const useFocusableVariants = (
       styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
       // eslint-disable-next-line react/display-name
       wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" {...buttonProps}>
+        <Button variant="reset" size="reset" type="button" ref={ref} {...buttonProps}>
           {children}
         </Button>
       ),
@@ -54,7 +55,7 @@ export const useFocusableVariants = (
       styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
       // eslint-disable-next-line react/display-name
       wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" as="a" {...anchorProps}>
+        <Button variant="reset" size="reset" type="button" as="a" ref={ref} {...anchorProps}>
           {children}
         </Button>
       ),

--- a/packages/paste-core/components/badge/src/hooks.tsx
+++ b/packages/paste-core/components/badge/src/hooks.tsx
@@ -42,7 +42,7 @@ export const useFocusableVariants = (
       styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
       // eslint-disable-next-line react/display-name
       wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" ref={ref} {...buttonProps}>
+        <Button variant="reset" size="reset" type="button" ref={buttonProps.ref} {...buttonProps}>
           {children}
         </Button>
       ),
@@ -55,7 +55,7 @@ export const useFocusableVariants = (
       styleProps: {...FOCUSABLE_STYLES} as FocusableStyleProps,
       // eslint-disable-next-line react/display-name
       wrapper: ({children}) => (
-        <Button variant="reset" size="reset" type="button" as="a" ref={ref} {...anchorProps}>
+        <Button variant="reset" size="reset" type="button" as="a" ref={anchorProps.ref} {...anchorProps}>
           {children}
         </Button>
       ),

--- a/packages/paste-core/components/badge/src/index.tsx
+++ b/packages/paste-core/components/badge/src/index.tsx
@@ -6,15 +6,18 @@ import {getVariantStyles} from './utils';
 import type {BadgeProps, BadgeVariants, BadgeChildren, BadgeBaseElements} from './types';
 import {useFocusableVariants, useResizeChildIcons} from './hooks';
 
+export {BadgeProps};
+
 export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   ({variant, children, element = 'BADGE', ...props}, ref) => {
     const resizedChildren = useResizeChildIcons(children);
     const {color, backgroundColor} = getVariantStyles(variant);
 
     const {styleProps, wrapper: Wrapper, spanProps} = useFocusableVariants(props);
+    const isFocusable = props.as !== 'span';
 
     return (
-      <Wrapper>
+      <Wrapper ref={isFocusable ? ref : null}>
         <Box
           {...spanProps}
           alignItems="center"
@@ -33,7 +36,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
           paddingX="space30"
           paddingY="space20"
           variant={variant}
-          ref={ref}
+          ref={!isFocusable ? ref : null}
           {...styleProps}
         >
           {resizedChildren}

--- a/packages/paste-core/components/badge/src/index.tsx
+++ b/packages/paste-core/components/badge/src/index.tsx
@@ -2,30 +2,31 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Box} from '@twilio-paste/box';
 
-import {getVariantStyles} from './utils';
-import type {BadgeProps, BadgeVariants, BadgeChildren, BadgeBaseElements} from './types';
-import {useFocusableVariants, useResizeChildIcons} from './hooks';
+import type {BadgeProps, BadgeVariants, BadgeChildren} from './types';
+import {useResizeChildIcons} from './hooks';
+import {badgeFocusableStyles, badgeVariantStyles} from './styles';
+import {getBadgeSpanProps, isFocusableElement} from './utils';
+import {BadgeWrapper} from './BadgeWrapper';
 
-export {BadgeProps};
+export type {BadgeProps};
 
-export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+export const Badge = React.forwardRef<HTMLElement, BadgeProps>(
   ({variant, children, element = 'BADGE', ...props}, ref) => {
     const resizedChildren = useResizeChildIcons(children);
-    const {color, backgroundColor} = getVariantStyles(variant);
 
-    const {styleProps, wrapper: Wrapper, spanProps} = useFocusableVariants({...props, ref});
-    const isFocusable = props.as !== 'span';
+    const variantStyles = badgeVariantStyles[variant];
+    const spanProps = getBadgeSpanProps(props);
+    const isFocusable = isFocusableElement(props);
 
     return (
-      <Wrapper>
+      // @ts-expect-error we need to explore polymorphic types for this ref to work https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+      <BadgeWrapper {...props} ref={isFocusable ? ref : null}>
         <Box
           {...spanProps}
           alignItems="center"
           as="span"
-          backgroundColor={backgroundColor}
           border="unset"
           borderRadius="borderRadius30"
-          color={color}
           columnGap="space10"
           display="flex"
           element={element}
@@ -37,11 +38,12 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
           paddingY="space20"
           variant={variant}
           ref={!isFocusable ? ref : null}
-          {...styleProps}
+          {...variantStyles}
+          {...(isFocusable && {...badgeFocusableStyles})}
         >
           {resizedChildren}
         </Box>
-      </Wrapper>
+      </BadgeWrapper>
     );
   }
 );
@@ -57,7 +59,9 @@ Badge.propTypes = {
   ]).isRequired as PropTypes.Validator<BadgeChildren>,
   element: PropTypes.string,
   variant: PropTypes.oneOf(['info', 'default', 'warning', 'error', 'success', 'new'] as BadgeVariants[]).isRequired,
-  as: PropTypes.oneOf(['span', 'button', 'a'] as BadgeBaseElements[]).isRequired,
+  // @ts-expect-error type unions are a little too much for prop types inferred types to handle
+  as: PropTypes.oneOf(['span', 'button', 'a']).isRequired,
   href: PropTypes.string,
+  // @ts-expect-error again type unions. This is required when a button but not when a span and banned when a link.
   onClick: PropTypes.func,
 };

--- a/packages/paste-core/components/badge/src/index.tsx
+++ b/packages/paste-core/components/badge/src/index.tsx
@@ -13,11 +13,11 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     const resizedChildren = useResizeChildIcons(children);
     const {color, backgroundColor} = getVariantStyles(variant);
 
-    const {styleProps, wrapper: Wrapper, spanProps} = useFocusableVariants(props);
+    const {styleProps, wrapper: Wrapper, spanProps} = useFocusableVariants({...props, ref});
     const isFocusable = props.as !== 'span';
 
     return (
-      <Wrapper ref={isFocusable ? ref : null}>
+      <Wrapper>
         <Box
           {...spanProps}
           alignItems="center"

--- a/packages/paste-core/components/badge/src/styles.ts
+++ b/packages/paste-core/components/badge/src/styles.ts
@@ -1,0 +1,38 @@
+import type {BoxStyleProps} from '@twilio-paste/box';
+import type {BadgeVariants} from './types';
+
+export const badgeVariantStyles: {
+  [key in BadgeVariants]: {backgroundColor: BoxStyleProps['backgroundColor']; color: BoxStyleProps['color']};
+} = {
+  success: {
+    backgroundColor: 'colorBackgroundSuccessWeakest',
+    color: 'colorTextSuccess',
+  },
+  error: {
+    backgroundColor: 'colorBackgroundErrorWeakest',
+    color: 'colorTextError',
+  },
+  warning: {
+    backgroundColor: 'colorBackgroundWarningWeakest',
+    color: 'colorTextWarningStrong',
+  },
+  new: {
+    backgroundColor: 'colorBackgroundNew',
+    color: 'colorTextNew',
+  },
+  info: {
+    backgroundColor: 'colorBackgroundNeutralWeakest',
+    color: 'colorTextNeutral',
+  },
+  default: {
+    backgroundColor: 'colorBackground',
+    color: 'colorTextWeak',
+  },
+};
+
+export const badgeFocusableStyles = {
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  _hover: {textDecoration: 'none'},
+  _focus: {boxShadow: 'shadowFocus', textDecoration: 'none'},
+} as Partial<BoxStyleProps>;

--- a/packages/paste-core/components/badge/src/types.ts
+++ b/packages/paste-core/components/badge/src/types.ts
@@ -2,13 +2,23 @@ import type {ButtonProps} from '@twilio-paste/button';
 import type {BoxProps} from '@twilio-paste/box';
 
 export type NamedChild = React.ReactElement<Record<string, any>, React.NamedExoticComponent>;
-
 export type BadgeChildren = NamedChild | React.ReactText | (React.ReactText | NamedChild)[];
-
 export type BadgeVariants = 'info' | 'default' | 'warning' | 'error' | 'success' | 'new';
-export type BadgeBaseElements = 'button' | 'span' | 'a';
-export interface BadgeProps extends Omit<ButtonProps, 'variant' | 'as'>, Pick<BoxProps, 'element'> {
-  variant: BadgeVariants;
+
+type BadgeBaseProps = Pick<BoxProps, 'element'> & {
   children: BadgeChildren;
-  as: BadgeBaseElements;
-}
+  variant: BadgeVariants;
+};
+type BadgeAsSpanProps = React.HTMLAttributes<HTMLSpanElement> & {
+  as: 'span';
+};
+type BadgeAsButtonProps = Omit<ButtonProps, 'variant' | 'as' | 'fullWidth' | 'size' | 'children'> & {
+  as: 'button';
+  onClick: ButtonProps['onClick'];
+};
+type BadgeAsAnchorProps = Omit<ButtonProps, 'variant' | 'as' | 'fullWidth' | 'size' | 'children'> & {
+  as: 'a';
+  href: ButtonProps['href'];
+  onClick?: never;
+};
+export type BadgeProps = (BadgeAsSpanProps | BadgeAsButtonProps | BadgeAsAnchorProps) & BadgeBaseProps;

--- a/packages/paste-core/components/badge/src/utils.ts
+++ b/packages/paste-core/components/badge/src/utils.ts
@@ -1,66 +1,11 @@
-import type {TextColorOptions, BackgroundColorOptions} from '@twilio-paste/style-props';
+import {safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BadgeProps} from './types';
 
-import type {BadgeVariants, BadgeProps} from './types';
+export const isFocusableElement = ({as}: Partial<BadgeProps>): boolean => as !== 'span';
 
-export const hasValidButtonVariantProps = ({as, onClick}: Pick<BadgeProps, 'as' | 'onClick'>): boolean => {
-  const clickHandlerIsValid = typeof onClick == 'function';
-  const asPropIsValid = as === 'button';
-  return clickHandlerIsValid && asPropIsValid;
-};
-export const hasValidAnchorVariantProps = ({as, href}: Pick<BadgeProps, 'as' | 'href'>): boolean => {
-  const asPropIsValid = as === 'a';
-  const hrefIsValid = typeof href === 'string';
-  return asPropIsValid && hrefIsValid;
-};
-
-type Props = Record<string, any>;
-export const safelySpreadProps = (props: Props, denylist: string[]): Partial<Props> =>
-  Object.keys(props).reduce<Props>((resultProps, key: string) => {
-    if (!denylist.includes(key)) {
-      // eslint-disable-next-line no-param-reassign
-      resultProps[key] = props[key];
-    }
-    return resultProps;
-  }, {});
-
-export const getVariantStyles = (
-  variant: BadgeVariants
-): {
-  color: TextColorOptions;
-  backgroundColor: BackgroundColorOptions;
-} => {
-  switch (variant) {
-    case 'success':
-      return {
-        backgroundColor: 'colorBackgroundSuccessWeakest',
-        color: 'colorTextSuccess',
-      };
-    case 'error':
-      return {
-        backgroundColor: 'colorBackgroundErrorWeakest',
-        color: 'colorTextError',
-      };
-    case 'warning':
-      return {
-        backgroundColor: 'colorBackgroundWarningWeakest',
-        color: 'colorTextWarningStrong',
-      };
-    case 'new':
-      return {
-        backgroundColor: 'colorBackgroundNew',
-        color: 'colorTextNew',
-      };
-
-    case 'info':
-      return {
-        backgroundColor: 'colorBackgroundNeutralWeakest',
-        color: 'colorTextNeutral',
-      };
-
-    default:
-      return {
-        backgroundColor: 'colorBackground',
-        color: 'colorTextWeak',
-      };
+export const getBadgeSpanProps = (props: Partial<BadgeProps>): Partial<BadgeProps> => {
+  if (isFocusableElement(props)) {
+    return {};
   }
+  return safelySpreadBoxProps(props);
 };

--- a/packages/paste-core/components/badge/src/utils.ts
+++ b/packages/paste-core/components/badge/src/utils.ts
@@ -1,7 +1,7 @@
 import {safelySpreadBoxProps} from '@twilio-paste/box';
 import type {BadgeProps} from './types';
 
-export const isFocusableElement = ({as}: Partial<BadgeProps>): boolean => as !== 'span';
+export const isFocusableElement = ({as}: Partial<BadgeProps>): boolean => as === 'button' || as === 'a';
 
 export const getBadgeSpanProps = (props: Partial<BadgeProps>): Partial<BadgeProps> => {
   if (isFocusableElement(props)) {

--- a/packages/paste-core/components/badge/stories/index.stories.tsx
+++ b/packages/paste-core/components/badge/stories/index.stories.tsx
@@ -48,10 +48,6 @@ export const AllBadges: React.FC = () => (
 
 export const DefaultBadge: React.FC = () => {
   const badgeRef = React.useRef(null);
-
-  React.useEffect(() => {
-    console.log('story ref', badgeRef.current);
-  });
   return (
     <Wrapper>
       <Badge as="span" variant="default" ref={badgeRef}>
@@ -71,10 +67,6 @@ export const DefaultBadge: React.FC = () => {
 
 export const DefaultBadgeAsAnchor: React.FC = () => {
   const badgeAnchor = React.useRef(null);
-
-  React.useEffect(() => {
-    console.log('story ref', badgeAnchor.current);
-  });
   return (
     <Wrapper>
       <Badge as="a" href="#" variant="default" ref={badgeAnchor}>
@@ -96,9 +88,6 @@ export const DefaultBadgeAsAnchor: React.FC = () => {
 
 export const DefaultBadgeAsButton: React.FC = () => {
   const badgeButton = React.useRef(null);
-  React.useEffect(() => {
-    console.log('story ref', badgeButton.current);
-  });
   return (
     <Box display="flex" flexDirection="column" alignContent="flex-start">
       <Wrapper>

--- a/packages/paste-core/components/badge/stories/index.stories.tsx
+++ b/packages/paste-core/components/badge/stories/index.stories.tsx
@@ -46,59 +46,79 @@ export const AllBadges: React.FC = () => (
   </Wrapper>
 );
 
-export const DefaultBadge: React.FC = () => (
-  <Wrapper>
-    <Badge as="span" variant="default">
-      Default
-    </Badge>
-    <Badge as="span" variant="default">
-      <InformationIcon decorative />
-      Default
-    </Badge>
-    <Badge as="span" variant="default">
-      Default
-      <InformationIcon decorative />
-    </Badge>
-  </Wrapper>
-);
+export const DefaultBadge: React.FC = () => {
+  const badgeRef = React.useRef(null);
 
-export const DefaultBadgeAsAnchor: React.FC = () => (
-  <Wrapper>
-    <Badge as="a" href="#" variant="default">
-      Default
-    </Badge>
-
-    <Badge as="a" href="#" variant="default">
-      <InformationIcon decorative />
-      Default
-    </Badge>
-
-    <Badge as="a" href="#" variant="default">
-      Default
-      <InformationIcon decorative />
-    </Badge>
-  </Wrapper>
-);
-
-export const DefaultBadgeAsButton: React.FC = () => (
-  <Box display="flex" flexDirection="column" alignContent="flex-start">
+  React.useEffect(() => {
+    console.log('story ref', badgeRef.current);
+  });
+  return (
     <Wrapper>
-      <Badge as="button" onClick={() => {}} variant="default">
+      <Badge as="span" variant="default" ref={badgeRef}>
         Default
       </Badge>
-
-      <Badge as="button" onClick={() => {}} variant="default">
+      <Badge as="span" variant="default">
         <InformationIcon decorative />
         Default
       </Badge>
-
-      <Badge as="button" onClick={() => {}} variant="default">
+      <Badge as="span" variant="default">
         Default
         <InformationIcon decorative />
       </Badge>
     </Wrapper>
-  </Box>
-);
+  );
+};
+
+export const DefaultBadgeAsAnchor: React.FC = () => {
+  const badgeAnchor = React.useRef(null);
+
+  React.useEffect(() => {
+    console.log('story ref', badgeAnchor.current);
+  });
+  return (
+    <Wrapper>
+      <Badge as="a" href="#" variant="default" ref={badgeAnchor}>
+        Default
+      </Badge>
+
+      <Badge as="a" href="#" variant="default">
+        <InformationIcon decorative />
+        Default
+      </Badge>
+
+      <Badge as="a" href="#" variant="default">
+        Default
+        <InformationIcon decorative />
+      </Badge>
+    </Wrapper>
+  );
+};
+
+export const DefaultBadgeAsButton: React.FC = () => {
+  const badgeButton = React.useRef(null);
+  React.useEffect(() => {
+    console.log('story ref', badgeButton.current);
+  });
+  return (
+    <Box display="flex" flexDirection="column" alignContent="flex-start">
+      <Wrapper>
+        <Badge as="button" onClick={() => {}} variant="default" ref={badgeButton}>
+          Default
+        </Badge>
+
+        <Badge as="button" onClick={() => {}} variant="default">
+          <InformationIcon decorative />
+          Default
+        </Badge>
+
+        <Badge as="button" onClick={() => {}} variant="default">
+          Default
+          <InformationIcon decorative />
+        </Badge>
+      </Wrapper>
+    </Box>
+  );
+};
 
 export const InfoBadge: React.FC = () => (
   <Wrapper>


### PR DESCRIPTION
If the Badge is focusable, the ref is passed to the wrapper component instead of the span.

Also export the BadgeProps type.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
