### PR TITLE
chore: only query patterns with docs

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/index.tsx
+++ b/packages/paste-website/src/components/site-wrapper/index.tsx
@@ -56,7 +56,9 @@ const pageQuery = graphql`
     }
     allPastePattern: allAirtable(
       sort: {fields: [data___Feature]}
-      filter: {data: {status: {nin: [null, "in development"]}, Component_Category: {eq: "pattern"}}}
+      filter: {
+        data: {status: {nin: [null, "in development"]}, Component_Category: {eq: "pattern"}, Documentation: {eq: true}}
+      }
     ) {
       edges {
         node {


### PR DESCRIPTION
This PR changes the graphql query for Patterns that are rendered to the sidenav on the website. Previously we were querying for all Patterns not "in development" and I added the filter "has documentation: true" so that pages will only appear on the side nav once that column is marked in the Airtable.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
