### PR TITLE
fix(combobox): multiselect combobox example doesn't reselect item when it is selected and then removed

### DIFF
--- a/.changeset/strong-buckets-smoke.md
+++ b/.changeset/strong-buckets-smoke.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/combobox': patch
+'@twilio-paste/core': patch
+---
+
+[Combobox] Fix internal refs so primitive doesn't override them

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -110,6 +110,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       highlightedIndex,
       isOpen,
     } = state || defaultState;
+
     React.useEffect(() => {
       if (highlightedIndex !== undefined && typeof scrollToIndex === 'function' && highlightedIndex > -1) {
         scrollToIndex(highlightedIndex);

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -18,6 +18,7 @@ import {ComboboxInputWrapper} from './styles/ComboboxInputWrapper';
 import {ComboboxListbox} from './styles/ComboboxListbox';
 import {ComboboxItems} from './ComboboxItems';
 import type {ComboboxProps} from './types';
+import {useMergeRefs} from '@twilio-paste/utils';
 
 const getHelpTextVariant = (variant: InputVariants, hasError: boolean | undefined): HelpTextVariants => {
   if (hasError && variant === 'inverse') {
@@ -109,7 +110,6 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       highlightedIndex,
       isOpen,
     } = state || defaultState;
-
     React.useEffect(() => {
       if (highlightedIndex !== undefined && typeof scrollToIndex === 'function' && highlightedIndex > -1) {
         scrollToIndex(highlightedIndex);
@@ -131,14 +131,15 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       );
     }
 
+    const {ref: toggleButtonRef, ...toggleButtonProps} = getToggleButtonProps({tabIndex: 0});
+    const mergedRefs = ref ? useMergeRefs(ref, toggleButtonRef) : toggleButtonRef;
+
     let iconColor = 'colorTextIcon' as TextColor;
     if (disabled) {
       iconColor = 'colorTextWeaker';
     } else if (variant === 'inverse') {
       iconColor = 'colorTextInverseWeak';
     }
-
-    const {ref: toggleButtonRef, ...toggleButtonProps} = getToggleButtonProps({tabIndex: 0, ref});
 
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
@@ -157,7 +158,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
             <ComboboxInputSelect
               {...toggleButtonProps}
               // we spread props into `getInputProps` so that Downshift handles events correctly
-              {...getInputProps({disabled, required, ref: toggleButtonRef, ...props})}
+              {...getInputProps({disabled, required, ref: mergedRefs, ...props})}
               {...(!autocomplete ? {onChange: (event: React.ChangeEvent) => event.preventDefault()} : undefined)}
               autocomplete={autocomplete}
               aria-describedby={helpTextId}

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -138,6 +138,8 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       iconColor = 'colorTextInverseWeak';
     }
 
+    const {ref: toggleButtonRef, ...toggleButtonProps} = getToggleButtonProps({tabIndex: 0, ref});
+
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
         <Label disabled={disabled} required={required} variant={variant} {...getLabelProps()}>
@@ -153,9 +155,9 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
         >
           <ComboboxInputWrapper {...getComboboxProps({role: 'combobox'})}>
             <ComboboxInputSelect
-              {...getToggleButtonProps({tabIndex: 0})}
+              {...toggleButtonProps}
               // we spread props into `getInputProps` so that Downshift handles events correctly
-              {...getInputProps({disabled, required, ref, ...props})}
+              {...getInputProps({disabled, required, ref: toggleButtonRef, ...props})}
               {...(!autocomplete ? {onChange: (event: React.ChangeEvent) => event.preventDefault()} : undefined)}
               autocomplete={autocomplete}
               aria-describedby={helpTextId}

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -13,12 +13,12 @@ import {HelpText} from '@twilio-paste/help-text';
 import type {HelpTextVariants} from '@twilio-paste/help-text';
 import type {InputVariants} from '@twilio-paste/input';
 import type {TextColor} from '@twilio-paste/style-props';
+import {useMergeRefs} from '@twilio-paste/utils';
 import {ComboboxInputSelect} from './styles/ComboboxInputSelect';
 import {ComboboxInputWrapper} from './styles/ComboboxInputWrapper';
 import {ComboboxListbox} from './styles/ComboboxListbox';
 import {ComboboxItems} from './ComboboxItems';
 import type {ComboboxProps} from './types';
-import {useMergeRefs} from '@twilio-paste/utils';
 
 const getHelpTextVariant = (variant: InputVariants, hasError: boolean | undefined): HelpTextVariants => {
   if (hasError && variant === 'inverse') {

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -30,19 +30,16 @@ export const DropdownCombobox = (): React.ReactNode => {
     selectedItem,
   } = useComboboxPrimitive({items});
   const uid = useUID();
+
+  const {ref, toggleButtonProps} = getToggleButtonProps({tabIndex: 0});
+
   return (
     <>
       <Label htmlFor={uid} {...getLabelProps()}>
         Choose a component:
       </Label>
       <Box {...getComboboxProps({role: 'combobox'})}>
-        <Input
-          id={uid}
-          type="text"
-          {...getInputProps()}
-          {...getToggleButtonProps({tabIndex: 0})}
-          value={selectedItem || ''}
-        />
+        <Input id={uid} type="text" {...toggleButtonProps} {...getInputProps({ref})} value={selectedItem || ''} />
       </Box>
       <ul {...getMenuProps()}>
         {isOpen &&
@@ -177,14 +174,13 @@ export const BasicMultiCombobox: React.ReactNode = () => {
   } = useMultiSelectPrimitive({});
 
   const handleSelectItemOnClick = React.useCallback(
-    (selectedItem) => {
+    ({selectedItem}) => {
       addSelectedItem(selectedItem);
       setFilteredItems((currentFilteredItems) =>
         currentFilteredItems.filter((item) => {
           return item !== selectedItem;
         })
       );
-      // setInputValue('');
     },
     [addSelectedItem, setFilteredItems]
   );
@@ -215,24 +211,24 @@ export const BasicMultiCombobox: React.ReactNode = () => {
         case useComboboxPrimitive.stateChangeTypes.InputChange:
           if (args.inputValue) {
             setInputValue(args.inputValue);
+            setFilteredItems(items.filter((item) => item.toLowerCase().startsWith(args.inputValue.toLowerCase())));
           }
           break;
         case useComboboxPrimitive.stateChangeTypes.InputKeyDownEnter:
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
-          console.log(args.selectedItem, args);
-          if (args.selectedItem) {
-            handleSelectItemOnClick(args.selectedItem);
-          } else if (args.inputValue) {
-            handleSelectItemOnClick(args.inputValue);
-          }
+          console.log(args);
+          handleSelectItemOnClick(args);
+          setInputValue('');
           break;
         default:
           break;
       }
     },
   });
+
   const uid = useUID();
+  const {ref, toggleButtonProps} = getToggleButtonProps({tabIndex: 0});
 
   return (
     <>
@@ -244,13 +240,16 @@ export const BasicMultiCombobox: React.ReactNode = () => {
           <Input
             id={uid}
             type="text"
-            {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}
-            {...getToggleButtonProps({tabIndex: 0})}
+            {...toggleButtonProps}
+            {...getInputProps({
+              ref,
+              ...getDropdownProps({preventKeyAction: isOpen}),
+            })}
           />
         </Box>
-        {isOpen && (
-          <ComboboxListbox {...getMenuProps()}>
-            <ComboboxListboxGroup>
+        <ComboboxListbox hidden={!isOpen} {...getMenuProps()}>
+          {isOpen && (
+            <>
               {filteredItems.map((item, index) => (
                 <ComboboxListboxOption
                   variant="default"
@@ -261,9 +260,9 @@ export const BasicMultiCombobox: React.ReactNode = () => {
                   {item}
                 </ComboboxListboxOption>
               ))}
-            </ComboboxListboxGroup>
-          </ComboboxListbox>
-        )}
+            </>
+          )}
+        </ComboboxListbox>
       </Box>
       <FormPillGroup {...formPillState} aria-label="Selected components">
         {selectedItems.map((selectedItem, index) => {

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -173,22 +173,9 @@ export const BasicMultiCombobox: React.ReactNode = () => {
     selectedItems,
   } = useMultiSelectPrimitive({});
 
-  const handleSelectItemOnClick = React.useCallback(
-    ({selectedItem}) => {
-      addSelectedItem(selectedItem);
-      setFilteredItems((currentFilteredItems) =>
-        currentFilteredItems.filter((item) => {
-          return item !== selectedItem;
-        })
-      );
-    },
-    [addSelectedItem, setFilteredItems]
-  );
-
   const handleRemoveItemOnClick = React.useCallback(
     (selectedItem) => {
       removeSelectedItem(selectedItem);
-
       setFilteredItems((currentFilteredItems) => [...currentFilteredItems, selectedItem].sort());
     },
     [removeSelectedItem]
@@ -203,23 +190,25 @@ export const BasicMultiCombobox: React.ReactNode = () => {
     getToggleButtonProps,
     highlightedIndex,
     isOpen,
+    selectItem,
   } = useComboboxPrimitive({
     inputValue,
     items: filteredItems,
     onStateChange: (args) => {
       switch (args.type) {
         case useComboboxPrimitive.stateChangeTypes.InputChange:
-          if (args.inputValue) {
-            setInputValue(args.inputValue);
-            setFilteredItems(items.filter((item) => item.toLowerCase().startsWith(args.inputValue.toLowerCase())));
-          }
+          setInputValue(args.inputValue);
+          setFilteredItems((currentFilteredItems) =>
+            currentFilteredItems.filter((item) => item.toLowerCase().startsWith(args.inputValue.toLowerCase()))
+          );
           break;
         case useComboboxPrimitive.stateChangeTypes.InputKeyDownEnter:
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
-          console.log(args);
-          handleSelectItemOnClick(args);
+          addSelectedItem(args.selectedItem);
+          setFilteredItems((currentFilteredItems) => currentFilteredItems.filter((item) => item !== args.selectedItem));
           setInputValue('');
+          selectItem(null);
           break;
         default:
           break;

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -161,7 +161,7 @@ export const ComboboxNonHooks = (): React.ReactNode => {
   );
 };
 
-export const BasicMultiCombobox: React.FC = () => {
+export const BasicMultiCombobox: React.ReactNode = () => {
   const seed = useUIDSeed();
   const [filteredItems, setFilteredItems] = React.useState([...items]);
   const [inputValue, setInputValue] = React.useState('');
@@ -184,7 +184,7 @@ export const BasicMultiCombobox: React.FC = () => {
           return item !== selectedItem;
         })
       );
-      setInputValue('');
+      // setInputValue('');
     },
     [addSelectedItem, setFilteredItems]
   );
@@ -220,6 +220,7 @@ export const BasicMultiCombobox: React.FC = () => {
         case useComboboxPrimitive.stateChangeTypes.InputKeyDownEnter:
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
+          console.log(args.selectedItem, args);
           if (args.selectedItem) {
             handleSelectItemOnClick(args.selectedItem);
           } else if (args.inputValue) {

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -176,7 +176,7 @@ export const BasicMultiCombobox: React.FC = () => {
     selectedItems,
   } = useMultiSelectPrimitive({});
 
-  const handleSelectItemOnChange = React.useCallback(
+  const handleSelectItemOnClick = React.useCallback(
     (selectedItem) => {
       addSelectedItem(selectedItem);
       setFilteredItems((currentFilteredItems) =>
@@ -221,9 +221,9 @@ export const BasicMultiCombobox: React.FC = () => {
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
           if (args.selectedItem) {
-            handleSelectItemOnChange(args.selectedItem);
+            handleSelectItemOnClick(args.selectedItem);
           } else if (args.inputValue) {
-            handleSelectItemOnChange(args.inputValue);
+            handleSelectItemOnClick(args.inputValue);
           }
           break;
         default:

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -160,9 +160,7 @@ export const ComboboxNonHooks = (): React.ReactNode => {
 
 export const BasicMultiCombobox: React.ReactNode = () => {
   const seed = useUIDSeed();
-  const [filteredItems, setFilteredItems] = React.useState([...items]);
   const [inputValue, setInputValue] = React.useState('');
-
   const formPillState = useFormPillState();
 
   const {
@@ -176,10 +174,13 @@ export const BasicMultiCombobox: React.ReactNode = () => {
   const handleRemoveItemOnClick = React.useCallback(
     (selectedItem) => {
       removeSelectedItem(selectedItem);
-      setFilteredItems((currentFilteredItems) => [...currentFilteredItems, selectedItem].sort());
     },
     [removeSelectedItem]
   );
+
+  const getFilteredItems = (): string[] => {
+    return items.filter((item) => item.toLowerCase().startsWith(inputValue.toLowerCase()));
+  };
 
   const {
     getComboboxProps,
@@ -193,22 +194,20 @@ export const BasicMultiCombobox: React.ReactNode = () => {
     selectItem,
   } = useComboboxPrimitive({
     inputValue,
-    items: filteredItems,
+    items: getFilteredItems(),
     onStateChange: (args) => {
       switch (args.type) {
         case useComboboxPrimitive.stateChangeTypes.InputChange:
           setInputValue(args.inputValue);
-          setFilteredItems((currentFilteredItems) =>
-            currentFilteredItems.filter((item) => item.toLowerCase().startsWith(args.inputValue.toLowerCase()))
-          );
           break;
         case useComboboxPrimitive.stateChangeTypes.InputKeyDownEnter:
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
-          addSelectedItem(args.selectedItem);
-          setFilteredItems((currentFilteredItems) => currentFilteredItems.filter((item) => item !== args.selectedItem));
-          setInputValue('');
-          selectItem(null);
+          if (args.selectedItem) {
+            addSelectedItem(args.selectedItem);
+            setInputValue('');
+            selectItem(null);
+          }
           break;
         default:
           break;
@@ -239,7 +238,7 @@ export const BasicMultiCombobox: React.ReactNode = () => {
         <ComboboxListbox hidden={!isOpen} {...getMenuProps()}>
           {isOpen && (
             <>
-              {filteredItems.map((item, index) => (
+              {getFilteredItems().map((item, index) => (
                 <ComboboxListboxOption
                   variant="default"
                   highlighted={highlightedIndex === index}

--- a/packages/paste-core/primitives/combobox/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/combobox/stories/index.stories.tsx
@@ -179,7 +179,9 @@ export const BasicMultiCombobox: React.ReactNode = () => {
   );
 
   const getFilteredItems = (): string[] => {
-    return items.filter((item) => item.toLowerCase().startsWith(inputValue.toLowerCase()));
+    return items.filter(
+      (item) => !selectedItems.includes(item) && item.toLowerCase().startsWith(inputValue.toLowerCase())
+    );
   };
 
   const {

--- a/packages/paste-website/src/component-examples/ComboboxPrimitiveExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxPrimitiveExamples.ts
@@ -119,7 +119,7 @@ export const BasicMultiCombobox: React.FC = () => {
     selectedItems,
   } = useMultiSelectPrimitive({});
 
-  const handleSelectItemOnChange = React.useCallback(
+  const handleSelectItemOnClick = React.useCallback(
     (selectedItem) => {
       addSelectedItem(selectedItem);
       setFilteredItems((currentFilteredItems) =>
@@ -164,9 +164,9 @@ export const BasicMultiCombobox: React.FC = () => {
         case useComboboxPrimitive.stateChangeTypes.ItemClick:
         case useComboboxPrimitive.stateChangeTypes.InputBlur:
           if (args.selectedItem) {
-            handleSelectItemOnChange(args.selectedItem);
+            handleSelectItemOnClick(args.selectedItem);
           } else if (args.inputValue) {
-            handleSelectItemOnChange(args.inputValue);
+            handleSelectItemOnClick(args.inputValue);
           }
           break;
         default:


### PR DESCRIPTION
Github Discussion: https://github.com/twilio-labs/paste/discussions/2115

**Bug:** When you select and then immediately unselect an item, if you try to select it again noting happens.
**Cause:** 
* We have a function called `handleSelectItemOnClick` that calls the downshift function to add the item to the list of selected items and removes it from the list of combobox items
* `handleSelectItemOnClick`  is passed to the `useComboboxPrimitive`  as the value for  `onSelectedItemChange`

So the problem is that when the user adds an item, removes it, and then adds it again, `handleSelectItemOnClick` isn’t being called because the item isn’t changing.

This bug happens in storybook and the website because it is the same code.

- [x] Fixes all the downshift console errors 
- [x] Uses a function to filter a static list of items to improve typeahead
- [x] Uses `onStateChange` instead of `selectedItemChange` to match best practices (https://downshift.netlify.app/use-multiple-selection)
- [x] Fixes the multiselect bug in storybook and website examples

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
