### PR TITLE
Fix: style props default import

### DIFF
--- a/.changeset/pretty-turkeys-decide.md
+++ b/.changeset/pretty-turkeys-decide.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/style-props': minor
+'@twilio-paste/core': minor
+---
+
+Fix default imports for JSON to play nice with webpack 5

--- a/packages/paste-style-props/src/constants.ts
+++ b/packages/paste-style-props/src/constants.ts
@@ -1,4 +1,4 @@
-import * as RawJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
+import RawJSON from '@twilio-paste/design-tokens/dist/tokens.raw.json';
 
 const camelCase = require('lodash.camelcase');
 

--- a/packages/paste-style-props/tsconfig.json
+++ b/packages/paste-style-props/tsconfig.json
@@ -2,12 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/",
+    "esModuleInterop": true
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["packages/**/*", "dangerfile.ts", ".danger/**/*", "./.jest/@types/index.d.ts"],
   "exclude": [


### PR DESCRIPTION
* Following #2106 / #2107, we noticed there was one more instance of a JSON default import in the style-props package.
* This change addresses that remaining instance, updating the import and the tsconfig to allow esModuleInterop