### PR TITLE
feat(website): update website codeblocks design

### DIFF
--- a/packages/paste-website/src/components/CopyButton.tsx
+++ b/packages/paste-website/src/components/CopyButton.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {Button} from '@twilio-paste/button';
+import {useClipboard} from '@twilio-paste/clipboard-copy-library';
+import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
+import {CopyIcon} from '@twilio-paste/icons/esm/CopyIcon';
+
+interface CopyButtonProps {
+  text: string;
+  copiedTimeout?: number;
+}
+
+export const CopyButton: React.FC<CopyButtonProps> = ({text, copiedTimeout = 1500}) => {
+  const clipboard = useClipboard({copiedTimeout});
+
+  const handleCopy = React.useCallback(() => {
+    clipboard.copy(text);
+  }, [text]);
+
+  return (
+    <Button variant="secondary" size="small" onClick={handleCopy}>
+      <CopyIcon decorative />
+      <span aria-live="polite">
+        {clipboard.copied ? 'Copied' : 'Copy'}
+        <ScreenReaderOnly>to clipboard</ScreenReaderOnly>
+      </span>
+    </Button>
+  );
+};

--- a/packages/paste-website/src/components/icons-list/IconCard.tsx
+++ b/packages/paste-website/src/components/icons-list/IconCard.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
-import {Button} from '@twilio-paste/button';
 import {Box} from '@twilio-paste/box';
-import {useClipboard} from '@twilio-paste/clipboard-copy-library';
 import {Text} from '@twilio-paste/text';
 import {Paragraph} from '@twilio-paste/paragraph';
-import {CopyIcon} from '@twilio-paste/icons/esm/CopyIcon';
-import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {Codeblock} from '../codeblock';
+import {CopyButton} from '../CopyButton';
 import {SiteLink} from '../SiteLink';
 import type {IconObject} from './types';
 
@@ -24,14 +21,7 @@ export interface IconCardProps {
 
 const IconCard: React.FC<IconCardProps> = ({selectedIcon}) => {
   if (selectedIcon === null) return null;
-  const clipboard = useClipboard({
-    copiedTimeout: 600,
-  });
   const Icon = selectedIcon.Component;
-
-  const handleClick = React.useCallback(() => {
-    clipboard.copy(iconSnippet(selectedIcon.name)); // programmatically copying a value
-  }, [clipboard.copy, selectedIcon.name]);
 
   return (
     <>
@@ -50,13 +40,7 @@ const IconCard: React.FC<IconCardProps> = ({selectedIcon}) => {
         <Box marginBottom="space70" position="relative">
           <Codeblock>{iconSnippet(selectedIcon.name)}</Codeblock>
           <Box bottom="10px" position="absolute" right="10px">
-            <Button onClick={handleClick} variant="secondary" size="small">
-              <CopyIcon decorative />
-              <span aria-live="polite">
-                {clipboard.copied ? 'Copied' : 'Copy'}
-                <ScreenReaderOnly>code snippet</ScreenReaderOnly>
-              </span>
-            </Button>
+            <CopyButton text={iconSnippet(selectedIcon.name)} />
           </Box>
         </Box>
         <Paragraph marginBottom="space0">

--- a/packages/paste-website/src/components/shortcodes/live-preview/CodeBlockOverlayShadow.tsx
+++ b/packages/paste-website/src/components/shortcodes/live-preview/CodeBlockOverlayShadow.tsx
@@ -1,0 +1,12 @@
+import {styled, css} from '@twilio-paste/styling-library';
+
+export const CodeBlockOverlayShadow = styled.div(
+  css({
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
+    left: 0,
+    top: 0,
+    background: `linear-gradient(0, #121C2D 0%, rgba(18, 28, 45, 0) 100%)`,
+  })
+);

--- a/packages/paste-website/src/components/site-wrapper/sidebar/SidebarAnchor.tsx
+++ b/packages/paste-website/src/components/site-wrapper/sidebar/SidebarAnchor.tsx
@@ -9,7 +9,9 @@ interface SidebarAnchorProps {
   onClick?: () => void;
 }
 
-const StyledSidebarAnchor = styled(Link)<SidebarAnchorProps>((props) =>
+const StyledSidebarAnchor = styled(Link, {
+  shouldForwardProp: (prop) => prop !== 'nested',
+})<SidebarAnchorProps>((props) =>
   css({
     position: 'relative',
     display: 'block',

--- a/packages/paste-website/stories/LivePreview.stories.tsx
+++ b/packages/paste-website/stories/LivePreview.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {Anchor} from '@twilio-paste/anchor';
+import {Stack} from '@twilio-paste/stack';
+import {LivePreview} from '../src/components/shortcodes/live-preview';
+
+export const SmallLivePreview = (): React.ReactNode => {
+  return (
+    <LivePreview scope={{Anchor}} language="jsx">
+      {`<Anchor href="/components">
+  Go to Paste components
+</Anchor>`}
+    </LivePreview>
+  );
+};
+
+export const LargeLivePreview = (): React.ReactNode => {
+  return (
+    <LivePreview scope={{Anchor, Stack}} language="jsx">
+      {`<Stack orientation="vertical" spacing="space50">
+  <Anchor href="/components">
+    Go to Paste components
+  </Anchor>
+  <Anchor href="/components">
+    Go to Paste components
+  </Anchor>
+</Stack>`}
+    </LivePreview>
+  );
+};
+
+export default {
+  title: 'Website/LivePreview',
+};


### PR DESCRIPTION
This change improves the codeblocks on our website by starting the code portion closed, adding a view/hide code button, and adding a copy button. This also improves the general styling.