### PR TITLE
chore: enable kodiak merge queue

### DIFF
--- a/.github/opened-pr-labeler.yml
+++ b/.github/opened-pr-labeler.yml
@@ -1,0 +1,5 @@
+# https://github.com/actions/labeler
+
+# Add 'Status: Do Not Merge' label to any newly opened PR
+"Status: Do Not Merge":
+  - "**/*"

--- a/.github/workflows/on_pull_request_open.yml
+++ b/.github/workflows/on_pull_request_open.yml
@@ -1,0 +1,14 @@
+name: Opened Pull Request Labeler
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/opened-pr-labeler.yml

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,13 @@
+version = 1
+
+[merge]
+automerge_label = "🚀 merge it!"
+blocking_labels = ["Status: WIP", "Status: Do Not Merge"]
+method = ["rebase_fast_forward", "rebase", "squash"]
+
+[merge.automerge_dependencies]
+# only auto merge "minor" and "patch" version upgrades.
+# do not automerge "major" version upgrades.
+versions = ["minor", "patch"]
+usernames = ["renovate"]
+


### PR DESCRIPTION
Enable the kodiak merge queue.

Add a `🚀 merge it!` label to add a pr to the queue once you are happy with it.

Add `Status: WIP` or `Status: Do Not Merge` to block / override.

For the future, I've added a rule for dependencies via Renovate