### PR TITLE
fix(label): default cursor when label is a legend

### DIFF
--- a/.changeset/tricky-rules-wonder.md
+++ b/.changeset/tricky-rules-wonder.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/label': patch
+'@twilio-paste/core': patch
+---
+
+[Label] Update the cursor

--- a/packages/paste-core/components/label/src/Label.tsx
+++ b/packages/paste-core/components/label/src/Label.tsx
@@ -27,6 +27,14 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
     } else if (variant === 'inverse') {
       textColor = 'colorTextInverse';
     }
+
+    let cursor = 'pointer';
+    if (disabled) {
+      cursor = 'not-allowed';
+    } else if (as === 'legend') {
+      cursor = 'default';
+    }
+
     return (
       <Box
         {...safelySpreadBoxProps(props)}
@@ -44,7 +52,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
         fontWeight="fontWeightBold"
         lineHeight="lineHeight30"
         color={textColor}
-        cursor={disabled ? 'not-allowed' : 'pointer'}
+        cursor={cursor}
         ref={ref}
       >
         <MediaObject verticalAlign="top">


### PR DESCRIPTION
For the label component - when the label has `as="legend"` and it is not `disabled`, the cursor should be default.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
