### PR TITLE
chore: pin changeset version. set correct pr commitsha

### DIFF
--- a/.github/workflows/on_merge_to_main.yml
+++ b/.github/workflows/on_merge_to_main.yml
@@ -113,7 +113,7 @@ jobs:
           git config --global user.name "PasteBot"
 
       - name: "Create Pull Request or Publish to npm"
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           version: yarn version
           publish: yarn release

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -358,7 +358,7 @@ jobs:
           autoAcceptChanges: "main"
           exitOnceUploaded: true
         env:
-          STORYBOOK_GITHUB_SHA: ${{ github.sha }}
+          STORYBOOK_GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
 
   cypress:
     name: Website tests


### PR DESCRIPTION
Changsets is complaining about not having a version set, after they released v1.

![image](https://user-images.githubusercontent.com/368249/153679392-e48bb780-400f-4ef0-8810-5cb491b0f55f.png)

When tracking render perf, we are currently using the wrong commit sha. So it doesn't match the commit in the PR commit history, which makes looking up the data per commit, very difficult as it's stored under a completely different sha
