### PR TITLE
fix(site-layout): add position relative on scrolling container

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
@@ -14,6 +14,7 @@ const StyledSiteBody = styled.div`
   display: flex;
   min-width: 240px;
   overflow: auto;
+  position: relative;
 
   @supports (scroll-behavior: smooth) {
     scroll-behavior: smooth;

--- a/packages/paste-website/src/html.tsx
+++ b/packages/paste-website/src/html.tsx
@@ -27,7 +27,7 @@ const HTML: React.FC<HTMLProps> = ({
         <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/main-1.2.0/fonts.css" />
         {headComponents}
       </head>
-      <body style={{overflow: 'hidden'}} {...bodyAttributes}>
+      <body {...bodyAttributes}>
         {preBodyComponents}
         <noscript key="noscript" id="gatsby-noscript">
           This app works best with JavaScript enabled.


### PR DESCRIPTION
* Our scrolling element was lacking a declaration of position: relative, leaving certain focus events tied into the body in Chrome, and causing rendering issues.
* This change introduces that css declaration. It also removes a previous attempt to fix this bug by suppressing overflow on the site body.