### PR TITLE
chore(core-bundle): fix incorrect tsconfig extend path

### DIFF
--- a/.changeset/little-bottles-scream.md
+++ b/.changeset/little-bottles-scream.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/core': patch
+---
+
+[Core] Fixed an incorrect path in the tsconfig.json file. Thanks @abereghici!

--- a/.danger/changesets-that-need-core-check.ts
+++ b/.danger/changesets-that-need-core-check.ts
@@ -28,7 +28,7 @@ const IGNORE_LIST = [
 export const shouldFlagChangeset = (filePath: string) => {
   const fileContent = fs.readFileSync(filePath).toString();
 
-  return !IGNORE_LIST.includes(fileContent);
+  return !IGNORE_LIST.some((ignorePath) => fileContent.match(ignorePath));
 };
 
 /**

--- a/packages/paste-core/core-bundle/tsconfig.json
+++ b/packages/paste-core/core-bundle/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.json",
+  "extends": "../../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
     "outDir": "./dist",


### PR DESCRIPTION
Taking over from #2062, thanks for the contribution @abereghici

This is so all the tests runs and checks pass that are dependent on secrets.