### PR TITLE
fix(badge): adjust error counter icon color

### DIFF
--- a/.changeset/thin-mangos-report.md
+++ b/.changeset/thin-mangos-report.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/badge': patch
+'@twilio-paste/core': patch
+---
+
+[Badge] adjust the error icon color for the error counter variant

--- a/packages/paste-core/components/badge/src/index.tsx
+++ b/packages/paste-core/components/badge/src/index.tsx
@@ -67,9 +67,7 @@ export const Badge = React.forwardRef<HTMLElement, BadgeProps>(
         ref={ref}
         {...badgeStyles}
       >
-        {variant === 'error_counter' ? (
-          <ErrorIcon element={`${element}_ICON`} color="colorTextIconError" decorative size="sizeIcon10" />
-        ) : null}
+        {variant === 'error_counter' ? <ErrorIcon element={`${element}_ICON`} decorative size="sizeIcon10" /> : null}
         {resizedChildren}
       </Box>
     );


### PR DESCRIPTION
Took out the specificity of the icon color for the error counter variant; it now inherits its color.