### PR TITLE
feat(logo-link): make entire logo clickable, add hover

### DIFF
--- a/packages/paste-website/src/components/icons/PasteIcon.tsx
+++ b/packages/paste-website/src/components/icons/PasteIcon.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import type * as CSS from 'csstype';
 import {useUID} from '@twilio-paste/uid-library';
 
-export interface PasteIconProps {
+export interface PasteIconProps<TLength = string | number> {
   decorative?: boolean;
   size?: number;
   title?: string;
   color?: CSS.ColorProperty;
   display?: CSS.DisplayProperty;
   position?: CSS.PositionProperty;
-  top?: CSS.DirectionProperty;
-  left?: CSS.DirectionProperty;
+  top?: CSS.TopProperty<TLength>;
+  left?: CSS.LeftProperty<TLength>;
   opacity?: CSS.OpacityProperty;
   transition?: CSS.TransitionProperty;
 }

--- a/packages/paste-website/src/components/icons/PasteIcon.tsx
+++ b/packages/paste-website/src/components/icons/PasteIcon.tsx
@@ -1,20 +1,36 @@
 import * as React from 'react';
+import type * as CSS from 'csstype';
 import {useUID} from '@twilio-paste/uid-library';
 
 export interface PasteIconProps {
-  className?: string;
-  color?: string;
   decorative?: boolean;
-  display?: string;
   size?: number;
   title?: string;
+  color?: CSS.ColorProperty;
+  display?: CSS.DisplayProperty;
+  position?: CSS.PositionProperty;
+  top?: CSS.DirectionProperty;
+  left?: CSS.DirectionProperty;
+  opacity?: CSS.OpacityProperty;
+  transition?: CSS.TransitionProperty;
 }
 
 const PasteIcon = React.memo(
-  ({title = 'Twilio Icon', className, color, decorative = true, display, size}: PasteIconProps) => {
+  ({
+    title = 'Twilio Icon',
+    color,
+    decorative = true,
+    display,
+    size,
+    opacity,
+    transition,
+    position,
+    top,
+    left,
+  }: PasteIconProps) => {
     const uid = useUID();
     return (
-      <span style={{color, display, width: size, height: size}} className={className}>
+      <span style={{color, display, opacity, transition, position, top, left, width: size, height: size}}>
         <svg
           role="img"
           aria-hidden={decorative}

--- a/packages/paste-website/src/components/icons/PasteIconPride.tsx
+++ b/packages/paste-website/src/components/icons/PasteIconPride.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
+import type * as CSS from 'csstype';
 import {useUID} from '@twilio-paste/uid-library';
 
 export interface PasteIconPrideProps {
-  className?: string;
   decorative?: boolean;
-  display?: string;
   size?: number;
   title?: string;
+  display?: CSS.DisplayProperty;
+  opacity?: CSS.OpacityProperty;
+  transition?: CSS.TransitionProperty;
 }
 
 const PasteIconPride = React.memo(
-  ({title = 'Twilio Paste', className, decorative = true, display, size}: PasteIconPrideProps) => {
+  ({title = 'Twilio Paste', decorative = true, display, size, opacity, transition}: PasteIconPrideProps) => {
     const titleId = `paste-icon-${useUID()}`;
     return (
-      <span style={{display, width: size, height: size}} className={className}>
+      <span style={{display, opacity, transition, width: size, height: size}}>
         <svg
           role="img"
           aria-hidden={decorative}

--- a/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
@@ -5,18 +5,32 @@ import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {MediaObject, MediaBody, MediaFigure} from '@twilio-paste/media-object';
 import {styled} from '@twilio-paste/styling-library';
-// import {useTheme} from '@twilio-paste/theme';
-// import {PasteIconInverse} from '../../icons/PasteIconInverse';
+import {useTheme} from '@twilio-paste/theme';
+import {PasteIcon} from '../../icons/PasteIcon';
 import {PasteIconPride} from '../../icons/PasteIconPride';
 
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  color: inherit;
+interface StyledLinkProps {
+  href: string;
+  onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}
 
-  &:visited {
-    color: inherit;
-  }
-`;
+const StyledLink: React.FC<StyledLinkProps> = ({children, ...props}) => {
+  return (
+    <Box
+      {...props}
+      as="a"
+      textDecoration="none"
+      color="colorTextInverse"
+      _hover={{textDecoration: 'underline'}}
+      _focus={{boxShadow: 'shadowFocus', borderRadius: 'borderRadius10'}}
+      _focusVisible={{outline: 'none'}}
+    >
+      {children}
+    </Box>
+  );
+};
 
 interface SiteHeaderLogoProps {
   title?: string;
@@ -26,7 +40,12 @@ interface SiteHeaderLogoProps {
 // Note: 'subtitle' isn't passed for the mobile view, so we use that fact
 // to render different sizes and spacing in mobile
 const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
-  // const theme = useTheme();
+  const theme = useTheme();
+
+  const pastePrideIcon = <PasteIconPride display="block" size={42} />;
+  const pasteRedIcon = <PasteIcon color={theme.textColors.colorTextBrandHighlight} display="block" size={42} />;
+  const [pasteIcon, setPasteIcon] = React.useState(pastePrideIcon);
+
   return (
     <Box
       display="flex"
@@ -38,39 +57,38 @@ const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
       borderRightWidth={['borderWidth0', 'borderWidth0', 'borderWidth10']}
       minWidth={subtitle ? 'sizeSidebar' : 'size0'}
     >
-      <MediaObject verticalAlign="center">
-        <MediaFigure spacing="space40">
-          {/* <PasteIconInverse color={theme.textColors.colorTextInverse} display="block" size={42} /> */}
-          <PasteIconPride display="block" size={42} />
-        </MediaFigure>
-        <MediaBody>
-          <Text as="div" fontSize="fontSize40" lineHeight="lineHeight40" color="colorTextInverse">
-            <StyledLink
-              to="/"
-              onClick={() =>
-                trackCustomEvent({
-                  category: 'Top Navigation',
-                  action: 'click-paste-logo',
-                  label: 'Paste logo',
-                })
-              }
-            >
+      <StyledLink
+        href="/"
+        onClick={() =>
+          trackCustomEvent({
+            category: 'Top Navigation',
+            action: 'click-paste-logo',
+            label: 'Paste logo',
+          })
+        }
+        onMouseEnter={() => setPasteIcon(pasteRedIcon)}
+        onMouseLeave={() => setPasteIcon(pastePrideIcon)}
+      >
+        <MediaObject verticalAlign="center">
+          <MediaFigure spacing="space40">{pasteIcon}</MediaFigure>
+          <MediaBody>
+            <Text as="div" fontSize="fontSize40" lineHeight="lineHeight40" color="colorTextInverse">
               {title}
-            </StyledLink>
-          </Text>
-          {subtitle ? (
-            <Text
-              as="div"
-              fontSize="fontSize20"
-              fontWeight="fontWeightNormal"
-              lineHeight="lineHeight20"
-              color="colorTextInverse"
-            >
-              {subtitle}
             </Text>
-          ) : null}
-        </MediaBody>
-      </MediaObject>
+            {subtitle ? (
+              <Text
+                as="div"
+                fontSize="fontSize20"
+                fontWeight="fontWeightNormal"
+                lineHeight="lineHeight20"
+                color="colorTextInverse"
+              >
+                {subtitle}
+              </Text>
+            ) : null}
+          </MediaBody>
+        </MediaObject>
+      </StyledLink>
     </Box>
   );
 };

--- a/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {Link} from 'gatsby';
 import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {MediaObject, MediaBody, MediaFigure} from '@twilio-paste/media-object';
-import {styled} from '@twilio-paste/styling-library';
 import {useTheme} from '@twilio-paste/theme';
 import {PasteIcon} from '../../icons/PasteIcon';
 import {PasteIconPride} from '../../icons/PasteIconPride';

--- a/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
@@ -21,6 +21,7 @@ const StyledLink: React.FC<StyledLinkProps> = ({children, ...props}) => {
       as="a"
       textDecoration="none"
       color="colorTextInverse"
+      position="relative"
       _hover={{textDecoration: 'underline'}}
       _focus={{boxShadow: 'shadowFocus', borderRadius: 'borderRadius10'}}
       _focusVisible={{outline: 'none'}}
@@ -39,10 +40,9 @@ interface SiteHeaderLogoProps {
 // to render different sizes and spacing in mobile
 const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
   const theme = useTheme();
-
-  const pastePrideIcon = <PasteIconPride display="block" size={42} />;
-  const pasteRedIcon = <PasteIcon color={theme.textColors.colorTextBrandHighlight} display="block" size={42} />;
-  const [pasteIcon, setPasteIcon] = React.useState(pastePrideIcon);
+  const [logoOpacity, setLogoOpacity] = React.useState(1);
+  const [hoverOpacity, setHoverOpacity] = React.useState(0);
+  const logoTransition = 'ease-out 350ms';
 
   return (
     <Box
@@ -64,13 +64,31 @@ const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
             label: 'Paste logo',
           })
         }
-        onMouseEnter={() => setPasteIcon(pasteRedIcon)}
-        onMouseLeave={() => setPasteIcon(pastePrideIcon)}
+        onMouseEnter={() => {
+          setLogoOpacity(0);
+          setHoverOpacity(1);
+        }}
+        onMouseLeave={() => {
+          setLogoOpacity(1);
+          setHoverOpacity(0);
+        }}
       >
         <MediaObject verticalAlign="center">
-          <MediaFigure spacing="space40">{pasteIcon}</MediaFigure>
+          <MediaFigure spacing="space40">
+            <PasteIconPride display="block" size={42} transition={logoTransition} opacity={logoOpacity} />
+            <PasteIcon
+              color={theme.textColors.colorTextBrandHighlight}
+              opacity={hoverOpacity}
+              transition={logoTransition}
+              display="block"
+              position="absolute"
+              top="0"
+              left="0"
+              size={42}
+            />
+          </MediaFigure>
           <MediaBody>
-            <Text as="div" fontSize="fontSize40" lineHeight="lineHeight40" color="colorTextInverse">
+            <Text as="div" fontSize="fontSize40" lineHeight="lineHeight30" color="colorTextInverse">
               {title}
             </Text>
             {subtitle ? (

--- a/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderLogo.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import {Link} from 'gatsby';
 import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
+import {styled, themeGet} from '@twilio-paste/styling-library';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {MediaObject, MediaBody, MediaFigure} from '@twilio-paste/media-object';
@@ -7,29 +9,21 @@ import {useTheme} from '@twilio-paste/theme';
 import {PasteIcon} from '../../icons/PasteIcon';
 import {PasteIconPride} from '../../icons/PasteIconPride';
 
-interface StyledLinkProps {
-  href: string;
-  onClick?: () => void;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
-}
+const LogoLink = styled(Link)`
+  position: relative;
+  text-decoration: none;
+  color: ${themeGet('textColors.colorTextInverse')};
 
-const StyledLink: React.FC<StyledLinkProps> = ({children, ...props}) => {
-  return (
-    <Box
-      {...props}
-      as="a"
-      textDecoration="none"
-      color="colorTextInverse"
-      position="relative"
-      _hover={{textDecoration: 'underline'}}
-      _focus={{boxShadow: 'shadowFocus', borderRadius: 'borderRadius10'}}
-      _focusVisible={{outline: 'none'}}
-    >
-      {children}
-    </Box>
-  );
-};
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: ${themeGet('shadows.shadowFocus')};
+    border-radius: ${themeGet('radii.borderRadius10')};
+  }
+`;
 
 interface SiteHeaderLogoProps {
   title?: string;
@@ -55,8 +49,8 @@ const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
       borderRightWidth={['borderWidth0', 'borderWidth0', 'borderWidth10']}
       minWidth={subtitle ? 'sizeSidebar' : 'size0'}
     >
-      <StyledLink
-        href="/"
+      <LogoLink
+        to="/"
         onClick={() =>
           trackCustomEvent({
             category: 'Top Navigation',
@@ -104,7 +98,7 @@ const SiteHeaderLogo: React.FC<SiteHeaderLogoProps> = ({title, subtitle}) => {
             ) : null}
           </MediaBody>
         </MediaObject>
-      </StyledLink>
+      </LogoLink>
     </Box>
   );
 };


### PR DESCRIPTION
* Makes full Paste logo on the website clickable
* Adds hover effect for logo swapping
* Updates logo UI to match Figma design

<img width="300" alt="Screen Shot 2022-01-12 at 10 12 50 AM" src="https://user-images.githubusercontent.com/36438/149178108-05b594d5-e284-4883-8df0-4b5ee1cd6736.png">
