### PR TITLE
chore: replace close icon with `secondary_icon` variant in Alert, Modal, Popover, Toast

### DIFF
--- a/.changeset/eleven-pets-applaud.md
+++ b/.changeset/eleven-pets-applaud.md
@@ -1,0 +1,9 @@
+---
+'@twilio-paste/alert': patch
+'@twilio-paste/modal': patch
+'@twilio-paste/popover': patch
+'@twilio-paste/toast': patch
+'@twilio-paste/core': patch
+---
+
+[Alert, Modal, Popover, Toast] Update close button to use `secondary_icon` button variant

--- a/packages/paste-core/components/alert/src/index.tsx
+++ b/packages/paste-core/components/alert/src/index.tsx
@@ -112,12 +112,12 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           <MediaBody as="div">{children}</MediaBody>
           {onDismiss && typeof onDismiss === 'function' && (
             <MediaFigure align="end" spacing="space60">
-              <Button onClick={onDismiss} variant="link" size="reset" element={`${element}_DISMISS_BUTTON`}>
+              <Button onClick={onDismiss} variant="secondary_icon" size="reset" element={`${element}_DISMISS_BUTTON`}>
                 <CloseIcon
                   element={`${element}_DISMISS_ICON`}
                   color="colorTextIcon"
                   decorative={false}
-                  title="dismiss this alert"
+                  title="Dismiss alert"
                   size="sizeIcon20"
                 />
               </Button>

--- a/packages/paste-core/components/modal/src/ModalHeader.tsx
+++ b/packages/paste-core/components/modal/src/ModalHeader.tsx
@@ -21,7 +21,7 @@ const ModalHeader = React.forwardRef<HTMLHeadElement, ModalHeaderProps>(
           <Flex vAlignContent="center" grow={1} marginRight="space70">
             {children}
           </Flex>
-          <Button element={`${element}_CLOSE_BUTTON`} variant="reset" size="reset" onClick={() => onDismiss()}>
+          <Button element={`${element}_CLOSE_BUTTON`} variant="secondary_icon" size="reset" onClick={() => onDismiss()}>
             <CloseIcon
               element={`${element}_CLOSE_ICON`}
               decorative={false}

--- a/packages/paste-core/components/popover/src/Popover.tsx
+++ b/packages/paste-core/components/popover/src/Popover.tsx
@@ -46,7 +46,7 @@ const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(({children, eleme
           <Box position="absolute" right={8} top={8}>
             <Button
               element={`${element}_CLOSE_BUTTON`}
-              variant="reset"
+              variant="secondary_icon"
               size="reset"
               // @ts-ignore
               // Property 'hide' does not exist on type 'Partial<PopoverState>'

--- a/packages/paste-core/components/toast/__tests__/toaster.spec.tsx
+++ b/packages/paste-core/components/toast/__tests__/toaster.spec.tsx
@@ -73,7 +73,7 @@ describe('Toaster', () => {
           <Toaster {...mockToasterState} data-testid="toaster" />
         </Theme.Provider>
       );
-      const dismissButton = screen.getByRole('button', {name: /dismiss this toast/i});
+      const dismissButton = screen.getByRole('button', {name: /dismiss toast/i});
       expect(document.activeElement).toEqual(dismissButton);
     });
 
@@ -100,7 +100,7 @@ describe('Toaster', () => {
           <Toaster {...mockToasterState} data-testid="toaster" />
         </Theme.Provider>
       );
-      const dismissButton = screen.getByText('dismiss this toast');
+      const dismissButton = screen.getByText('Dismiss toast');
       fireEvent.click(dismissButton);
       expect(mockDismiss).toHaveBeenCalledWith('custom_id');
     });
@@ -157,7 +157,7 @@ describe('Toaster', () => {
       fireEvent.click(triggerButton);
       const renderedToasts = screen.getAllByRole('status');
       expect(renderedToasts.length).toEqual(1);
-      expect(document.activeElement).toEqual(screen.getByRole('button', {name: /dismiss this toast/i}));
+      expect(document.activeElement).toEqual(screen.getByRole('button', {name: /dismiss toast/i}));
     });
 
     it('should handle clicking the dismiss button', async () => {
@@ -165,7 +165,7 @@ describe('Toaster', () => {
       const triggerButton = screen.getByText('Add toast');
       fireEvent.click(triggerButton);
       rerender(<MockToasterTrigger />);
-      const dismissButton = screen.getByRole('button', {name: /dismiss this toast/i});
+      const dismissButton = screen.getByRole('button', {name: /dismiss toast/i});
       fireEvent.click(dismissButton);
       rerender(<MockToasterTrigger />);
       await waitFor(() => {

--- a/packages/paste-core/components/toast/src/Toast.tsx
+++ b/packages/paste-core/components/toast/src/Toast.tsx
@@ -89,7 +89,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
             <MediaFigure align="end" spacing="space40">
               <Button
                 onClick={onDismiss}
-                variant="link"
+                variant="secondary_icon"
                 ref={buttonRef}
                 size="reset"
                 element={`${element}_CLOSE_BUTTON`}
@@ -97,7 +97,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                 <CloseIcon
                   color="colorTextIcon"
                   decorative={false}
-                  title="dismiss this toast"
+                  title="Dismiss toast"
                   size="sizeIcon20"
                   element={`${element}_CLOSE_ICON`}
                 />


### PR DESCRIPTION
[Ticket](https://issues.corp.twilio.com/browse/DSYS-2269)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
