### PR TITLE
fix: default imports for JSON for webpack 5 compatibility

### DIFF
--- a/.changeset/fluffy-beers-help.md
+++ b/.changeset/fluffy-beers-help.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/color-contrast-utils': minor
+---
+
+Fix default imports for JSON to play nice with webpack 5

--- a/packages/paste-color-contrast-utils/src/utils.ts
+++ b/packages/paste-color-contrast-utils/src/utils.ts
@@ -2,7 +2,7 @@ import ColorCombos from 'color-combos';
 import type {ColorCombo} from 'color-combos';
 import type {GenericTokensShape, AllGenericTokens} from '@twilio-paste/design-tokens/types/GenericTokensShape';
 import type {DesignToken, DesignTokensJSON, TokenPairContrastRating} from '@twilio-paste/design-tokens/types';
-import * as DefaultRawTokenJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
+import DefaultRawTokenJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
 
 const camelCase = require('lodash.camelcase');
 

--- a/packages/paste-color-contrast-utils/tsconfig.json
+++ b/packages/paste-color-contrast-utils/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__tests__"]


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Addresses #2097, fixing JSON default imports in paste to be compatible with webpack 5 without throwing warnings during compilation.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
