### PR TITLE
fix(website): remove link from dodont

### DIFF
--- a/packages/paste-website/src/component-examples/PrivacyPatternExamples.tsx
+++ b/packages/paste-website/src/component-examples/PrivacyPatternExamples.tsx
@@ -1,6 +1,3 @@
-import * as React from 'react';
-import {Anchor} from '@twilio-paste/anchor';
-
 export const PrivacyExample = `
 <>
   <Label htmlFor="input">Friendly name</Label>
@@ -83,7 +80,3 @@ const PrivacyPatternError = () => {
 
 render(<PrivacyPatternError />)
 `.trim();
-
-export const dontText = `Update the copy specific to a particular field as that may encourage inconsistencies across the customer experience. If the default copy doesn’t work for your use case, please ${(
-  <Anchor href="https://github.com/twilio-labs/paste/discussions">create a GitHub Discussion</Anchor>
-)} to discuss adding a new variant.`;

--- a/packages/paste-website/src/pages/patterns/privacy/index.mdx
+++ b/packages/paste-website/src/pages/patterns/privacy/index.mdx
@@ -21,7 +21,6 @@ import {
   FriendlyName,
   WithHelpText,
   WithErrorText,
-  dontText,
 } from '../../../component-examples/PrivacyPatternExamples.tsx';
 import {Button} from '@twilio-paste/button';
 
@@ -209,8 +208,11 @@ If an input containing a privacy indicator is in an error state, the error messa
       </HelpText>
     </Box>
   </Do>
-  {/* omitted the anchor to GH Discussions in the body here, is that ok? */}
-  <Dont title="Don't" body={dontText} preview={false}>
+  <Dont
+    title="Don't"
+    body="Update the copy specific to a particular field as that may encourage inconsistencies across the customer experience. If the default copy doesn’t work for your use case, please create a Github Discussion to discuss adding a new variant."
+    preview={false}
+  >
     <Box padding="space60">
       <Label htmlFor="dont-1">Friendly name</Label>
       <Input type="text" id="dont-1" aria-describedby="dont-1-ht" value="My favorite service" />


### PR DESCRIPTION
Fixes a bug that Lee found, I removed the link from the do/don't text because it won't render.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
