### PR TITLE
feat(Data Grid): add i18n props

### DIFF
--- a/.changeset/chilly-insects-smell.md
+++ b/.changeset/chilly-insects-smell.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/toast': patch
+'@twilio-paste/core': patch
+---
+
+[Toast] use title for i18n status labels

--- a/.changeset/hungry-clocks-count.md
+++ b/.changeset/hungry-clocks-count.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/alert': patch
+'@twilio-paste/core': patch
+---
+
+[Alert] use title for i18n status labels

--- a/.changeset/itchy-lions-switch.md
+++ b/.changeset/itchy-lions-switch.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/data-grid': patch
+'@twilio-paste/core': patch
+---
+
+[Data Grid] add i18n props to support i18n

--- a/packages/paste-core/components/alert/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert/__tests__/index.spec.tsx
@@ -238,7 +238,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(error)');
+      expect(icon?.textContent).toEqual('(error)');
     });
 
     it('should have default neutral variant icon text', () => {
@@ -249,7 +249,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(information)');
+      expect(icon?.textContent).toEqual('(information)');
     });
 
     it('should have default warning variant icon text', () => {
@@ -260,7 +260,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(warning)');
+      expect(icon?.textContent).toEqual('(warning)');
     });
 
     it('should use the i18nErrorLabel for error variant icon text', () => {
@@ -271,7 +271,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(erreur)');
+      expect(icon?.textContent).toEqual('(erreur)');
     });
 
     it('should use the i18nNeutralLabel for neutral variant icon text', () => {
@@ -282,7 +282,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(information)');
+      expect(icon?.textContent).toEqual('(information)');
     });
 
     it('should use the i18nWarningLabel for warning variant icon text', () => {
@@ -293,7 +293,7 @@ describe('Alert', () => {
       );
       const alert = screen.getByTestId('alert-i18n');
       const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
-      expect(icon.textContent).toEqual('(avertissement)');
+      expect(icon?.textContent).toEqual('(avertissement)');
     });
   });
 });

--- a/packages/paste-core/components/alert/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert/__tests__/index.spec.tsx
@@ -231,51 +231,69 @@ describe('Alert', () => {
     });
 
     it('should have default error variant icon text', () => {
-      render(<Alert variant="error">This is an alert</Alert>);
-      const iconText = screen.getByText('(error)');
-      expect(iconText).toBeDefined();
+      render(
+        <Alert data-testid="alert-i18n" variant="error">
+          This is an alert
+        </Alert>
+      );
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(error)');
     });
 
     it('should have default neutral variant icon text', () => {
-      render(<Alert variant="neutral">This is an alert</Alert>);
-      const iconText = screen.getByText('(information)');
-      expect(iconText).toBeDefined();
+      render(
+        <Alert data-testid="alert-i18n" variant="neutral">
+          This is an alert
+        </Alert>
+      );
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(information)');
     });
 
     it('should have default warning variant icon text', () => {
-      render(<Alert variant="warning">This is an alert</Alert>);
-      const iconText = screen.getByText('(warning)');
-      expect(iconText).toBeDefined();
+      render(
+        <Alert data-testid="alert-i18n" variant="warning">
+          This is an alert
+        </Alert>
+      );
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(warning)');
     });
 
     it('should use the i18nErrorLabel for error variant icon text', () => {
       render(
-        <Alert variant="error" i18nErrorLabel="(erreur)">
+        <Alert data-testid="alert-i18n" variant="error" i18nErrorLabel="(erreur)">
           C&apos;est une alerte.
         </Alert>
       );
-      const iconText = screen.getByText('(erreur)');
-      expect(iconText).toBeDefined();
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(erreur)');
     });
 
     it('should use the i18nNeutralLabel for neutral variant icon text', () => {
       render(
-        <Alert variant="neutral" i18nNeutralLabel="(information)">
+        <Alert data-testid="alert-i18n" variant="neutral" i18nNeutralLabel="(information)">
           C&apos;est une alerte.
         </Alert>
       );
-      const iconText = screen.getByText('(information)');
-      expect(iconText).toBeDefined();
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(information)');
     });
 
     it('should use the i18nWarningLabel for warning variant icon text', () => {
       render(
-        <Alert variant="warning" i18nWarningLabel="(avertissement)">
+        <Alert data-testid="alert-i18n" variant="warning" i18nWarningLabel="(avertissement)">
           C&apos;est une alerte.
         </Alert>
       );
-      const iconText = screen.getByText('(avertissement)');
-      expect(iconText).toBeDefined();
+      const alert = screen.getByTestId('alert-i18n');
+      const icon = alert.querySelector('[data-paste-element="ALERT_ICON"]');
+      expect(icon.textContent).toEqual('(avertissement)');
     });
   });
 });

