### PR TITLE
feat(toast): add i18n props

### DIFF
--- a/.changeset/fluffy-sheep-try.md
+++ b/.changeset/fluffy-sheep-try.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/toast': patch
+'@twilio-paste/core': patch
+---
+
+[Toast] add i18n props for variants to support i18n

--- a/packages/paste-core/components/toast/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/toast/__tests__/index.spec.tsx
@@ -56,6 +56,92 @@ describe('Toast', () => {
     });
   });
 
+  describe('i18n', () => {
+    it('should have default dismiss button text', () => {
+      render(
+        <Toast variant="neutral" onDismiss={onDismissMock}>
+          This is a toast
+        </Toast>
+      );
+      const dismissButton = screen.getByRole('button', {name: 'Dismiss toast'});
+      expect(dismissButton).toBeDefined();
+    });
+
+    it('should use i18nDismissLabel for dismiss button text', () => {
+      render(
+        <Toast variant="neutral" i18nDismissLabel="Cerrar notificacion" onDismiss={onDismissMock}>
+          Esta es una notificacion
+        </Toast>
+      );
+      const dismissButton = screen.getByRole('button', {name: 'Cerrar notificacion'});
+      expect(dismissButton).toBeDefined();
+    });
+
+    it('should have default error variant icon text', () => {
+      render(<Toast variant="error">This is a toast</Toast>);
+      const iconText = screen.getByText('(error)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should have default neutral variant icon text', () => {
+      render(<Toast variant="neutral">This is a toast</Toast>);
+      const iconText = screen.getByText('(information)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should have default success variant icon text', () => {
+      render(<Toast variant="success">This is a toast</Toast>);
+      const iconText = screen.getByText('(success)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should have default warning variant icon text', () => {
+      render(<Toast variant="warning">This is a toast</Toast>);
+      const iconText = screen.getByText('(warning)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should use i18n prop for error variant icon text', () => {
+      render(
+        <Toast variant="error" i18nErrorLabel="(erreur)">
+          This is a toast
+        </Toast>
+      );
+      const iconText = screen.getByText('(erreur)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should use i18n prop for neutral variant icon text', () => {
+      render(
+        <Toast variant="neutral" i18nNeutralLabel="(informacion)">
+          This is a toast
+        </Toast>
+      );
+      const iconText = screen.getByText('(informacion)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should use i18n prop for success variant icon text', () => {
+      render(
+        <Toast variant="success" i18nSuccessLabel="(éxito)">
+          This is a toast
+        </Toast>
+      );
+      const iconText = screen.getByText('(éxito)');
+      expect(iconText).toBeDefined();
+    });
+
+    it('should use i18n prop for warning variant icon text', () => {
+      render(
+        <Toast variant="warning" i18nWarningLabel="(aviso)">
+          This is a toast
+        </Toast>
+      );
+      const iconText = screen.getByText('(aviso)');
+      expect(iconText).toBeDefined();
+    });
+  });
+
   describe('Accessibility', () => {
     it('Should have no accessibility violations', async () => {
       const {container} = render(

--- a/packages/paste-core/components/toast/src/Toast.tsx
+++ b/packages/paste-core/components/toast/src/Toast.tsx
@@ -6,6 +6,7 @@ import {NeutralIcon} from '@twilio-paste/icons/esm/NeutralIcon';
 import {SuccessIcon} from '@twilio-paste/icons/esm/SuccessIcon';
 import {WarningIcon} from '@twilio-paste/icons/esm/WarningIcon';
 import {MediaObject, MediaFigure, MediaBody} from '@twilio-paste/media-object';
+import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {ErrorToast} from './ErrorToast';
 import {NeutralToast} from './NeutralToast';
 import {SuccessToast} from './SuccessToast';
@@ -24,51 +25,34 @@ const ToastComponentVariants = {
 const renderToastIcon = (variant: ToastVariants, element?: string): React.ReactElement => {
   switch (variant) {
     case ToastVariantObject.ERROR:
-      return (
-        <ErrorIcon
-          color="colorTextIconError"
-          decorative={false}
-          element={`${element}_ICON`}
-          title="error: "
-          size="sizeIcon20"
-        />
-      );
+      return <ErrorIcon color="colorTextIconError" decorative element={`${element}_ICON`} size="sizeIcon20" />;
     case ToastVariantObject.SUCCESS:
-      return (
-        <SuccessIcon
-          color="colorTextIconSuccess"
-          decorative={false}
-          element={`${element}_ICON`}
-          title="success: "
-          size="sizeIcon20"
-        />
-      );
+      return <SuccessIcon color="colorTextIconSuccess" decorative element={`${element}_ICON`} size="sizeIcon20" />;
     case ToastVariantObject.WARNING:
-      return (
-        <WarningIcon
-          color="colorTextIconWarning"
-          decorative={false}
-          element={`${element}_ICON`}
-          title="warning: "
-          size="sizeIcon20"
-        />
-      );
+      return <WarningIcon color="colorTextIconWarning" decorative element={`${element}_ICON`} size="sizeIcon20" />;
     case ToastVariantObject.NEUTRAL:
     default:
-      return (
-        <NeutralIcon
-          color="colorTextIconNeutral"
-          decorative={false}
-          element={`${element}_ICON`}
-          title="information: "
-          size="sizeIcon20"
-        />
-      );
+      return <NeutralIcon color="colorTextIconNeutral" decorative element={`${element}_ICON`} size="sizeIcon20" />;
   }
 };
 
 const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
-  ({children, onDismiss, variant = 'neutral', element = 'TOAST', setFocus, ...props}, ref) => {
+  (
+    {
+      children,
+      onDismiss,
+      variant = 'neutral',
+      element = 'TOAST',
+      setFocus,
+      i18nDismissLabel = 'Dismiss toast',
+      i18nErrorLabel = '(error)',
+      i18nNeutralLabel = '(information)',
+      i18nSuccessLabel = '(success)',
+      i18nWarningLabel = '(warning)',
+      ...props
+    },
+    ref
+  ) => {
     const ToastComponent = ToastComponentVariants[variant];
     const buttonRef: React.RefObject<HTMLButtonElement> = React.useRef(null);
 
@@ -78,11 +62,20 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       }
     }, [setFocus]);
 
+    // uses variant to return the correct i18n label prop for that variant
+    const i18nVariants = {
+      error: i18nErrorLabel,
+      neutral: i18nNeutralLabel,
+      success: i18nSuccessLabel,
+      warning: i18nWarningLabel,
+    };
+
     return (
       <ToastComponent role="status" variant={variant} element={element} ref={ref} {...props}>
         <MediaObject as="div">
           <MediaFigure as="div" spacing="space60">
             {renderToastIcon(variant, element)}
+            <ScreenReaderOnly>{i18nVariants[variant]}</ScreenReaderOnly>
           </MediaFigure>
           <MediaBody as="div">{children}</MediaBody>
           {onDismiss && typeof onDismiss === 'function' && (
@@ -94,13 +87,8 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                 size="reset"
                 element={`${element}_CLOSE_BUTTON`}
               >
-                <CloseIcon
-                  color="colorTextIcon"
-                  decorative={false}
-                  title="Dismiss toast"
-                  size="sizeIcon20"
-                  element={`${element}_CLOSE_ICON`}
-                />
+                <CloseIcon color="colorTextIcon" decorative size="sizeIcon20" element={`${element}_CLOSE_ICON`} />
+                <ScreenReaderOnly>{i18nDismissLabel}</ScreenReaderOnly>
               </Button>
             </MediaFigure>
           )}

--- a/packages/paste-core/components/toast/src/propTypes.ts
+++ b/packages/paste-core/components/toast/src/propTypes.ts
@@ -6,6 +6,11 @@ export const ToastPropTypes = {
   onDismiss: PropTypes.func,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variant: PropTypes.oneOf(['error', 'neutral', 'success', 'warning']) as any,
+  i18nDismissLabel: PropTypes.string,
+  i18nErrorLabel: PropTypes.string,
+  i18nNeutralLabel: PropTypes.string,
+  i18nSuccessLabel: PropTypes.string,
+  i18nWarningLabel: PropTypes.string,
 };
 
 export const ToastPortalPropTypes = {

--- a/packages/paste-core/components/toast/src/types.ts
+++ b/packages/paste-core/components/toast/src/types.ts
@@ -18,6 +18,26 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement>, Pick<B
    * Use this to set focus within the toast when it is rendered
    */
   setFocus?: boolean;
+  /**
+   * Label for the dismiss button in a dismissable toast
+   */
+  i18nDismissLabel?: string;
+  /**
+   * Icon label text for the error variant
+   */
+  i18nErrorLabel?: string;
+  /**
+   * Icon label text for the neutral variant
+   */
+  i18nNeutralLabel?: string;
+  /**
+   * Icon label text for the success variant
+   */
+  i18nSuccessLabel?: string;
+  /**
+   * Icon label text for the warning variant
+   */
+  i18nWarningLabel?: string;
 }
 
 export interface ToastPortalProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/paste-core/components/toast/stories/index.stories.tsx
+++ b/packages/paste-core/components/toast/stories/index.stories.tsx
@@ -177,6 +177,57 @@ export const Warning = (): React.ReactNode => {
   );
 };
 
+export const I18n = (): React.ReactNode => {
+  return (
+    <Box minHeight="size90">
+      <ToastContainer>
+        <Toast variant="neutral" i18nDismissLabel="Cerrar notificacion" i18nNeutralLabel="(informacion)">
+          <Text as="div">Soy una notificacion</Text>
+        </Toast>
+        <Toast
+          variant="neutral"
+          onDismiss={action('dismiss')}
+          i18nDismissLabel="Cerrar notificacion"
+          i18nNeutralLabel="(informacion)"
+        >
+          <Text as="div">
+            <strong>Título</strong> Soy una notificacion
+          </Text>
+        </Toast>
+        <Toast variant="neutral" i18nDismissLabel="Cerrar notificacion" i18nNeutralLabel="(informacion)">
+          <Text as="div">
+            Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Praesent
+            commodo cursus magna.
+          </Text>
+        </Toast>
+        <Toast
+          variant="neutral"
+          onDismiss={action('dismiss')}
+          i18nDismissLabel="Cerrar notificacion"
+          i18nNeutralLabel="(informacion)"
+        >
+          <Text as="div">
+            Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Praesent
+            commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat
+            porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla
+            vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem
+            malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec
+            ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.
+          </Text>
+          <Text as="p">
+            <Truncate title="http://www.extremelylongurlthatmightbreakthelayout.com">
+              http://www.extremelylongurlthatmightbreakthelayout.com
+            </Truncate>
+          </Text>
+        </Toast>
+      </ToastContainer>
+    </Box>
+  );
+};
+
+I18n.storyName = 'i18n Prop';
+
 interface ToastContainerExample {
   variant: ToastVariants;
   message: string;

--- a/packages/paste-website/src/component-examples/ToastExamples.tsx
+++ b/packages/paste-website/src/component-examples/ToastExamples.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {useUID} from '@twilio-paste/uid-library';
-import {Toaster, useToaster, ToastVariants} from '@twilio-paste/toast';
+import {Toaster, useToaster} from '@twilio-paste/toast';
+import type {ToastVariants} from '@twilio-paste/toast';
 import {Button} from '@twilio-paste/button';
 import {Stack} from '@twilio-paste/stack';
 import {Input} from '@twilio-paste/input';
@@ -83,3 +84,15 @@ export const ToasterExample: React.FC = () => {
     </div>
   );
 };
+
+export const i18nExample = `
+const I18nExample = () => {
+  return (
+    <Toast variant="neutral" i18nDismissLabel="Cerrar notificacion" i18nNeutralLabel="(informacion)">
+      <Text as="div">Soy una notificacion</Text>
+    </Toast>
+  );
+};
+
+render(<I18nExample />);
+`;

--- a/packages/paste-website/src/pages/components/toast/index.mdx
+++ b/packages/paste-website/src/pages/components/toast/index.mdx
@@ -24,7 +24,7 @@ import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
 import {Codeblock} from '../../../components/codeblock';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {InlineCode} from '../../../components/Typography';
-import {ToasterExample} from '../../../component-examples/ToastExamples';
+import {ToasterExample, i18nExample} from '../../../component-examples/ToastExamples';
 import Changelog from '@twilio-paste/toast/CHANGELOG.md';
 
 export const pageQuery = graphql`
@@ -332,6 +332,24 @@ Be cautious when using an error alert because they can be stressful for a user t
 </Toast>`}
 </LivePreview>
 
+### Internationalization
+
+To internationalize a toast, simply pass different text as children to the toast.
+The only exceptions to this are the labels for both the dismiss button and the variant icons.
+To change the dismiss button&apos;s label text, use the `i18nDismissLabel` prop.
+To change the label of a variant's icon, use the matching i18n prop for the variant.
+For a `success` variant, for example, set the `i18nSuccessLabel` prop.
+
+<LivePreview
+  scope={{
+    Toast,
+    Text,
+  }}
+  noInline
+>
+  {i18nExample}
+</LivePreview>
+
 ## Composition Notes
 
 Keep toast text brief and scannable by placing only the highest priority information in it. Too much text in a toast can overwhelm a user. Aim for no more than 140 characters in a toast, and keep the text directly related to the user's current action. Success toasts generally run about 50 characters long, while all other alerts might run about 100 characters long. However, don't [sacrifice being direct and straightforward](/foundations/content/product-style-guide#be-direct-and-straightforward) for a shorter message.
@@ -457,11 +475,16 @@ If you choose to handle state entirely yourself, you can use `<Toaster />` on it
 
 #### Toast Props
 
-| Prop       | Type         | Description                                                 | Default |
-| ---------- | ------------ | ----------------------------------------------------------- | ------- |
-| children   | `ReactNode`  |                                                             | null    |
-| onDismiss? | `() => void` | Create dismissable toast by providing an onDismiss callback | null    |
-| variant    | `string`     | `error` / `neutral` / `sucess` / `warning`                  | null    |
+| Prop             | Type         | Description                                                 | Default         |
+| ---------------- | ------------ | ----------------------------------------------------------- | --------------- |
+| children         | `ReactNode`  |                                                             | null            |
+| onDismiss?       | `() => void` | Create dismissable toast by providing an onDismiss callback | null            |
+| variant          | `string`     | `error` / `neutral` / `sucess` / `warning`                  | null            |
+| i18nDismissLabel | `string`     | Label for the dismiss button in a dismissable toast         | 'Dismiss toast' |
+| i18nErrorLabel   | `string`     | Icon label text for the `error` variant                     | '(error)'       |
+| i18nNeutralLabel | `string`     | Icon label text for the `neutral` variant                   | '(information)' |
+| i18nSuccessLabel | `string`     | Icon label text for the `success` variant                   | '(success)'     |
+| i18nWarningLabel | `string`     | Icon label text for the `warning` variant                   | '(warning)'     |
 
 #### useToaster return state
 


### PR DESCRIPTION
- [x]  add `i18nDismissLabel` prop for dismiss button
- [x]  add `i18nErrorLabel`, `i18nNeutralLabel`, `i18nSuccessLabel`, `i18nWarningLabel` props for icons of variants
- [x]  add i18n story
- [x]  add tests for default and custom i18n props
- [x]  add example to website
- [x]  add prop to Popover prop list on website