### PR TITLE
fix(breadcrumb): spread props on child Anchor or Text element

### DIFF
--- a/.changeset/afraid-dancers-confess.md
+++ b/.changeset/afraid-dancers-confess.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/breadcrumb': patch
+'@twilio-paste/core': patch
+---
+
+[Breadcrumb] spread props onto Anchor or Text of breadcrumb, not the list item wrapping it.

--- a/packages/paste-core/components/breadcrumb/__tests__/breadcrumb.spec.tsx
+++ b/packages/paste-core/components/breadcrumb/__tests__/breadcrumb.spec.tsx
@@ -58,6 +58,18 @@ describe('Breadcrumb', () => {
     expect(getByText('foo').getAttribute('aria-current')).toBe('page');
   });
 
+  it('should pass props given to BreadcrumbItem onto its Anchor or Text child', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbItem href="#" data-testid="breadcrumb-anchor">
+          foo
+        </BreadcrumbItem>
+      </Breadcrumb>
+    );
+    const breadcrumbAnchor = screen.getByRole('listitem').firstChild as HTMLElement;
+    expect(breadcrumbAnchor.getAttribute('data-testid')).toEqual('breadcrumb-anchor');
+  });
+
   describe('Accessibility', () => {
     it('Should have no accessibility violations', async () => {
       const {container} = render(<BreadcrumbExample />);
@@ -81,14 +93,14 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByTestId('breadcrumb').getAttribute('data-paste-element')).toEqual('TEST_PARENT');
 
-      const breadcrumbItem1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
-      const breadcrumbItem2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
+      const breadcrumbItem1 = screen.getAllByRole('listitem')[0] as HTMLElement;
+      const breadcrumbItem2 = screen.getAllByRole('listitem')[1] as HTMLElement;
 
       expect(breadcrumbItem1.getAttribute('data-paste-element')).toEqual('TEST_ITEM');
       expect(breadcrumbItem2.getAttribute('data-paste-element')).toEqual('TEST_ITEM');
 
-      const node1 = breadcrumbItem1.firstChild as HTMLElement;
-      const node2 = breadcrumbItem2.firstChild as HTMLElement;
+      const node1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
+      const node2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
 
       expect(node1.getAttribute('data-paste-element')).toEqual('TEST_ANCHOR');
       expect(node2.getAttribute('data-paste-element')).toEqual('TEST_ANCHOR');
@@ -111,14 +123,14 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByTestId('breadcrumb').getAttribute('data-paste-element')).toEqual('TEST_PARENT');
 
-      const breadcrumbItem1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
-      const breadcrumbItem2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
+      const breadcrumbItem1 = screen.getAllByRole('listitem')[0] as HTMLElement;
+      const breadcrumbItem2 = screen.getAllByRole('listitem')[1] as HTMLElement;
 
       expect(breadcrumbItem1.getAttribute('data-paste-element')).toEqual('TEST_PARENT_ITEM');
       expect(breadcrumbItem2.getAttribute('data-paste-element')).toEqual('TEST_PARENT_ITEM');
 
-      const node1 = breadcrumbItem1.firstChild as HTMLElement;
-      const node2 = breadcrumbItem2.firstChild as HTMLElement;
+      const node1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
+      const node2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
 
       expect(node1.getAttribute('data-paste-element')).toEqual('TEST_PARENT_ANCHOR');
       expect(node2.getAttribute('data-paste-element')).toEqual('TEST_PARENT_ANCHOR');
@@ -142,14 +154,14 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByTestId('breadcrumb').getAttribute('data-paste-element')).toEqual('BREADCRUMB');
 
-      const breadcrumbItem1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
-      const breadcrumbItem2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
+      const breadcrumbItem1 = screen.getAllByRole('listitem')[0] as HTMLElement;
+      const breadcrumbItem2 = screen.getAllByRole('listitem')[1] as HTMLElement;
 
       expect(breadcrumbItem1.getAttribute('data-paste-element')).toEqual('BREADCRUMB_ITEM');
       expect(breadcrumbItem2.getAttribute('data-paste-element')).toEqual('BREADCRUMB_ITEM');
 
-      const node1 = breadcrumbItem1.firstChild as HTMLElement;
-      const node2 = breadcrumbItem2.firstChild as HTMLElement;
+      const node1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
+      const node2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
 
       expect(node1.getAttribute('data-paste-element')).toEqual('BREADCRUMB_ANCHOR');
       expect(node2.getAttribute('data-paste-element')).toEqual('BREADCRUMB_ANCHOR');
@@ -194,27 +206,27 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByTestId('breadcrumb')).toHaveStyleRule('font-variant-numeric', 'slashed-zero');
 
