### PR TITLE
fix(website): fix overflow on codeblocks, revert overflowX fix

### DIFF
--- a/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
@@ -58,7 +58,6 @@ const LivePreview: React.FC<LivePreviewProps> = ({
           borderTopLeftRadius="borderRadius20"
           borderTopRightRadius="borderRadius20"
           position="relative"
-          overflowX="auto"
         >
           <ReactLivePreview />
         </Box>


### PR DESCRIPTION
This PR fixes a recently introduced bug on the doc site that would prevent code examples from overflowing the preview container (video attached).

https://user-images.githubusercontent.com/1592327/144492980-b9a6d6b9-8832-4826-bf15-e7dddd83647d.mov

For some reason, the `overflow-x` CSS rule is applying a un-overwriteable `overflow-y: hidden`, and I can't quite work it out at this time. By removing the `overflow-x`, I revert the recent improvement of having a horizontal scrollbar (like for the tables examples), but I restore the old expected behavior. 