### PR TITLE
fix: remove duplicated onChange props from textarea example

### DIFF
--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -160,7 +160,7 @@ The textarea should include the base textarea, along with supporting elements to
 <LivePreview scope={{Label, HelpText, TextArea}} language="jsx">
   {`<>
   <Label htmlFor="message" required>Message (at least 120 characters)</Label>
-  <TextArea onChange={()=>{}} onChange={()=>{}} aria-describedby="message_help_text" id="message" name="message" required />
+  <TextArea onChange={()=>{}} aria-describedby="message_help_text" id="message" name="message" required />
   <HelpText id="message_help_text">Enter at least 120 characters</HelpText>
 </>`}
 </LivePreview>


### PR DESCRIPTION
Removed duplicated props from site documentation for TextArea component

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
