### PR TITLE
fix(website): image paths

### DIFF
--- a/packages/paste-website/src/pages/introduction/for-designers/design-guidelines/index.mdx
+++ b/packages/paste-website/src/pages/introduction/for-designers/design-guidelines/index.mdx
@@ -70,9 +70,9 @@ If you want to control libraries per file, go to the “Assets” tab on a file.
 also where you can drag in components to your file. Click the book icon in the upper
 corner. From the modal, you can turn libraries on and off.
 
-![Buttons to click in Figma to open the library selector](../../../assets/images/design-guidelines/figma-open-library-modal.png)
+![Buttons to click in Figma to open the library selector](../../../../assets/images/design-guidelines/figma-open-library-modal.png)
 
-![Modal in Figma where you can select the Paste components library to link to your project](../../../assets/images/design-guidelines/figma-link-paste-libraries.png)
+![Modal in Figma where you can select the Paste components library to link to your project](../../../../assets/images/design-guidelines/figma-link-paste-libraries.png)
 
 ### Main libraries
 
@@ -102,7 +102,7 @@ When you have a theme library linked, you'll have access to:
 - Colour styles (fill and stroke for background, border, and text colors)
 - Effect styles (shadows, etc.)
 
-![Menu in Figma when you can navigate through tokens for the Default theme](../../../assets/images/design-guidelines/token-styles.png)
+![Menu in Figma when you can navigate through tokens for the Default theme](../../../../assets/images/design-guidelines/token-styles.png)
 
 You should be using components from Paste to compose your UIs whenever possible, but the text and layer styles will be helpful when you need to compose something more custom.
 


### PR DESCRIPTION
Because the design guidelines page moved in the IA updates, the image paths broke (see: https://paste.twilio.design/introduction/for-designers/design-guidelines/)

Checked all the other pages with images and their paths are still correct.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