-      const breadcrumbItem1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
-      const breadcrumbItem2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
-      const breadcrumbItem3 = screen.getByTestId('breadcrumb-item-3') as HTMLElement;
+      const breadcrumbItem1 = screen.getAllByRole('listitem')[0] as HTMLElement;
+      const breadcrumbItem2 = screen.getAllByRole('listitem')[1] as HTMLElement;
+      const breadcrumbItem3 = screen.getAllByRole('listitem')[2] as HTMLElement;
 
       expect(breadcrumbItem1).toHaveStyleRule('font-weight', '500');
       expect(breadcrumbItem2).toHaveStyleRule('font-weight', '500');
       expect(breadcrumbItem3).toHaveStyleRule('font-weight', '500');
 
-      const node1 = breadcrumbItem1.firstChild as HTMLElement;
+      const node1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
       const separator1 = breadcrumbItem1.lastChild as HTMLElement;
       expect(node1).toHaveStyleRule('text-decoration', 'underline wavy');
       expect(node1).toHaveStyleRule('color', 'rgb(96,107,133)');
       expect(separator1).toHaveStyleRule('color', 'rgb(242,47,70)');
 
-      const node2 = breadcrumbItem2.firstChild as HTMLElement;
-      const separator2 = breadcrumbItem2.lastChild as HTMLElement;
+      const node2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
+      const separator2 = breadcrumbItem1.lastChild as HTMLElement;
       expect(node2).toHaveStyleRule('text-decoration', 'underline wavy');
       expect(node2).toHaveStyleRule('color', 'rgb(96,107,133)');
       expect(separator2).toHaveStyleRule('color', 'rgb(242,47,70)');
 
-      const node3 = breadcrumbItem3.firstChild as HTMLElement;
+      const node3 = screen.getByTestId('breadcrumb-item-3') as HTMLElement;
       expect(node3).toHaveStyleRule('letter-spacing', '0.25rem');
     });
 
@@ -257,25 +269,25 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByTestId('breadcrumb')).toHaveStyleRule('font-variant-numeric', 'ordinal');
 
-      const breadcrumbItem1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
-      const breadcrumbItem2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
-      const breadcrumbItem3 = screen.getByTestId('breadcrumb-item-3') as HTMLElement;
+      const breadcrumbItem1 = screen.getAllByRole('listitem')[0] as HTMLElement;
+      const breadcrumbItem2 = screen.getAllByRole('listitem')[1] as HTMLElement;
+      const breadcrumbItem3 = screen.getAllByRole('listitem')[2] as HTMLElement;
 
       expect(breadcrumbItem1).toHaveStyleRule('font-weight', '400');
       expect(breadcrumbItem2).toHaveStyleRule('font-weight', '400');
       expect(breadcrumbItem3).toHaveStyleRule('font-weight', '700');
 
-      const node1 = breadcrumbItem1.firstChild as HTMLElement;
+      const node1 = screen.getByTestId('breadcrumb-item-1') as HTMLElement;
       const separator1 = breadcrumbItem1.lastChild as HTMLElement;
       expect(node1).toHaveStyleRule('font-weight', '700');
       expect(separator1).toHaveStyleRule('color', 'rgb(96,107,133)');
 
-      const node2 = breadcrumbItem2.firstChild as HTMLElement;
+      const node2 = screen.getByTestId('breadcrumb-item-2') as HTMLElement;
       const separator2 = breadcrumbItem2.lastChild as HTMLElement;
       expect(node2).toHaveStyleRule('font-weight', '600');
       expect(separator2).toHaveStyleRule('color', 'rgb(96,107,133)');
 
-      const node3 = breadcrumbItem3.firstChild as HTMLElement;
+      const node3 = screen.getByTestId('breadcrumb-item-3') as HTMLElement;
       expect(node3).toHaveStyleRule('letter-spacing', '0.25rem');
     });
   });

--- a/packages/paste-core/components/breadcrumb/src/index.tsx
+++ b/packages/paste-core/components/breadcrumb/src/index.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
-import type {BoxElementProps} from '@twilio-paste/box';
+import type {BoxProps, BoxElementProps} from '@twilio-paste/box';
 import {Anchor} from '@twilio-paste/anchor';
