### PR TITLE
fix: default imports for JSON for webpack 5 compatibility

### DIFF
--- a/.changeset/fluffy-beers-help.md
+++ b/.changeset/fluffy-beers-help.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/color-contrast-utils': minor
+---
+
+Fix default imports for JSON to play nice with webpack 5

--- a/.changeset/fluffy-beers-help.md
+++ b/.changeset/fluffy-beers-help.md
@@ -1,5 +1,6 @@
 ---
 '@twilio-paste/color-contrast-utils': minor
+'@twilio-paste/core': minor
 ---
 
 Fix default imports for JSON to play nice with webpack 5

--- a/packages/paste-color-contrast-utils/src/utils.ts
+++ b/packages/paste-color-contrast-utils/src/utils.ts
@@ -2,7 +2,7 @@ import ColorCombos from 'color-combos';
 import type {ColorCombo} from 'color-combos';
 import type {GenericTokensShape, AllGenericTokens} from '@twilio-paste/design-tokens/types/GenericTokensShape';
 import type {DesignToken, DesignTokensJSON, TokenPairContrastRating} from '@twilio-paste/design-tokens/types';
-import * as DefaultRawTokenJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
+import DefaultRawTokenJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
 
 const camelCase = require('lodash.camelcase');
 

--- a/packages/paste-color-contrast-utils/tsconfig.json
+++ b/packages/paste-color-contrast-utils/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__tests__"]


### PR DESCRIPTION
Taking over from https://github.com/twilio-labs/paste/pull/2106, thanks for the contribution @stanlemon

This is so all the tests runs and checks pass that are dependent on secrets.