### PR TITLE
chore: loosen eng lead review requirement to only core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,16 @@
-* @twilio-labs/design-system-eng-leads
+* @twilio-labs/design-system-eng
 
-# Paste core - round robin someone from the team and a lead for review
-/packages/ @twilio-labs/design-systems-eng @twilio-labs/design-system-eng-leads
+# Paste core - round robin someone from leads for review
+/packages/paste-core @twilio-labs/design-system-eng-leads
+
+# Paste customization - round robin someone from leads for review
+/packages/paste-customization @twilio-labs/design-system-eng-leads
+
+# Paste style props - round robin someone from leads for review
+/packages/paste-style-props @twilio-labs/design-system-eng-leads
+
+# Paste theme - round robin someone from leads for review
+/packages/paste-theme @twilio-labs/design-system-eng-leads
 
 # Design tokens - ensure someone from design reviews to keep in sync with Figma
 /packages/paste-design-tokens @twilio-labs/design-systems-pd @twilio-labs/design-system-eng-leads


### PR DESCRIPTION
This PR modifies the Code owner requirements such that Eng Leads, @TheSisb, @zahnster and myself, only require a review for things that are core library specific.

Rules are now:

- any file must have 2 reviews from different engineers.
- anything file in design-tokens, core, customization, style-props and theme must also have an eng lead
- icons must also have a design review
- design tokens must also have a design review