### PR TITLE
chore: upgrade esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "emotion": "10.0.27",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
-    "esbuild": "^0.8.30",
+    "esbuild": "^0.10.2",
     "eslint": "7.23.0",
     "eslint-config-airbnb-typescript": "12.0.0",
     "eslint-config-prettier": "6.11.0",

--- a/tools/build/esbuild.js
+++ b/tools/build/esbuild.js
@@ -67,7 +67,7 @@ function build(packageJson) {
     bundle: true,
     // Sets the target environment so the code is changed into a format that
     // works  with node12 and the listed browsers
-    target: ['chrome58', 'firefox57', 'safari11', 'edge16', 'node12.19.0'],
+    target: ['chrome58', 'firefox57', 'safari11', 'edge18', 'node12.19.0'],
     define: {
       'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -24181,12 +24181,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.8.30":
-  version: 0.8.30
-  resolution: "esbuild@npm:0.8.30"
+"esbuild@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "esbuild@npm:0.10.2"
   bin:
     esbuild: bin/esbuild
-  checksum: 599e0431e7614eb7e731410eabc967232b242262a50a692b1903ef3376ad71f4284167357c4cd61613d4d14e71ba3b14f2ae2cc3801378b984cc07b3a465ce2c
+  checksum: eff6deffa4d2b1734ad6ff9f0f6b66f3ee73d392c58798f1e4ee7390c0e1e7357ff975892de3f5173ebed8b670975952328247d745256050d76739236d84bba7
   languageName: node
   linkType: hard
 
@@ -38727,7 +38727,7 @@ is-whitespace@latest:
     emotion: 10.0.27
     enzyme: ^3.10.0
     enzyme-adapter-react-16: ^1.14.0
-    esbuild: ^0.8.30
+    esbuild: ^0.10.2
     eslint: 7.23.0
     eslint-config-airbnb-typescript: 12.0.0
     eslint-config-prettier: 6.11.0


### PR DESCRIPTION
Upgrading esbuild to the latest version. Noticed [this thread](https://github.com/evanw/esbuild/issues/359) that might relate to our flaky builds, so hoping that this upgrade will fix it.

v10.2 is the latest esbuild version that doesn't break our builds.