### PR TITLE
Fix/scroll jump

### DIFF
--- a/.changeset/four-cycles-collect.md
+++ b/.changeset/four-cycles-collect.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/checkbox': patch
+'@twilio-paste/core': patch
+---
+
+Declare relative position on checkbox to fix focus position bug

--- a/packages/paste-core/components/checkbox/src/Checkbox.tsx
+++ b/packages/paste-core/components/checkbox/src/Checkbox.tsx
@@ -114,6 +114,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         backgroundColor={checkboxBackground}
         borderRadius={isSelectAll ? 'borderRadius10' : null}
         display="inline-flex"
+        position="relative"
         flexDirection="column"
         padding={isSelectAll ? 'space30' : null}
         paddingBottom={isSelectAll ? 'space20' : null}

--- a/packages/paste-website/src/html.tsx
+++ b/packages/paste-website/src/html.tsx
@@ -27,7 +27,7 @@ const HTML: React.FC<HTMLProps> = ({
         <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/main-1.2.0/fonts.css" />
         {headComponents}
       </head>
-      <body {...bodyAttributes}>
+      <body style={{overflow: 'hidden'}} {...bodyAttributes}>
         {preBodyComponents}
         <noscript key="noscript" id="gatsby-noscript">
           This app works best with JavaScript enabled.


### PR DESCRIPTION
This change introduces two fixes:

1. Our Checkbox component has an absolutely positioned (hidden) input, but the Checkbox container doesn't declare relative position, leaving the positioning of the checkbox element ambiguous. This causes the 'jump' when our checkboxes are clicked in our website's layout. The change to Checkbox declares position relative on the Checkbox container so the input has a declared relative container.
2. Since our website uses flex / div-based scrolling, we don't want elements hidden outside the layout to invoke an overflow state on the body. Adding overflow: hidden will suppress these elements from triggering an overflow scroll on the site body.