-import {Text} from '@twilio-paste/text';
+import type {AnchorProps} from '@twilio-paste/anchor';
+import {Text, safelySpreadTextProps} from '@twilio-paste/text';
 import {useUIDSeed} from '@twilio-paste/uid-library';
 
 const BreadcrumbSeparator: React.FC<{element: BoxElementProps['element']}> = ({element}) => (
@@ -21,22 +22,28 @@ const BreadcrumbSeparator: React.FC<{element: BoxElementProps['element']}> = ({e
   </Text>
 );
 
-export interface BreadcrumbItemProps extends React.HTMLAttributes<HTMLLIElement> {
+type BreadcrumbItemBaseProps = Pick<BoxProps, 'element'> & {
   children: NonNullable<React.ReactNode>;
-  element?: BoxElementProps['element'];
   parentElement?: BoxElementProps['element'];
-  href?: string;
   last?: boolean;
-}
+};
+
+type BreadcrumbItemAsSpanProps = React.HTMLAttributes<HTMLSpanElement> &
+  BreadcrumbItemBaseProps & {
+    href?: never;
+  };
+
+type BreadcrumbItemAsAnchorProps = AnchorProps & BreadcrumbItemBaseProps;
+
+type BreadcrumbItemProps = BreadcrumbItemAsSpanProps | BreadcrumbItemAsAnchorProps;
 
 const DEFAULT_ELEMENT_NAME = 'BREADCRUMB';
 
-const BreadcrumbItem = React.forwardRef<HTMLAnchorElement, BreadcrumbItemProps>(
+const BreadcrumbItem = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, BreadcrumbItemProps>(
   ({children, element, parentElement, href, last, ...props}, ref) => {
     const elementName = element || parentElement || DEFAULT_ELEMENT_NAME;
     return (
       <Box
-        {...safelySpreadBoxProps(props)}
         alignItems="center"
         as="li"
         color="colorText"
@@ -46,11 +53,17 @@ const BreadcrumbItem = React.forwardRef<HTMLAnchorElement, BreadcrumbItemProps>(
         lineHeight="lineHeight20"
       >
         {href ? (
-          <Anchor element={`${elementName}_ANCHOR`} href={href} ref={ref}>
+          <Anchor
+            {...(props as Partial<BreadcrumbItemAsAnchorProps>)}
+            element={`${elementName}_ANCHOR`}
+            href={href}
+            ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+          >
             {children}
           </Anchor>
         ) : (
           <Text
+            {...safelySpreadTextProps(props)}
             aria-current="page"
             as="span"
             element={`${elementName}_TEXT`}
@@ -73,7 +86,7 @@ if (process.env.NODE_ENV === 'development') {
   BreadcrumbItem.propTypes = {
     children: PropTypes.node.isRequired,
     element: PropTypes.string,
-    href: PropTypes.string,
+    href: PropTypes.string as PropTypes.Validator<string>,
     last: PropTypes.bool,
   };
 }

--- a/packages/paste-website/src/pages/components/breadcrumb/index.mdx
+++ b/packages/paste-website/src/pages/components/breadcrumb/index.mdx
@@ -154,6 +154,22 @@ You may choose to use a page Heading as the current page in the breadcrumb.
 </Box>`}
 </LivePreview>
 
+### Breadcrumb with a router
+
+Using breadcrumb with a router is analogous to
+[using Anchor with a router](/components/anchor/#using-anchor-with-a-router), since
+our BreadcrumbItem component creates links using [Anchor](/components/anchor) under the hood.
+
+<iframe
+  src="https://codesandbox.io/embed/using-breadcrumb-with-react-router-t24en?fontsize=14&hidenavigation=1&theme=dark&initialpath=/page2"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Using BreadcrumbItem with React Router"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+---
+
 ## Considerations
 
 <DoDont>


### PR DESCRIPTION
In Breadcrumb:
- Before: props were spread onto the Box as list item element. 
- In this PR: props are spread onto either the Anchor or Text element inside of the Box list item. This was done to match the component's presentation: BreadcrumbItem looks like an Anchor, so a data-testid on BreadcrumbItem should map onto the Anchor component.

Docs site:
- Section added to the Breadcrumb docs to indicate how to use routing, which is analogous to Anchor routing. Along these same lines, there's a link to a codesandbox that uses Breadcrumb alongside React Router. Would love eyes on this codesanbox, since the one for Anchor routing has had like +11k views 👀 

Open questions
- [ ] Will this structure change break anyone's stuff? Is it a Breaking Change (right now its changeset has it be a minor change)? Will we only know this through reporting?
