### PR TITLE
chore(website): change page section link to icon

### DIFF
--- a/.changeset/serious-bulldogs-cheer.md
+++ b/.changeset/serious-bulldogs-cheer.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/heading': minor
+'@twilio-paste/core': minor
+---
+
+[Heading] Added the prop "display" to Heading to make aligning Headings with Icons possible

--- a/packages/paste-core/components/heading/src/PropTypes.ts
+++ b/packages/paste-core/components/heading/src/PropTypes.ts
@@ -13,4 +13,5 @@ export const HeadingPropTypes = {
     'heading50',
     'heading60',
   ] as HeadingVariants[]).isRequired,
+  display: PropTypes.string,
 };

--- a/packages/paste-core/components/heading/src/index.tsx
+++ b/packages/paste-core/components/heading/src/index.tsx
@@ -57,13 +57,13 @@ function getHeadingProps(headingVariant?: HeadingVariants, marginBottom?: 'space
 }
 
 const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
-  ({as, children, element = 'HEADING', id, marginBottom, variant, ...props}, ref) => {
+  ({as, children, display = 'block', element = 'HEADING', id, marginBottom, variant, ...props}, ref) => {
     return (
       <Text
         {...safelySpreadTextProps(props)}
         {...getHeadingProps(variant, marginBottom)}
         as={as}
-        display="block"
+        display={display}
         element={element}
         id={id}
         color="colorText"

--- a/packages/paste-core/components/heading/src/types.ts
+++ b/packages/paste-core/components/heading/src/types.ts
@@ -3,7 +3,7 @@ import type {TextProps} from '@twilio-paste/text';
 export type AsTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div' | 'label' | 'span' | 'header';
 export type HeadingVariants = 'heading10' | 'heading20' | 'heading30' | 'heading40' | 'heading50' | 'heading60';
 
-export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement>, Pick<TextProps, 'element'> {
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement>, Pick<TextProps, 'element' | 'display'> {
   as: AsTags;
   className?: never;
   id?: string;

--- a/packages/paste-website/src/components/Heading.tsx
+++ b/packages/paste-website/src/components/Heading.tsx
@@ -1,34 +1,81 @@
 import * as React from 'react';
-import {Heading, HeadingProps} from '@twilio-paste/heading';
-import {styled, themeGet} from '@twilio-paste/styling-library';
+import {Box} from '@twilio-paste/box';
+import type {BoxStyleProps} from '@twilio-paste/box';
+import {Heading} from '@twilio-paste/heading';
+import type {HeadingProps} from '@twilio-paste/heading';
+import {LinkIcon} from '@twilio-paste/icons/esm/LinkIcon';
 import {slugify} from '../utils/RouteUtils';
 
-const StyledAnchorHyperlink = styled.a`
-  text-decoration: none;
-  margin-left: ${themeGet('space.space30')};
-  color: ${themeGet('textColors.colorTextWeak')};
-
-  &:hover {
-    text-decoration: underline;
+const anchoredHeadingSpacing: Partial<
+  {
+    [key in HeadingProps['variant']]: Partial<BoxStyleProps>;
   }
-`;
+> = {
+  heading10: {
+    marginBottom: 'space70',
+  },
+  heading20: {
+    marginBottom: 'space60',
+  },
+  heading30: {
+    marginBottom: 'space50',
+  },
+  heading40: {
+    marginBottom: 'space40',
+  },
+  heading50: {
+    marginBottom: 'space30',
+  },
+  heading60: {
+    marginBottom: 'space30',
+  },
+};
 
-const AnchoredHeading: React.FC<HeadingProps> = (props) => {
+const StyledAnchorHyperlink: React.FC<{href: string}> = ({children, ...props}) => {
+  return (
+    <Box
+      {...props}
+      textDecoration="none"
+      marginLeft="space30"
+      color="colorTextIcon"
+      borderRadius="borderRadius10"
+      outline="none"
+      display="inline-block"
+      verticalAlign="text-bottom"
+      _hover={{color: 'colorTextLinkStronger'}}
+      _focus={{boxShadow: 'shadowFocus', color: 'colorTextLinkStronger'}}
+      as="a"
+    >
+      {children}
+    </Box>
+  );
+};
+
+type AnchoredHeadingProps = HeadingProps & {
+  existingSlug?: string;
+};
+
+const AnchoredHeading: React.FC<AnchoredHeadingProps> = ({variant, as, existingSlug, ...props}) => {
   // Only generate slugs for headings where children is 'string'
   if (typeof props.children === 'string') {
     const id = slugify(props.children);
 
+    // keeps the existingSlug if one is given (like in Roadmap)
+    const slug = existingSlug || id;
+
     return (
-      <Heading {...props} id={id}>
-        {props.children}
-        <StyledAnchorHyperlink href={`#${id}`} data-cy={`anchored-heading-${props.as}`}>
-          #
+      <Box alignItems="start" {...anchoredHeadingSpacing[variant]}>
+        <Heading display="inline" variant={variant} as={as} {...props} id={slug}>
+          {props.children}
+        </Heading>
+        <StyledAnchorHyperlink data-cy={`anchored-heading-${as}`} href={`#${slug}`}>
+          <LinkIcon decorative={false} title={`${props.children} page anchor`} size="sizeIcon30" />
         </StyledAnchorHyperlink>
-      </Heading>
+      </Box>
     );
   }
 
-  return <Heading {...props} />;
+  return <Heading variant={variant} as={as} {...props} />;
 };
 
-export {AnchoredHeading};
+export {AnchoredHeading, StyledAnchorHyperlink};

--- a/packages/paste-website/src/components/Roadmap/Roadmap.tsx
+++ b/packages/paste-website/src/components/Roadmap/Roadmap.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
-import {Heading} from '@twilio-paste/heading';
 import {Badge} from '@twilio-paste/badge';
 import {Table, THead, TBody, Tr, Td, Th} from '@twilio-paste/table';
 import {Stack} from '@twilio-paste/stack';
-import {Anchor} from '@twilio-paste/anchor';
-import {LinkIcon} from '@twilio-paste/icons/esm/LinkIcon';
 import {useUID} from '@twilio-paste/uid-library';
 import {Statuses} from './constants';
 import type {RoadmapProps} from './types';
 import {slugify} from '../../utils/RouteUtils';
+import {AnchoredHeading} from '../Heading';
 
 const StatusBadges = {
   [Statuses.TODO]: (
@@ -44,19 +42,9 @@ const Roadmap: React.FC<RoadmapProps> = ({data}) => {
 
           return (
             <Box key={useUID()} id={releaseSlug} data-cy={`release-container-#${releaseSlug}`}>
-              <Heading as="h2" variant="heading20">
-                <Box as="span" display="flex" alignItems="center">
-                  Release - {release.release}
-                  <Anchor data-cy="anchored-heading-h2" href={`#${releaseSlug}`}>
-                    <LinkIcon
-                      color="colorTextIcon"
-                      decorative={false}
-                      title={`${release.release} page anchor`}
-                      size="sizeIcon40"
-                    />
-                  </Anchor>
-                </Box>
-              </Heading>
+              <AnchoredHeading as="h2" variant="heading20" existingSlug={releaseSlug}>
+                {release.release}
+              </AnchoredHeading>
               <Table>
                 <THead>
                   <Tr>

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -221,12 +221,13 @@ const Component = () => (
 
 #### Props
 
-| Prop          | Type                | Description                                                                  | Default |
-| ------------- | ------------------- | ---------------------------------------------------------------------------- | ------- |
-| as            | `asTags`            | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                   | null    |
-| id?           | `string`            |                                                                              | null    |
-| marginBottom? | `oneOf(['space0'])` | Currently we only allow `space0` to remove bottom margin                     | null    |
-| variant       | `headingVariants`   | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60' | null    |
+| Prop          | Type                           | Description                                                                               | Default |
+| ------------- | ------------------------------ | ----------------------------------------------------------------------------------------- | ------- |
+| as            | `asTags`                       | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                                | null    |
+| id?           | `string`                       |                                                                                           | null    |
+| marginBottom? | `oneOf(['space0'])`            | Currently we only allow `space0` to remove bottom margin                                  | null    |
+| variant       | `headingVariants`              | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'              | null    |
+| display?      | `CSS display property options` | 'block', 'inline', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid', and more | "block" |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/stories/AnchoredHeading.stories.tsx
+++ b/packages/paste-website/stories/AnchoredHeading.stories.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import {AnchoredHeading} from '../src/components/Heading';
+
+export const SectionHeaderAnchor = (): React.ReactNode => {
+  return (
+    <>
+      <AnchoredHeading as="h2" variant="heading20">
+        Page Section Header
+      </AnchoredHeading>
+      <AnchoredHeading as="h3" variant="heading30">
+        Smaller Page Section Header
+      </AnchoredHeading>
+      <AnchoredHeading as="h4" variant="heading40">
+        Even smaller Page Section Header
+      </AnchoredHeading>
+    </>
+  );
+};
+
+export default {
+  title: 'Website/SectionHeaderAnchor',
+};


### PR DESCRIPTION
Changes the link on the page section headers from the "#" character to the LinkIcon icon. 