### PR TITLE
fix(website): component import codeblock missing quotes

### DIFF
--- a/packages/paste-website/src/pages/patterns/empty-states/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-states/index.mdx
@@ -121,11 +121,11 @@ For illustrations, we recommend using a fixed width of `$size-20`. The illustrat
 
 ```jsx
 // import all ingredients for the empty state patterns
-import {​Card} from '@twilio-paste/core/card';
-import {Heading} from '@twilio-paste/core/heading';
-import {Paragraph} from '@twilio-paste/core/paragraph';
-import {Button} from '@twilio-paste/core/button';
-import {​Anchor} from '@twilio-paste/core/anchor';
+import {​Card} from "@twilio-paste/core/card";
+import {Heading} from "@twilio-paste/core/heading";
+import {Paragraph} from "@twilio-paste/core/paragraph";
+import {Button} from "@twilio-paste/core/button";
+import {​Anchor} from "@twilio-paste/core/anchor";
 ```
 
 ## Usage

--- a/packages/paste-website/src/pages/patterns/object-details/index.mdx
+++ b/packages/paste-website/src/pages/patterns/object-details/index.mdx
@@ -127,11 +127,11 @@ export const pageQuery = graphql`
 // import all components for Object details patterns
 
 import {​ Heading } from "@twilio-paste/core/heading";
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@twilio-paste/core/tabs';
-import {​ Text } from "@twilio-paste/core/text;
-import { Box } from "@twilio-paste/core/box;
-import { Stack } from "@twilio-paste/core/stack;
-import { Grid, Column } from "@twilio-paste/core/grid;
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@twilio-paste/core/tabs";
+import {​ Text } from "@twilio-paste/core/text";
+import { Box } from "@twilio-paste/core/box";
+import { Stack } from "@twilio-paste/core/stack";
+import { Grid, Column } from "@twilio-paste/core/grid";
 ```
 
 ## Usage

--- a/packages/paste-website/src/pages/patterns/status/index.mdx
+++ b/packages/paste-website/src/pages/patterns/status/index.mdx
@@ -139,14 +139,14 @@ export const pageQuery = graphql`
 // import all components for Status patterns
 
 import {​ Text } from "@twilio-paste/core/text";
-import { Box } from '@twilio-paste/core/box';
-import { ProcessDisabledIcon } from '@twilio-paste/icons/esm/ProcessDisabledIcon';
-import { ProcessDraftIcon } from '@twilio-paste/icons/esm/ProcessDraftIcon';
-import { ProcessErrorIcon } from '@twilio-paste/icons/esm/ProcessErrorIcon';
-import { ProcessInProgressIcon } from '@twilio-paste/icons/esm/ProcessInProgressIcon';
-import { ProcessNeutralIcon } from '@twilio-paste/icons/esm/ProcessNeutralIcon';
-import { ProcessSuccessIcon } from '@twilio-paste/icons/esm/ProcessSuccessIcon';
-import { ProcessWarningIcon } from '@twilio-paste/icons/esm/ProcessWarningIcon';
+import { Box } from "@twilio-paste/core/box";
+import { ProcessDisabledIcon } from "@twilio-paste/icons/esm/ProcessDisabledIcon";
+import { ProcessDraftIcon } from "@twilio-paste/icons/esm/ProcessDraftIcon";
+import { ProcessErrorIcon } from "@twilio-paste/icons/esm/ProcessErrorIcon";
+import { ProcessInProgressIcon } from "@twilio-paste/icons/esm/ProcessInProgressIcon";
+import { ProcessNeutralIcon } from "@twilio-paste/icons/esm/ProcessNeutralIcon";
+import { ProcessSuccessIcon } from "@twilio-paste/icons/esm/ProcessSuccessIcon";
+import { ProcessWarningIcon } from "@twilio-paste/icons/esm/ProcessWarningIcon";
 
 ```
 


### PR DESCRIPTION
Fixing inconsistent and missing quotes on website's pattern import codeblocks. If copy pasted (which is the intended use), can be confusing to debug.