--- a/packages/paste-core/components/alert/src/index.tsx
+++ b/packages/paste-core/components/alert/src/index.tsx
@@ -56,15 +56,39 @@ export interface AlertProps extends Pick<BoxProps, 'element'> {
   i18nWarningLabel?: string;
 }
 
-const renderAlertIcon = (variant: AlertVariants, element: string): React.ReactElement => {
+const renderAlertIcon = (variant: AlertVariants, element: string, title: string): React.ReactElement => {
   switch (variant) {
     case AlertVariants.ERROR:
-      return <ErrorIcon element={`${element}_ICON`} color="colorTextIconError" decorative size="sizeIcon20" />;
+      return (
+        <ErrorIcon
+          element={`${element}_ICON`}
+          color="colorTextIconError"
+          decorative={false}
+          title={title}
+          size="sizeIcon20"
+        />
+      );
     case AlertVariants.WARNING:
-      return <WarningIcon element={`${element}_ICON`} color="colorTextIconWarning" decorative size="sizeIcon20" />;
+      return (
+        <WarningIcon
+          element={`${element}_ICON`}
+          color="colorTextIconWarning"
+          decorative={false}
+          title={title}
+          size="sizeIcon20"
+        />
+      );
     case AlertVariants.NEUTRAL:
     default:
-      return <NeutralIcon element={`${element}_ICON`} color="colorTextIconNeutral" decorative size="sizeIcon20" />;
+      return (
+        <NeutralIcon
+          element={`${element}_ICON`}
+          color="colorTextIconNeutral"
+          decorative={false}
+          title={title}
+          size="sizeIcon20"
+        />
+      );
   }
 };
 
@@ -108,8 +132,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       >
         <MediaObject as="div">
           <MediaFigure as="div" spacing="space30">
-            {renderAlertIcon(variant, element)}
-            <ScreenReaderOnly>{i18nLabelVariantMap[variant]}</ScreenReaderOnly>
+            {renderAlertIcon(variant, element, i18nLabelVariantMap[variant])}
           </MediaFigure>
           <MediaBody as="div">{children}</MediaBody>
           {onDismiss && typeof onDismiss === 'function' && (

--- a/packages/paste-core/components/data-grid/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/data-grid/__tests__/index.spec.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import {Button} from '@twilio-paste/button';
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // @ts-ignore typescript doesn't like js imports
 import axe from '../../../../../.jest/axe-helper';
 
+import {DataGridHeaderSort} from '../src';
 import {ComposableCellsDataGrid} from '../stories/components/ComposableCellsDataGrid';
 import {SortableColumnsDataGrid} from '../stories/components/SortableColumnsDataGrid';
 import {PaginatedDataGrid} from '../stories/components/PaginatedDataGrid';
@@ -228,6 +229,46 @@ describe('Data Grid', () => {
       // Because it is in a table, we don't need labels
       const results = await axe(container, {rules: {label: {enabled: false}}});
       expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+describe('i18n', () => {
+  describe('DataGridHeaderSort', () => {
+    it('should have default ascending label', () => {
+      render(<DataGridHeaderSort direction="ascending" />);
+      const button = screen.getByRole('button', {name: 'Sort ascending'});
+      expect(button).toBeDefined();
+    });
+
+    it('should have default descending label', () => {
+      render(<DataGridHeaderSort direction="descending" />);
+      const button = screen.getByRole('button', {name: 'Sort descending'});
+      expect(button).toBeDefined();
+    });
+
+    it('should have default unsorted label', () => {
+      render(<DataGridHeaderSort direction="none" />);
+      const button = screen.getByRole('button', {name: 'Unsorted'});
+      expect(button).toBeDefined();
+    });
+
+    it('should use i18nAscendingLabel for the ascending label', () => {
+      render(<DataGridHeaderSort direction="ascending" i18nAscendingLabel="Tri croissant" />);
+      const button = screen.getByRole('button', {name: 'Tri croissant'});
+      expect(button).toBeDefined();
+    });
+
+    it('should use i18nDescendingLabel for the descending label', () => {
+      render(<DataGridHeaderSort direction="descending" i18nDescendingLabel="Tri décroissant" />);
+      const button = screen.getByRole('button', {name: 'Tri décroissant'});
+      expect(button).toBeDefined();
+    });
+
+    it('should use i18nUnsortedLabel for the unsorted label', () => {
+      render(<DataGridHeaderSort direction="none" i18nUnsortedLabel="Non triés" />);
+      const button = screen.getByRole('button', {name: 'Non triés'});
+      expect(button).toBeDefined();
     });
   });
 });

--- a/packages/paste-core/components/data-grid/src/DataGridHeaderSort.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridHeaderSort.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import type {BoxProps} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
+import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {ArrowDownIcon} from '@twilio-paste/icons/esm/ArrowDownIcon';
 import {ArrowUpIcon} from '@twilio-paste/icons/esm/ArrowUpIcon';
 import {UnsortedIcon} from '@twilio-paste/icons/esm/UnsortedIcon';
@@ -11,16 +12,19 @@ export type SortDirection = 'ascending' | 'descending' | 'none';
 interface DataGridHeaderSortIconProps {
   direction: SortDirection;
   element?: BoxProps['element'];
+  i18nAscendingLabel?: string;
+  i18nDescendingLabel?: string;
+  i18nUnsortedLabel?: string;
 }
 
 const DataGridHeaderSortIcon: React.FC<DataGridHeaderSortIconProps> = ({direction, element}) => {
   switch (direction) {
     case 'ascending':
-      return <ArrowUpIcon decorative={false} element={element} title="Sort ascending" />;
+      return <ArrowUpIcon decorative element={element} />;
     case 'descending':
-      return <ArrowDownIcon decorative={false} element={element} title="Sort descending" />;
+      return <ArrowDownIcon decorative element={element} />;
     case 'none':
-      return <UnsortedIcon decorative={false} element={element} title="Unsorted" />;
+      return <UnsortedIcon decorative element={element} />;
     default:
       return null;
   }
@@ -41,12 +45,22 @@ export const DataGridHeaderSort: React.FC<DataGridHeaderSortProps> = ({
   direction,
   onClick,
   element = 'DATA_GRID_HEADER_SORT',
+  i18nAscendingLabel = 'Sort ascending',
+  i18nDescendingLabel = 'Sort descending',
+  i18nUnsortedLabel = 'Unsorted',
   ...props
 }) => {
+  const i18nLabelDirectionMap = {
+    ascending: i18nAscendingLabel,
+    descending: i18nDescendingLabel,
+    none: i18nUnsortedLabel,
+  };
+
   return (
     // @ts-ignore fixme when button accepts element
     <Button element={element} variant="reset" size="reset" onClick={onClick} {...props}>
       <DataGridHeaderSortIcon element={`${element}_ICON`} direction={direction} />
+      <ScreenReaderOnly>{i18nLabelDirectionMap[direction]}</ScreenReaderOnly>
     </Button>
   );
 };

--- a/packages/paste-core/components/data-grid/src/DataGridHeaderSort.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridHeaderSort.tsx
@@ -57,7 +57,6 @@ export const DataGridHeaderSort: React.FC<DataGridHeaderSortProps> = ({
   };
 
   return (
-    // @ts-ignore fixme when button accepts element
     <Button element={element} variant="reset" size="reset" onClick={onClick} {...props}>
       <DataGridHeaderSortIcon element={`${element}_ICON`} direction={direction} />
       <ScreenReaderOnly>{i18nLabelDirectionMap[direction]}</ScreenReaderOnly>

--- a/packages/paste-core/components/data-grid/stories/components/I18nDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/I18nDataGrid.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {
+  DataGrid,
+  DataGridHead,
+  DataGridRow,
+  DataGridHeader,
+  DataGridHeaderSort,
+  DataGridBody,
+  DataGridCell,
+} from '../../src';
+import type {SortDirection} from '../../src';
+import {I18nTableHeaderData, I18nTableBodyData} from './constants';
+
+// Sorting function
+const simpleComparator = (a: string[], b: string[], ascending: boolean, columnId: number): number => {
+  if (a[columnId] === b[columnId]) {
+    return 0;
+  }
+  if (a[columnId] > b[columnId]) {
+    return ascending ? 1 : -1;
+  }
+  return ascending ? -1 : 1;
+};
+
+const numColumns = I18nTableHeaderData.length;
+const initialHeaderData = [...new Array(numColumns)].map((_, index) => (index === 0 ? 'ascending' : 'none'));
+const initialBodyData = I18nTableBodyData.sort((a, b) => simpleComparator(a, b, true, 0));
+
+export const I18nDataGrid = (): React.ReactNode => {
+  const [sortedColumns, setSortedColumns] = React.useState<Array<SortDirection>>(initialHeaderData);
+  const [sortedData, setSortedData] = React.useState(initialBodyData);
+
+  // Handle sorting behavior
+  const handleSortingColumn = (columnId: number): void => {
+    // Update the state of the sort direction in column headers
+    const newSortedColumns: Array<SortDirection> = sortedColumns.map(() => 'none');
+    if (sortedColumns[columnId] === 'ascending') {
+      newSortedColumns[columnId] = 'descending';
+    } else {
+      newSortedColumns[columnId] = 'ascending';
+    }
+    setSortedColumns(newSortedColumns);
+
+    // Update the table data to be sorted correctly
+    setSortedData(
+      I18nTableBodyData.sort((a, b) => simpleComparator(a, b, newSortedColumns[columnId] === 'ascending', columnId))
+    );
+  };
+
+  /* eslint-disable react/no-array-index-key */
+  return (
+    <DataGrid aria-label="User information table" striped>
+      <DataGridHead>
+        <DataGridRow>
+          <DataGridHeader aria-sort={sortedColumns[0]} data-testid="header">
+            <Box display="flex" alignItems="center" columnGap="space20">
+              {I18nTableHeaderData[0]}
+              <DataGridHeaderSort
+                direction={sortedColumns[0]}
+                onClick={() => handleSortingColumn(0)}
+                data-testid="header-sort"
+              />
+            </Box>
+          </DataGridHeader>
+          <DataGridHeader aria-sort={sortedColumns[1]}>
+            <Box display="flex" alignItems="center" columnGap="space20">
+              {I18nTableHeaderData[1]}
+              <DataGridHeaderSort direction={sortedColumns[1]} onClick={() => handleSortingColumn(1)} />
+            </Box>
+          </DataGridHeader>
+          <DataGridHeader aria-sort={sortedColumns[2]}>
+            <Box display="flex" alignItems="center" columnGap="space20">
+              {I18nTableHeaderData[2]}
+              <DataGridHeaderSort direction={sortedColumns[2]} onClick={() => handleSortingColumn(2)} />
+            </Box>
+          </DataGridHeader>
+          <DataGridHeader aria-sort={sortedColumns[3]}>
+            <Box display="flex" alignItems="center" columnGap="space20">
+              {I18nTableHeaderData[3]}
+              <DataGridHeaderSort direction={sortedColumns[3]} onClick={() => handleSortingColumn(3)} />
+            </Box>
+          </DataGridHeader>
+          <DataGridHeader aria-sort={sortedColumns[4]}>
+            <Box display="flex" alignItems="center" columnGap="space20">
+              {I18nTableHeaderData[4]}
+              <DataGridHeaderSort direction={sortedColumns[4]} onClick={() => handleSortingColumn(4)} />
+            </Box>
+          </DataGridHeader>
+        </DataGridRow>
+      </DataGridHead>
+      <DataGridBody>
+        {sortedData.map((row) => (
+          <DataGridRow key={`${row[0]}-${row[1]}`}>
+            {row.map((col, colIndex) => (
+              <DataGridCell key={`${col}-${colIndex}`}>{col}</DataGridCell>
+            ))}
+          </DataGridRow>
+        ))}
+      </DataGridBody>
+    </DataGrid>
+  );
+  /* eslint-enable react/no-array-index-key */
+};
+
+I18nDataGrid.storyName = 'i18n Data Grid';

--- a/packages/paste-core/components/data-grid/stories/components/constants.ts
+++ b/packages/paste-core/components/data-grid/stories/components/constants.ts
@@ -18,6 +18,27 @@ export const TableBodyData = [
   ['Fritz', 'Bashirian', 'France', 'Magali.Harber@hotmail.com', '1-229-278-7567'],
 ];
 
+export const I18nTableHeaderData = ['Prénom', 'Nom de famille', 'Pays', 'Email', 'N º de téléphone'];
+
+export const I18nTableBodyData = [
+  ['Lottie', 'Hintz', 'Corée du Sud', 'John.Zulauf@gmail.com', '1-652-451-4330'],
+  [
+    'Paige',
+    'Kshlerin',
+    "Territoire britannique de l'océan Indien (Îles Chagos)",
+    'Natalie.Klein@yahoo.com',
+    '668.667.3238 x27714',
+  ],
+  ['Kadin', 'Will', 'Haïti', 'Ora_Bartoletti@yahoo.com', '446.666.1937 x759'],
+  ['Troy', 'McDermott', 'Qatar', 'Richmond34@hotmail.com', '(209) 774-9227 x5109'],
+  ['Devyn', 'Weimann', 'République démocratique du Congo', 'Matilde86@gmail.com', '652-441-1766 x377'],
+  ['Triston', 'Dickinson', 'Terres australes françaises', 'Violette.Kihn97@yahoo.com', '939.571.3994'],
+  ['Maeve', 'West', 'Norvège', 'Mittie80@yahoo.com', '395.983.4598 x8023'],
+  ['Tracey', 'Farrell', 'Macao', 'Barrett72@yahoo.com', '1-805-781-6325'],
+  ['Jovanny', 'Mante', 'Îles Pitcairn', 'Fausto_Vandervort15@gmail.com', '(629) 375-5743 x726'],
+  ['Fritz', 'Bashirian', 'France', 'Magali.Harber@hotmail.com', '1-229-278-7567'],
+];
+
 export const PaginatedTableBodyData = [
   ['Dana', 'Purdy', 'Kyrgyz Republic', 'Summer_Schulist82@gmail.com', '1-509-540-5248 x5237'],
   ['Newton', 'Smith', 'Ireland', 'Julianne52@hotmail.com', '482.997.2560'],

--- a/packages/paste-core/components/data-grid/stories/index.stories.tsx
+++ b/packages/paste-core/components/data-grid/stories/index.stories.tsx
@@ -5,6 +5,7 @@ export {SelectableRowsDataGrid} from './components/SelectableRowsDataGrid';
 export {PaginatedDataGrid} from './components/PaginatedDataGrid';
 export {SortableColumnsDataGrid} from './components/SortableColumnsDataGrid';
 export {KitchenSinkDataGrid} from './components/KitchenSinkDataGrid';
+export {I18nDataGrid} from './components/I18nDataGrid';
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/packages/paste-core/components/toast/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/toast/__tests__/index.spec.tsx
@@ -78,67 +78,92 @@ describe('Toast', () => {
     });
 
     it('should have default error variant icon text', () => {
-      render(<Toast variant="error">This is a toast</Toast>);
-      const iconText = screen.getByText('(error)');
-      expect(iconText).toBeDefined();
+      render(
+        <Toast data-testid="toast-i18n" variant="error">
+          This is a toast
+        </Toast>
+      );
+
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(error)');
     });
 
     it('should have default neutral variant icon text', () => {
-      render(<Toast variant="neutral">This is a toast</Toast>);
-      const iconText = screen.getByText('(information)');
-      expect(iconText).toBeDefined();
+      render(
+        <Toast data-testid="toast-i18n" variant="neutral">
+          This is a toast
+        </Toast>
+      );
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(information)');
     });
 
     it('should have default success variant icon text', () => {
-      render(<Toast variant="success">This is a toast</Toast>);
-      const iconText = screen.getByText('(success)');
-      expect(iconText).toBeDefined();
+      render(
+        <Toast data-testid="toast-i18n" variant="success">
+          This is a toast
+        </Toast>
+      );
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(success)');
     });
 
     it('should have default warning variant icon text', () => {
-      render(<Toast variant="warning">This is a toast</Toast>);
-      const iconText = screen.getByText('(warning)');
-      expect(iconText).toBeDefined();
+      render(
+        <Toast data-testid="toast-i18n" variant="warning">
+          This is a toast
+        </Toast>
+      );
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(warning)');
     });
 
     it('should use i18n prop for error variant icon text', () => {
       render(
-        <Toast variant="error" i18nErrorLabel="(erreur)">
+        <Toast data-testid="toast-i18n" variant="error" i18nErrorLabel="(erreur)">
           This is a toast
         </Toast>
       );
-      const iconText = screen.getByText('(erreur)');
-      expect(iconText).toBeDefined();
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(erreur)');
     });
 
     it('should use i18n prop for neutral variant icon text', () => {
       render(
-        <Toast variant="neutral" i18nNeutralLabel="(informacion)">
+        <Toast data-testid="toast-i18n" variant="neutral" i18nNeutralLabel="(informacion)">
           This is a toast
         </Toast>
       );
-      const iconText = screen.getByText('(informacion)');
-      expect(iconText).toBeDefined();
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(informacion)');
     });
 
     it('should use i18n prop for success variant icon text', () => {
       render(
-        <Toast variant="success" i18nSuccessLabel="(éxito)">
+        <Toast data-testid="toast-i18n" variant="success" i18nSuccessLabel="(éxito)">
           This is a toast
         </Toast>
       );
-      const iconText = screen.getByText('(éxito)');
-      expect(iconText).toBeDefined();
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(éxito)');
     });
 
     it('should use i18n prop for warning variant icon text', () => {
       render(
-        <Toast variant="warning" i18nWarningLabel="(aviso)">
+        <Toast data-testid="toast-i18n" variant="warning" i18nWarningLabel="(aviso)">
           This is a toast
         </Toast>
       );
-      const iconText = screen.getByText('(aviso)');
-      expect(iconText).toBeDefined();
+      const toast = screen.getByTestId('toast-i18n');
+      const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
+      expect(icon.textContent).toEqual('(aviso)');
     });
   });
 

--- a/packages/paste-core/components/toast/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/toast/__tests__/index.spec.tsx
@@ -86,7 +86,7 @@ describe('Toast', () => {
 
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(error)');
+      expect(icon?.textContent).toEqual('(error)');
     });
 
     it('should have default neutral variant icon text', () => {
@@ -97,7 +97,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(information)');
+      expect(icon?.textContent).toEqual('(information)');
     });
 
     it('should have default success variant icon text', () => {
@@ -108,7 +108,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(success)');
+      expect(icon?.textContent).toEqual('(success)');
     });
 
     it('should have default warning variant icon text', () => {
@@ -119,7 +119,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(warning)');
+      expect(icon?.textContent).toEqual('(warning)');
     });
 
     it('should use i18n prop for error variant icon text', () => {
@@ -130,7 +130,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(erreur)');
+      expect(icon?.textContent).toEqual('(erreur)');
     });
 
     it('should use i18n prop for neutral variant icon text', () => {
@@ -141,7 +141,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(informacion)');
+      expect(icon?.textContent).toEqual('(informacion)');
     });
 
     it('should use i18n prop for success variant icon text', () => {
@@ -152,7 +152,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(éxito)');
+      expect(icon?.textContent).toEqual('(éxito)');
     });
 
     it('should use i18n prop for warning variant icon text', () => {
@@ -163,7 +163,7 @@ describe('Toast', () => {
       );
       const toast = screen.getByTestId('toast-i18n');
       const icon = toast.querySelector('[data-paste-element="TOAST_ICON"]');
-      expect(icon.textContent).toEqual('(aviso)');
+      expect(icon?.textContent).toEqual('(aviso)');
     });
   });
 

--- a/packages/paste-core/components/toast/src/Toast.tsx
+++ b/packages/paste-core/components/toast/src/Toast.tsx
@@ -22,17 +22,49 @@ const ToastComponentVariants = {
   warning: WarningToast,
 };
 
-const renderToastIcon = (variant: ToastVariants, element?: string): React.ReactElement => {
+const renderToastIcon = (variant: ToastVariants, title: string, element?: string): React.ReactElement => {
   switch (variant) {
     case ToastVariantObject.ERROR:
-      return <ErrorIcon color="colorTextIconError" decorative element={`${element}_ICON`} size="sizeIcon20" />;
+      return (
+        <ErrorIcon
+          color="colorTextIconError"
+          decorative={false}
+          title={title}
+          element={`${element}_ICON`}
+          size="sizeIcon20"
+        />
+      );
     case ToastVariantObject.SUCCESS:
-      return <SuccessIcon color="colorTextIconSuccess" decorative element={`${element}_ICON`} size="sizeIcon20" />;
+      return (
+        <SuccessIcon
+          color="colorTextIconSuccess"
+          decorative={false}
+          title={title}
+          element={`${element}_ICON`}
+          size="sizeIcon20"
+        />
+      );
     case ToastVariantObject.WARNING:
-      return <WarningIcon color="colorTextIconWarning" decorative element={`${element}_ICON`} size="sizeIcon20" />;
+      return (
+        <WarningIcon
+          color="colorTextIconWarning"
+          decorative={false}
+          title={title}
+          element={`${element}_ICON`}
+          size="sizeIcon20"
+        />
+      );
     case ToastVariantObject.NEUTRAL:
     default:
-      return <NeutralIcon color="colorTextIconNeutral" decorative element={`${element}_ICON`} size="sizeIcon20" />;
+      return (
+        <NeutralIcon
+          color="colorTextIconNeutral"
+          decorative={false}
+          title={title}
+          element={`${element}_ICON`}
+          size="sizeIcon20"
+        />
+      );
   }
 };
 
@@ -74,8 +106,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       <ToastComponent role="status" variant={variant} element={element} ref={ref} {...props}>
         <MediaObject as="div">
           <MediaFigure as="div" spacing="space60">
-            {renderToastIcon(variant, element)}
-            <ScreenReaderOnly>{i18nVariants[variant]}</ScreenReaderOnly>
+            {renderToastIcon(variant, i18nVariants[variant], element)}
           </MediaFigure>
           <MediaBody as="div">{children}</MediaBody>
           {onDismiss && typeof onDismiss === 'function' && (

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -223,6 +223,21 @@ This example combines all the separate features displayed previously into one ex
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
+### Internationalization
+
+To internationalize an data grid, simply pass different text as children to the data grid sub-components.
+The only exceptions to this are the labels for the `DataGridHeaderSortIcon` component.
+To change the label of a sorting icons, use the matching i18n prop for the direction.
+For an `ascending` variant, for example, set the `i18nAscendingLabel` prop.
+
+<iframe
+  src="https://codesandbox.io/embed/internationalization-data-grid-s3uuul?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Internationalization Data Grid"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
 ## Composition Notes
 
 The Data Grid component was designed to be [accessible and composable](/introduction/about-paste/#paste-is).
@@ -371,11 +386,14 @@ const Component = () => (
 
 #### DataGridHeaderSort Props
 
-| Prop      | Type                              | Description                                                       | Default                 |
-| --------- | --------------------------------- | ----------------------------------------------------------------- | ----------------------- |
-| direction | "ascending", "descending", "none" | Sort direction matching aria spec                                 | null                    |
-| onClick?  | `() => {}`                        | Callback when the sort button is pressed. Used to handle sorting. | null                    |
-| element?  | `string`                          | Override for customization element name                           | `DATA_GRID_HEADER_SORT` |
+| Prop                 | Type                              | Description                                                       | Default                 |
+| -------------------- | --------------------------------- | ----------------------------------------------------------------- | ----------------------- |
+| direction            | "ascending", "descending", "none" | Sort direction matching aria spec                                 | null                    |
+| onClick?             | `() => {}`                        | Callback when the sort button is pressed. Used to handle sorting. | null                    |
+| element?             | `string`                          | Override for customization element name                           | `DATA_GRID_HEADER_SORT` |
+| i18nAscendingLabel?  | `string`                          | Sort button label text when `direction` is "ascending"            | `'Sort ascending'`      |
+| i18nDescendingLabel? | `string`                          | Sort button label text when `direction` is "descending"           | `'Sort descending'`     |
+| i18nUnsortedLabel?   | `string`                          | Sort button label text when `direction` is "none"                 | `'Unsorted'`            |
 
 #### DataGridRow Props
 


### PR DESCRIPTION
Data Grid
- [x]  add i18nAscendingLabel, i18nDescendingLabel, and i18nUnsortedLabel props
- [x]  add i18n story
- [x]  add tests for default and custom i18n props
- [x]  add example to website
- [x]  add prop to DataGridHeaderSort prop list on website

Alert
- [x] switch alert status icon text to title attribute instead of screen reader only
- [x] update tests to look for icon text within the icon  

Toast
- [x] switch toast status icon text to title attribute instead of screen reader only
- [x] update tests to look for icon text within the icon  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
