### PR TITLE
fix: data grid layout backwards compat with older tables. Support responsive tables

### DIFF
--- a/.changeset/giant-pillows-lick.md
+++ b/.changeset/giant-pillows-lick.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/table': patch
+'@twilio-paste/core': patch
+---
+
+[Table] Adds the ability to safely render tables for mobile screens using the `isResponsive` prop. Also adds the `noWrap` prop to control cell density by preventing line wrapping.

--- a/.changeset/giant-pillows-lick.md
+++ b/.changeset/giant-pillows-lick.md
@@ -1,6 +1,6 @@
 ---
-'@twilio-paste/table': patch
-'@twilio-paste/core': patch
+'@twilio-paste/table': minor
+'@twilio-paste/core': minor
 ---
 
-[Table] Adds the ability to safely render tables for mobile screens using the `isResponsive` prop. Also adds the `noWrap` prop to control cell density by preventing line wrapping.
+[Table] Adds the ability to safely render tables for mobile screens using the `scrollHorizontally` prop. Also adds the `noWrap` prop to control cell density by preventing line wrapping.

--- a/.changeset/lovely-guests-think.md
+++ b/.changeset/lovely-guests-think.md
@@ -1,6 +1,6 @@
 ---
-'@twilio-paste/data-grid': patch
-'@twilio-paste/core': patch
+'@twilio-paste/data-grid': minor
+'@twilio-paste/core': minor
 ---
 
 [Data grid]: inherit more things from the base table component, including the new responsive and no line wrapping behaviours for better table rendering options.

--- a/.changeset/lovely-guests-think.md
+++ b/.changeset/lovely-guests-think.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/data-grid': patch
+'@twilio-paste/core': patch
+---
+
+[Data grid]: inherit more things from the base table component, including the new responsive and no line wrapping behaviours for better table rendering options.

--- a/packages/paste-core/components/data-grid/src/DataGrid.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGrid.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {Box} from '@twilio-paste/box';
 import {useUID} from '@twilio-paste/uid-library';
 import {useCompositeState, Composite} from '@twilio-paste/reakit-library';
 import {Table} from '@twilio-paste/table';
@@ -130,27 +129,21 @@ export const DataGrid = React.forwardRef<HTMLTableElement, DataGridProps>(
 
     return (
       <DataGridContext.Provider value={dataGridState}>
-        <Box
+        <Composite
+          {...props}
+          {...compositeState}
           id={dataGridId}
-          element={`${element}_WRAPPER`}
-          overflowX="auto"
-          whiteSpace="nowrap"
-          boxShadow={actionable ? 'shadowFocus' : null}
-        >
-          <Composite
-            {...props}
-            {...compositeState}
-            ref={ref}
-            as={Table}
-            element={element}
-            role="grid"
-            onKeyDown={handleKeypress}
-            onMouseDown={handleMouseDown}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            data-actionable={actionable}
-          />
-        </Box>
+          ref={ref}
+          as={Table}
+          element={element}
+          role="grid"
+          onKeyDown={handleKeypress}
+          onMouseDown={handleMouseDown}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          isActionable={actionable}
+          data-actionable={actionable}
+        />
       </DataGridContext.Provider>
     );
   }

--- a/packages/paste-core/components/data-grid/src/DataGridCell.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridCell.tsx
@@ -14,6 +14,7 @@ const isElement = require('lodash.iselement');
 
 type CellType = 'th' | 'td';
 export interface DataGridCellProps extends Pick<TdProps, 'textAlign'> {
+  colSpan?: number;
   as?: CellType;
   element?: BoxElementProps['element'];
 }

--- a/packages/paste-core/components/data-grid/stories/components/DataGridLayouts.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/DataGridLayouts.tsx
@@ -1,0 +1,382 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {Text} from '@twilio-paste/text';
+import {Stack} from '@twilio-paste/stack';
+import {Heading} from '@twilio-paste/heading';
+import {Anchor} from '@twilio-paste/anchor';
+import {Truncate} from '@twilio-paste/truncate';
+import {Button} from '@twilio-paste/button';
+import {DataGrid, DataGridHead, DataGridRow, DataGridHeader, DataGridBody, DataGridCell, DataGridFoot} from '../../src';
+
+export const DataGridLayouts = (): React.ReactNode => {
+  return (
+    <Box borderStyle="solid" borderColor="colorBorder" borderWidth="borderWidth10" padding="space40" maxWidth="800px">
+      <Stack orientation="vertical" spacing="space40">
+        <Heading as="h2" variant="heading40">
+          Default
+        </Heading>
+        <DataGrid aria-label="Data grid layout example">
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          Layout fixed
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" tableLayout="fixed">
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          No wrap
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" noWrap>
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          No wrap, layout fixed, truncate needed
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" tableLayout="fixed" noWrap>
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </DataGridCell>
+              <DataGridCell>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">
+                  <Truncate title="Duplicate flow">Duplicate flow</Truncate>
+                </Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          isReponsive
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" isResponsive>
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          isReponsive, layout fixed
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" isResponsive tableLayout="fixed">
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          isReponsive, whitespace no wrap
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" isResponsive noWrap>
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>16:24:28 UTC 2020-09-17</DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+        <Heading as="h2" variant="heading40">
+          isReponsive, whitespace no wrap, layout fixed, truncate needed
+        </Heading>
+        <DataGrid aria-label="Data grid layout example" isResponsive tableLayout="fixed" noWrap>
+          <DataGridHead>
+            <DataGridRow>
+              <DataGridHeader>Flow</DataGridHeader>
+              <DataGridHeader>SID</DataGridHeader>
+              <DataGridHeader>Date created</DataGridHeader>
+              <DataGridHeader>Date updated</DataGridHeader>
+              <DataGridHeader>Logs</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+              <DataGridHeader>&nbsp;</DataGridHeader>
+            </DataGridRow>
+          </DataGridHead>
+          <DataGridBody>
+            <DataGridRow>
+              <DataGridCell>
+                <Anchor href="#">Flow link</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </DataGridCell>
+              <DataGridCell>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </DataGridCell>
+              <DataGridCell>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </DataGridCell>
+              <DataGridCell>
+                <Anchor href="#">Logs</Anchor>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="link">Duplicate flow</Button>
+              </DataGridCell>
+              <DataGridCell>
+                <Button variant="destructive_link">Delete flow</Button>
+              </DataGridCell>
+            </DataGridRow>
+          </DataGridBody>
+          <DataGridFoot>
+            <DataGridRow>
+              <DataGridCell colSpan={7}>&nbsp;</DataGridCell>
+            </DataGridRow>
+          </DataGridFoot>
+        </DataGrid>
+      </Stack>
+    </Box>
+  );
+};
+
+DataGridLayouts.storyName = 'Data Grid Layouts';

--- a/packages/paste-core/components/data-grid/stories/components/DataGridLayouts.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/DataGridLayouts.tsx
@@ -197,7 +197,7 @@ export const DataGridLayouts = (): React.ReactNode => {
         <Heading as="h2" variant="heading40">
           isReponsive
         </Heading>
-        <DataGrid aria-label="Data grid layout example" isResponsive>
+        <DataGrid aria-label="Data grid layout example" scrollHorizontally>
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader>Flow</DataGridHeader>
@@ -241,7 +241,7 @@ export const DataGridLayouts = (): React.ReactNode => {
         <Heading as="h2" variant="heading40">
           isReponsive, layout fixed
         </Heading>
-        <DataGrid aria-label="Data grid layout example" isResponsive tableLayout="fixed">
+        <DataGrid aria-label="Data grid layout example" scrollHorizontally tableLayout="fixed">
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader>Flow</DataGridHeader>
@@ -285,7 +285,7 @@ export const DataGridLayouts = (): React.ReactNode => {
         <Heading as="h2" variant="heading40">
           isReponsive, whitespace no wrap
         </Heading>
-        <DataGrid aria-label="Data grid layout example" isResponsive noWrap>
+        <DataGrid aria-label="Data grid layout example" scrollHorizontally noWrap>
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader>Flow</DataGridHeader>
@@ -329,7 +329,7 @@ export const DataGridLayouts = (): React.ReactNode => {
         <Heading as="h2" variant="heading40">
           isReponsive, whitespace no wrap, layout fixed, truncate needed
         </Heading>
-        <DataGrid aria-label="Data grid layout example" isResponsive tableLayout="fixed" noWrap>
+        <DataGrid aria-label="Data grid layout example" scrollHorizontally tableLayout="fixed" noWrap>
           <DataGridHead>
             <DataGridRow>
               <DataGridHeader>Flow</DataGridHeader>

--- a/packages/paste-core/components/data-grid/stories/index.stories.tsx
+++ b/packages/paste-core/components/data-grid/stories/index.stories.tsx
@@ -6,6 +6,7 @@ export {PaginatedDataGrid} from './components/PaginatedDataGrid';
 export {SortableColumnsDataGrid} from './components/SortableColumnsDataGrid';
 export {KitchenSinkDataGrid} from './components/KitchenSinkDataGrid';
 export {I18nDataGrid} from './components/I18nDataGrid';
+export {DataGridLayouts} from './components/DataGridLayouts';
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/packages/paste-core/components/table/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/table/__tests__/index.spec.tsx
@@ -224,7 +224,7 @@ describe('Table', () => {
 
   it('should render responsive table styles', (): void => {
     const {container} = render(
-      <Table isResponsive>
+      <Table scrollHorizontally>
         <TBody>
           <Tr verticalAlign="top" data-testid="mockTr">
             <Td>Column 1</Td>

--- a/packages/paste-core/components/table/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/table/__tests__/index.spec.tsx
@@ -222,6 +222,48 @@ describe('Table', () => {
     expect(renderedTd).toHaveStyleRule('text-align', 'right');
   });
 
+  it('should render responsive table styles', (): void => {
+    const {container} = render(
+      <Table isResponsive>
+        <TBody>
+          <Tr verticalAlign="top" data-testid="mockTr">
+            <Td>Column 1</Td>
+          </Tr>
+        </TBody>
+      </Table>
+    );
+    const renderWrapper = container.querySelector('[data-paste-element="TABLE_WRAPPER"]');
+    expect(renderWrapper).toHaveStyleRule('overflow-x', 'auto');
+  });
+
+  it('should render no wrap table styles', (): void => {
+    const {container} = render(
+      <Table noWrap>
+        <TBody>
+          <Tr verticalAlign="top" data-testid="mockTr">
+            <Td>Column 1</Td>
+          </Tr>
+        </TBody>
+      </Table>
+    );
+    const renderWrapper = container.querySelector('[data-paste-element="TABLE_WRAPPER"]');
+    expect(renderWrapper).toHaveStyleRule('white-space', 'nowrap');
+  });
+
+  it('should render actionable table styles', (): void => {
+    const {container} = render(
+      <Table isActionable>
+        <TBody>
+          <Tr verticalAlign="top" data-testid="mockTr">
+            <Td>Column 1</Td>
+          </Tr>
+        </TBody>
+      </Table>
+    );
+    const renderWrapper = container.querySelector('[data-paste-element="TABLE_WRAPPER"]');
+    expect(renderWrapper).toHaveStyleRule('box-shadow', 'shadowFocus');
+  });
+
   describe('HTML Attribute', () => {
     it('should set an element data attribute for Table (default)', () => {
       render(

--- a/packages/paste-core/components/table/src/Table.tsx
+++ b/packages/paste-core/components/table/src/Table.tsx
@@ -10,7 +10,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
       element = 'TABLE',
       id,
       isActionable,
-      isResponsive,
+      scrollHorizontally,
       noWrap,
       striped = false,
       tableLayout = 'auto',
@@ -28,7 +28,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
         <Box
           id={id}
           element={`${element}_WRAPPER`}
-          overflowX={isResponsive ? 'auto' : null}
+          overflowX={scrollHorizontally ? 'auto' : null}
           whiteSpace={noWrap ? 'nowrap' : null}
           boxShadow={isActionable ? 'shadowFocus' : null}
         >

--- a/packages/paste-core/components/table/src/Table.tsx
+++ b/packages/paste-core/components/table/src/Table.tsx
@@ -5,7 +5,20 @@ import type {TableProps} from './types';
 import {TablePropTypes} from './proptypes';
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>(
-  ({element = 'TABLE', striped = false, tableLayout = 'auto', variant = 'default', ...props}, ref) => {
+  (
+    {
+      element = 'TABLE',
+      id,
+      isActionable,
+      isResponsive,
+      noWrap,
+      striped = false,
+      tableLayout = 'auto',
+      variant = 'default',
+      ...props
+    },
+    ref
+  ) => {
     const tableContext = {
       striped,
     };
@@ -13,18 +26,26 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
     return (
       <TableContext.Provider value={tableContext}>
         <Box
-          {...safelySpreadBoxProps(props)}
-          ref={ref}
-          as="table"
-          borderCollapse="collapse"
-          borderColor="colorBorderWeaker"
-          borderSpacing="0"
-          borderStyle="solid"
-          borderWidth={variant === 'borderless' ? 'borderWidth0' : 'borderWidth10'}
-          element={element}
-          tableLayout={tableLayout === 'fixed' ? 'fixed' : 'auto'}
-          width="100%"
-        />
+          id={id}
+          element={`${element}_WRAPPER`}
+          overflowX={isResponsive ? 'auto' : null}
+          whiteSpace={noWrap ? 'nowrap' : null}
+          boxShadow={isActionable ? 'shadowFocus' : null}
+        >
+          <Box
+            {...safelySpreadBoxProps(props)}
+            ref={ref}
+            as="table"
+            borderCollapse="collapse"
+            borderColor="colorBorderWeaker"
+            borderSpacing="0"
+            borderStyle="solid"
+            borderWidth={variant === 'borderless' ? 'borderWidth0' : 'borderWidth10'}
+            element={element}
+            tableLayout={tableLayout === 'fixed' ? 'fixed' : 'auto'}
+            width="100%"
+          />
+        </Box>
       </TableContext.Provider>
     );
   }

--- a/packages/paste-core/components/table/src/proptypes.ts
+++ b/packages/paste-core/components/table/src/proptypes.ts
@@ -6,6 +6,9 @@ import {TableAlignmentObject, TableLayoutObject, TableVariantObject, TableVertic
 export const TablePropTypes = {
   children: PropTypes.node.isRequired,
   element: PropTypes.string,
+  isActionable: PropTypes.bool,
+  isResponsive: PropTypes.bool,
+  noWrap: PropTypes.bool,
   striped: PropTypes.bool,
   tableLayout: PropTypes.oneOf(Object.values(TableLayoutObject)),
   variant: PropTypes.oneOf(Object.values(TableVariantObject)),

--- a/packages/paste-core/components/table/src/proptypes.ts
+++ b/packages/paste-core/components/table/src/proptypes.ts
@@ -7,7 +7,7 @@ export const TablePropTypes = {
   children: PropTypes.node.isRequired,
   element: PropTypes.string,
   isActionable: PropTypes.bool,
-  isResponsive: PropTypes.bool,
+  scrollHorizontally: PropTypes.bool,
   noWrap: PropTypes.bool,
   striped: PropTypes.bool,
   tableLayout: PropTypes.oneOf(Object.values(TableLayoutObject)),

--- a/packages/paste-core/components/table/src/types.ts
+++ b/packages/paste-core/components/table/src/types.ts
@@ -27,7 +27,7 @@ export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> 
   /**
    * Controls a tables ability to be shown on smaller viewports
    */
-  isResponsive?: boolean;
+  scrollHorizontally?: boolean;
   /**
    * Controls table cell content line wrapping
    */

--- a/packages/paste-core/components/table/src/types.ts
+++ b/packages/paste-core/components/table/src/types.ts
@@ -24,6 +24,16 @@ export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> 
   striped?: boolean;
   tableLayout?: TableLayoutOptions;
   variant?: TableVariantOptions;
+  /**
+   * Controls a tables ability to be shown on smaller viewports
+   */
+  isResponsive?: boolean;
+  /**
+   * Controls table cell content line wrapping
+   */
+  noWrap?: boolean;
+  /** Displays table and data grid actionable mode */
+  isActionable?: boolean;
 }
 
 export interface THeadProps extends React.TableHTMLAttributes<HTMLTableSectionElement> {

--- a/packages/paste-core/components/table/stories/index.stories.tsx
+++ b/packages/paste-core/components/table/stories/index.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
+import {Stack} from '@twilio-paste/stack';
 import {MediaObject, MediaBody, MediaFigure} from '@twilio-paste/media-object';
 import {Menu, MenuButton, MenuItem, MenuSeparator, useMenuState} from '@twilio-paste/menu';
 import {CustomizationProvider} from '@twilio-paste/customization';
@@ -7,6 +8,9 @@ import {useTheme} from '@twilio-paste/theme';
 import {AttachIcon} from '@twilio-paste/icons/esm/AttachIcon';
 import {MoreIcon} from '@twilio-paste/icons/esm/MoreIcon';
 import {Text} from '@twilio-paste/text';
+import {Heading} from '@twilio-paste/heading';
+import {Anchor} from '@twilio-paste/anchor';
+import {Button} from '@twilio-paste/button';
 import {Truncate} from '@twilio-paste/truncate';
 import {Table, THead, TBody, TFoot, Tr, Td, Th} from '../src';
 
@@ -1006,6 +1010,375 @@ export const Truncation = (): React.ReactNode => {
         </Tr>
       </TFoot>
     </Table>
+  );
+};
+
+export const Layouts = (): React.ReactNode => {
+  return (
+    <Box borderStyle="solid" borderColor="colorBorder" borderWidth="borderWidth10" padding="space40" maxWidth="800px">
+      <Stack orientation="vertical" spacing="space40">
+        <Heading as="h2" variant="heading40">
+          Default
+        </Heading>
+        <Table>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          Layout fixed
+        </Heading>
+        <Table tableLayout="fixed">
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          No wrap
+        </Heading>
+        <Table noWrap>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          Fixed layout, No wrap, truncate needed
+        </Heading>
+        <Table tableLayout="fixed" noWrap>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </Td>
+              <Td>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          isResponsive
+        </Heading>
+        <Table isResponsive>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          isResponsive, fixed layout
+        </Heading>
+        <Table isResponsive tableLayout="fixed">
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          isResponsive, no wrap
+        </Heading>
+        <Table isResponsive noWrap>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>16:24:28 UTC 2020-09-17</Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+        <Heading as="h2" variant="heading40">
+          isResponsive, no wrap, fixed layout, truncate needed
+        </Heading>
+        <Table isResponsive tableLayout="fixed" noWrap>
+          <THead>
+            <Tr>
+              <Th>Flow</Th>
+              <Th>SID</Th>
+              <Th>Date created</Th>
+              <Th>Date updated</Th>
+              <Th>Logs</Th>
+              <Th>&nbsp;</Th>
+              <Th>&nbsp;</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            <Tr>
+              <Td>
+                <Anchor href="#">Flow link</Anchor>
+              </Td>
+              <Td>
+                <Text as="div" fontFamily="fontFamilyCode">
+                  <Truncate title="SM0yc4mxi6cn4z13bte7qmflc2drc85mlp">SM0yc4mxi6cn4z13bte7qmflc2drc85mlp</Truncate>
+                </Text>
+              </Td>
+              <Td>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </Td>
+              <Td>
+                <Truncate title="16:24:28 UTC 2020-09-17">16:24:28 UTC 2020-09-17</Truncate>
+              </Td>
+              <Td>
+                <Anchor href="#">Logs</Anchor>
+              </Td>
+              <Td>
+                <Button variant="link">Duplicate flow</Button>
+              </Td>
+              <Td>
+                <Button variant="destructive_link">Delete flow</Button>
+              </Td>
+            </Tr>
+          </TBody>
+          <TFoot>
+            <Tr>
+              <Td colSpan={7}>&nbsp;</Td>
+            </Tr>
+          </TFoot>
+        </Table>
+      </Stack>
+    </Box>
   );
 };
 

--- a/packages/paste-core/components/table/stories/index.stories.tsx
+++ b/packages/paste-core/components/table/stories/index.stories.tsx
@@ -1198,9 +1198,9 @@ export const Layouts = (): React.ReactNode => {
           </TFoot>
         </Table>
         <Heading as="h2" variant="heading40">
-          isResponsive
+          scrollHorizontally
         </Heading>
-        <Table isResponsive>
+        <Table scrollHorizontally>
           <THead>
             <Tr>
               <Th>Flow</Th>
@@ -1242,9 +1242,9 @@ export const Layouts = (): React.ReactNode => {
           </TFoot>
         </Table>
         <Heading as="h2" variant="heading40">
-          isResponsive, fixed layout
+          scrollHorizontally, fixed layout
         </Heading>
-        <Table isResponsive tableLayout="fixed">
+        <Table scrollHorizontally tableLayout="fixed">
           <THead>
             <Tr>
               <Th>Flow</Th>
@@ -1286,9 +1286,9 @@ export const Layouts = (): React.ReactNode => {
           </TFoot>
         </Table>
         <Heading as="h2" variant="heading40">
-          isResponsive, no wrap
+          scrollHorizontally, no wrap
         </Heading>
-        <Table isResponsive noWrap>
+        <Table scrollHorizontally noWrap>
           <THead>
             <Tr>
               <Th>Flow</Th>
@@ -1330,9 +1330,9 @@ export const Layouts = (): React.ReactNode => {
           </TFoot>
         </Table>
         <Heading as="h2" variant="heading40">
-          isResponsive, no wrap, fixed layout, truncate needed
+          scrollHorizontally, no wrap, fixed layout, truncate needed
         </Heading>
-        <Table isResponsive tableLayout="fixed" noWrap>
+        <Table scrollHorizontally tableLayout="fixed" noWrap>
           <THead>
             <Tr>
               <Th>Flow</Th>

--- a/packages/paste-website/src/component-examples/DataExportPatternExamples.ts
+++ b/packages/paste-website/src/component-examples/DataExportPatternExamples.ts
@@ -206,7 +206,7 @@ const ExportDownloadPage = () => (
     <Heading as="h2" variant="heading20">
       Active Exports
     </Heading>
-    <Table>
+    <Table isResponsive>
       <THead>
         <Tr>
           <Th>Status</Th>

--- a/packages/paste-website/src/component-examples/DataExportPatternExamples.ts
+++ b/packages/paste-website/src/component-examples/DataExportPatternExamples.ts
@@ -206,7 +206,7 @@ const ExportDownloadPage = () => (
     <Heading as="h2" variant="heading20">
       Active Exports
     </Heading>
-    <Table isResponsive>
+    <Table scrollHorizontally>
       <THead>
         <Tr>
           <Th>Status</Th>

--- a/packages/paste-website/src/components/FormPillVsDisplayPillTable.tsx
+++ b/packages/paste-website/src/components/FormPillVsDisplayPillTable.tsx
@@ -10,7 +10,7 @@ export interface FormPillVsDisplayPillTableProps {
 const FormPillVsDisplayPillTable: React.FC<FormPillVsDisplayPillTableProps> = () => {
   return (
     <Box marginBottom="space70">
-      <Table isResponsive>
+      <Table scrollHorizontally>
         <THead>
           <Tr>
             <Th>&nbsp;</Th>

--- a/packages/paste-website/src/components/FormPillVsDisplayPillTable.tsx
+++ b/packages/paste-website/src/components/FormPillVsDisplayPillTable.tsx
@@ -10,7 +10,7 @@ export interface FormPillVsDisplayPillTableProps {
 const FormPillVsDisplayPillTable: React.FC<FormPillVsDisplayPillTableProps> = () => {
   return (
     <Box marginBottom="space70">
-      <Table>
+      <Table isResponsive>
         <THead>
           <Tr>
             <Th>&nbsp;</Th>

--- a/packages/paste-website/src/components/Roadmap/Roadmap.tsx
+++ b/packages/paste-website/src/components/Roadmap/Roadmap.tsx
@@ -58,7 +58,7 @@ const Roadmap: React.FC<RoadmapProps> = ({data}) => {
               <AnchoredHeading as="h2" variant="heading20" existingSlug={releaseSlug}>
                 {release.release}
               </AnchoredHeading>
-              <Table isResponsive>
+              <Table scrollHorizontally>
                 <THead>
                   <Tr>
                     <Th width="200px">Feature</Th>

--- a/packages/paste-website/src/components/Roadmap/Roadmap.tsx
+++ b/packages/paste-website/src/components/Roadmap/Roadmap.tsx
@@ -58,7 +58,7 @@ const Roadmap: React.FC<RoadmapProps> = ({data}) => {
               <AnchoredHeading as="h2" variant="heading20" existingSlug={releaseSlug}>
                 {release.release}
               </AnchoredHeading>
-              <Table>
+              <Table isResponsive>
                 <THead>
                   <Tr>
                     <Th width="200px">Feature</Th>

--- a/packages/paste-website/src/components/component-overview-table/index.tsx
+++ b/packages/paste-website/src/components/component-overview-table/index.tsx
@@ -26,7 +26,7 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({category
 
   return (
     <Box marginTop="space60" marginBottom="space60">
-      <Table isResponsive data-cy="overview-table">
+      <Table scrollHorizontally data-cy="overview-table">
         <THead>
           <Tr>
             <Th width="150px">Name</Th>

--- a/packages/paste-website/src/components/component-overview-table/index.tsx
+++ b/packages/paste-website/src/components/component-overview-table/index.tsx
@@ -26,7 +26,7 @@ const ComponentOverviewTable: React.FC<ComponentOverviewTableProps> = ({category
 
   return (
     <Box marginTop="space60" marginBottom="space60">
-      <Table data-cy="overview-table">
+      <Table isResponsive data-cy="overview-table">
         <THead>
           <Tr>
             <Th width="150px">Name</Th>

--- a/packages/paste-website/src/components/paste-mdx-provider/index.tsx
+++ b/packages/paste-website/src/components/paste-mdx-provider/index.tsx
@@ -69,7 +69,7 @@ const MDXPoviderComponents = {
   blockquote: (props: React.ComponentProps<'blockquote'>): React.ReactElement => <blockquote {...props} />,
   table: (props: React.ComponentProps<typeof Table>): React.ReactElement => (
     <Box marginBottom="space60">
-      <Table isResponsive tableLayout="fixed" {...props} />
+      <Table scrollHorizontally tableLayout="fixed" {...props} />
     </Box>
   ),
   thead: (props: React.ComponentProps<typeof THead>): React.ReactElement => <THead {...props} />,

--- a/packages/paste-website/src/components/paste-mdx-provider/index.tsx
+++ b/packages/paste-website/src/components/paste-mdx-provider/index.tsx
@@ -69,7 +69,7 @@ const MDXPoviderComponents = {
   blockquote: (props: React.ComponentProps<'blockquote'>): React.ReactElement => <blockquote {...props} />,
   table: (props: React.ComponentProps<typeof Table>): React.ReactElement => (
     <Box marginBottom="space60">
-      <Table tableLayout="fixed" {...props} />
+      <Table isResponsive tableLayout="fixed" {...props} />
     </Box>
   ),
   thead: (props: React.ComponentProps<typeof THead>): React.ReactElement => <THead {...props} />,

--- a/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/live-preview/index.tsx
@@ -58,6 +58,7 @@ const LivePreview: React.FC<LivePreviewProps> = ({
           borderTopLeftRadius="borderRadius20"
           borderTopRightRadius="borderRadius20"
           position="relative"
+          overflowX="auto"
         >
           <ReactLivePreview />
         </Box>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -157,7 +157,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
               </AnchoredHeading>
               {cat.info}
               <Box marginBottom="space160" data-cy="tokens-table-container">
-                <Table isResponsive>
+                <Table scrollHorizontally>
                   <THead>
                     <Tr>
                       <Th>Token</Th>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -157,7 +157,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
               </AnchoredHeading>
               {cat.info}
               <Box marginBottom="space160" data-cy="tokens-table-container">
-                <Table>
+                <Table isResponsive>
                   <THead>
                     <Tr>
                       <Th>Token</Th>

--- a/packages/paste-website/src/pages/components/breadcrumb/index.mdx
+++ b/packages/paste-website/src/pages/components/breadcrumb/index.mdx
@@ -215,7 +215,7 @@ our BreadcrumbItem component creates links using [Anchor](/components/anchor) un
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/breadcrumb/index.mdx
+++ b/packages/paste-website/src/pages/components/breadcrumb/index.mdx
@@ -215,7 +215,7 @@ our BreadcrumbItem component creates links using [Anchor](/components/anchor) un
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -221,7 +221,7 @@ For full details on how to use the state hook, and what props to provide it, fol
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -221,7 +221,7 @@ For full details on how to use the state hook, and what props to provide it, fol
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -211,6 +211,10 @@ in the cells to create a more pleasant loading experience.
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
+### Layouts
+
+The Data Grid inherits from the [Table component](/components/table/), so you can take advantage of all the same layout techniques found in the [Table examples](/components/table#layouts) to control how your Data Grids render on the page.
+
 ### Kitchen sink
 
 This example combines all the separate features displayed previously into one example. It shows how all the features work together harmoniously through composition.

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -99,7 +99,7 @@ export const pageQuery = graphql`
 
 ## Guidelines
 
-## About Data Grid
+### About Data Grid
 
 The Data Grid is an enhanced [Table](/components/table) component. It can be used to improve the way
 users scan and interact with tabular data. It can be used alongside other components in Paste to provide
@@ -351,12 +351,16 @@ const Component = () => (
 
 #### DataGrid Props
 
-| Prop       | Type        | Description                                             | Default     |
-| ---------- | ----------- | ------------------------------------------------------- | ----------- |
-| aria-label | `string`    | Defines a string value that labels the current element. | null        |
-| striped?   | `boolean`   | Toggles row zebra striping                              | false       |
-| element?   | `string`    | Override for customization element name                 | `DATA_GRID` |
-| children?  | `ReactNode` |                                                         | null        |
+| Prop                | Type                    | Description                                                     | Default     |
+| ------------------- | ----------------------- | --------------------------------------------------------------- | ----------- |
+| aria-label          | `string`                | Defines a string value that labels the current element.         | null        |
+| striped?            | `boolean`               | Toggles row zebra striping                                      | false       |
+| scrollHorizontally? | `boolean`               | Sets the table to scroll horizontally on small screens.         | false       |
+| noWrap?             | `boolean`               | Sets the table cells to not line wrap.                          | false       |
+| tableLayout?        | "auto", "fixed"         | Sets the `table-layout` style of the Table. Defaults to `auto`. | false       |
+| variant?            | "default", "borderless" | Sets the `border` style of the Table. Defaults to `default`.    | false       |
+| element?            | `string`                | Override for customization element name                         | `DATA_GRID` |
+| children?           | `ReactNode`             |                                                                 | null        |
 
 #### DataGridHead Props
 

--- a/packages/paste-website/src/pages/components/date-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/date-picker/index.mdx
@@ -105,7 +105,7 @@ It is used with the [Label](/components/label) and [Help Text](/components/help-
 Because browsers' implementations of the native date picker vary, this component <strong>may not be fully accessible</strong> in all cases. Chrome/Edge, Safari and Firefox all support the Date Picker, but the user experience differs browser-to-browser. Some of those differences are outlined below:
 
 <Box margin="space70">
-  <Table variant="borderless">
+  <Table isResponsive variant="borderless">
     <TBody>
       <Tr verticalAlign="middle">
         <Td textAlign="left">
@@ -414,7 +414,7 @@ Error text should:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/date-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/date-picker/index.mdx
@@ -105,7 +105,7 @@ It is used with the [Label](/components/label) and [Help Text](/components/help-
 Because browsers' implementations of the native date picker vary, this component <strong>may not be fully accessible</strong> in all cases. Chrome/Edge, Safari and Firefox all support the Date Picker, but the user experience differs browser-to-browser. Some of those differences are outlined below:
 
 <Box margin="space70">
-  <Table isResponsive variant="borderless">
+  <Table scrollHorizontally variant="borderless">
     <TBody>
       <Tr verticalAlign="middle">
         <Td textAlign="left">
@@ -414,7 +414,7 @@ Error text should:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/help-text/index.mdx
+++ b/packages/paste-website/src/pages/components/help-text/index.mdx
@@ -282,7 +282,7 @@ Use Help Text when users might need additional information to fill out a form fi
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/help-text/index.mdx
+++ b/packages/paste-website/src/pages/components/help-text/index.mdx
@@ -282,7 +282,7 @@ Use Help Text when users might need additional information to fill out a form fi
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/input/index.mdx
+++ b/packages/paste-website/src/pages/components/input/index.mdx
@@ -516,7 +516,7 @@ Use an input when users are expected to enter less than a single line of text, o
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/input/index.mdx
+++ b/packages/paste-website/src/pages/components/input/index.mdx
@@ -516,7 +516,7 @@ Use an input when users are expected to enter less than a single line of text, o
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/label/index.mdx
+++ b/packages/paste-website/src/pages/components/label/index.mdx
@@ -253,7 +253,7 @@ Use a Label to clearly describe the the form field.
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/label/index.mdx
+++ b/packages/paste-website/src/pages/components/label/index.mdx
@@ -253,7 +253,7 @@ Use a Label to clearly describe the the form field.
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/pagination/index.mdx
+++ b/packages/paste-website/src/pages/components/pagination/index.mdx
@@ -408,7 +408,7 @@ Consider [contributing a Table Actions pattern](/introduction/contributing/patte
 ### PaginationArrow
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -471,7 +471,7 @@ Consider [contributing a Table Actions pattern](/introduction/contributing/patte
 ### PaginationNumber
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/pagination/index.mdx
+++ b/packages/paste-website/src/pages/components/pagination/index.mdx
@@ -408,7 +408,7 @@ Consider [contributing a Table Actions pattern](/introduction/contributing/patte
 ### PaginationArrow
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -471,7 +471,7 @@ Consider [contributing a Table Actions pattern](/introduction/contributing/patte
 ### PaginationNumber
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/select/index.mdx
+++ b/packages/paste-website/src/pages/components/select/index.mdx
@@ -702,7 +702,7 @@ Use a select when:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/select/index.mdx
+++ b/packages/paste-website/src/pages/components/select/index.mdx
@@ -702,7 +702,7 @@ Use a select when:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -1,40 +1,36 @@
 ---
 title: Table
-package: "@twilio-paste/table"
+package: '@twilio-paste/table'
 description: Tables are used to display information that is meant to be compared across columns and rows.
 slug: /components/table/
 ---
 
-import { graphql } from "gatsby";
-import { Anchor } from "@twilio-paste/anchor";
-import { Avatar } from "@twilio-paste/avatar";
-import { Box } from "@twilio-paste/box";
-import { Button } from "@twilio-paste/button";
-import { Card } from "@twilio-paste/card";
-import { Heading } from "@twilio-paste/heading";
-import { Stack } from "@twilio-paste/stack";
-import { Table, THead, TBody, TFoot, Tr, Th, Td } from "@twilio-paste/table";
-import { Text } from "@twilio-paste/text";
-import { Tooltip } from "@twilio-paste/tooltip";
-import { Truncate } from "@twilio-paste/truncate";
-import { UnorderedList, ListItem } from "@twilio-paste/list";
-import { InformationIcon } from "@twilio-paste/icons/esm/InformationIcon";
-import { ProcessErrorIcon } from "@twilio-paste/icons/esm/ProcessErrorIcon";
-import { ProcessWarningIcon } from "@twilio-paste/icons/esm/ProcessWarningIcon";
-import { ProcessSuccessIcon } from "@twilio-paste/icons/esm/ProcessSuccessIcon";
-import Changelog from "@twilio-paste/table/CHANGELOG.md";
-import {
-  Callout,
-  CalloutTitle,
-  CalloutText,
-} from "../../../components/callout";
-import { DoDont, Do, Dont } from "../../../components/DoDont";
-import { SidebarCategoryRoutes } from "../../../constants";
-import { SiteLink } from "../../../components/SiteLink";
+import {graphql} from 'gatsby';
+import {Anchor} from '@twilio-paste/anchor';
+import {Avatar} from '@twilio-paste/avatar';
+import {Box} from '@twilio-paste/box';
+import {Button} from '@twilio-paste/button';
+import {Card} from '@twilio-paste/card';
+import {Heading} from '@twilio-paste/heading';
+import {Stack} from '@twilio-paste/stack';
+import {Table, THead, TBody, TFoot, Tr, Th, Td} from '@twilio-paste/table';
+import {Text} from '@twilio-paste/text';
+import {Tooltip} from '@twilio-paste/tooltip';
+import {Truncate} from '@twilio-paste/truncate';
+import {UnorderedList, ListItem} from '@twilio-paste/list';
+import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
+import {ProcessErrorIcon} from '@twilio-paste/icons/esm/ProcessErrorIcon';
+import {ProcessWarningIcon} from '@twilio-paste/icons/esm/ProcessWarningIcon';
+import {ProcessSuccessIcon} from '@twilio-paste/icons/esm/ProcessSuccessIcon';
+import Changelog from '@twilio-paste/table/CHANGELOG.md';
+import {Callout, CalloutTitle, CalloutText} from '../../../components/callout';
+import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {SidebarCategoryRoutes} from '../../../constants';
+import {SiteLink} from '../../../components/SiteLink';
 
 export const pageQuery = graphql`
   {
-    allPasteComponent(filter: { name: { eq: "@twilio-paste/table" } }) {
+    allPasteComponent(filter: {name: {eq: "@twilio-paste/table"}}) {
       edges {
         node {
           name
@@ -44,7 +40,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    mdx(fields: { slug: { eq: "/components/table/" } }) {
+    mdx(fields: {slug: {eq: "/components/table/"}}) {
       fileAbsolutePath
       frontmatter {
         slug
@@ -55,7 +51,7 @@ export const pageQuery = graphql`
         value
       }
     }
-    allAirtable(filter: { data: { Feature: { eq: "Table" } } }) {
+    allAirtable(filter: {data: {Feature: {eq: "Table"}}}) {
       edges {
         node {
           data {
@@ -119,14 +115,12 @@ Accessibility recommendations:
   selecting rows, or deleting rows), use <SiteLink to="/components/data-grid">Data Grid</SiteLink> instead.
 
 <Callout>
-  <CalloutTitle>
-    Accessibility insight: navigating tables with a screen reader
-  </CalloutTitle>
+  <CalloutTitle>Accessibility insight: navigating tables with a screen reader</CalloutTitle>
   <CalloutText>
-    Learn more about why semantic table markup is important in{" "}
+    Learn more about why semantic table markup is important in{' '}
     <Anchor href="https://youtu.be/tlpQ0d2ADNo" showExternal>
       this demo video by Inclusive Components
-    </Anchor>{" "}
+    </Anchor>{' '}
     that shows what it's like to explore a data table with a screen reader.
   </CalloutText>
 </Callout>
@@ -139,7 +133,7 @@ Accessibility recommendations:
 
 The Default Table uses an automatic table layout algorithm dictated by the browser. The width of the table cells are adjusted to fit the content.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td, Text }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td, Text}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -193,10 +187,7 @@ The Default Table uses an automatic table layout algorithm dictated by the brows
 
 The Fixed Table variant sets equal column widths for the table.
 
-<LivePreview
-  scope={{ Table, THead, TBody, TFoot, Tr, Th, Td, Text }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Text}} language="jsx">
   {`<Table tableLayout="fixed">
   <THead>
     <Tr>
@@ -236,7 +227,7 @@ The Fixed Table variant sets equal column widths for the table.
 
 THead cells (`Th`) can be given a width in order to fill a section of the Table row (`Tr`). Widths can be set with Paste Size Tokens or a number value, e.g. 120px.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -273,6 +264,110 @@ THead cells (`Th`) can be given a width in order to fill a section of the Table 
 </Table>`}
 </LivePreview>
 
+#### Responsive Layouts
+
+Tabular data can on small screens can be problematic. The data can often cause tables to overflow the browser window. If you need to support small screens, you can set `isResponsive` and the table will scroll horizontally when the data can no longer fit on the screen.
+
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Text, Truncate}} language="jsx">
+  {`<Table isResponsive>
+  <THead>
+    <Tr>
+      <Th>Date</Th>
+      <Th>SID</Th>
+      <Th>From</Th>
+    </Tr>
+  </THead>
+  <TBody>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SM0yc4mxi6cn4z13bte7qmflc2drc85mlp
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SMl29llgoihx286uhxfb0yc5n0sg391x5n
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SMxarke3v30fv17hauqn86a7nhgm3b5d87
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+  </TBody>
+</Table>`}
+</LivePreview>
+
+#### Density
+
+You can control a tables vertical density by setting `noWrap` on the table. This will ensure table cell content stays on a single line.
+
+Coupled with a fixed table layout and [truncation](/components/table/#table-with-truncated-cells) you can increase the data density of a table dramatically. You should be extremely mindful of readability trade-offs when doing so.
+
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Text, Truncate}} language="jsx">
+  {`<Table isResponsive noWrap>
+  <THead>
+    <Tr>
+      <Th>Date</Th>
+      <Th>SID</Th>
+      <Th>From</Th>
+    </Tr>
+  </THead>
+  <TBody>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SM0yc4mxi6cn4z13bte7qmflc2drc85mlp
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SMl29llgoihx286uhxfb0yc5n0sg391x5n
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+    <Tr>
+      <Td>
+        16:24:28 PDT 2020-09-17
+      </Td>
+      <Td>
+        <Text as="span" fontFamily="fontFamilyCode">
+          SMxarke3v30fv17hauqn86a7nhgm3b5d87
+        </Text>
+      </Td>
+      <Td>(602) 609-6747</Td>
+    </Tr>
+  </TBody>
+</Table>`}
+</LivePreview>
+
 ### Alignment
 
 #### Column alignment
@@ -283,7 +378,7 @@ In general, text should be left-aligned, numbers should be right-aligned, and th
 Data should rarely ever be centered. Numbers only need to be right-aligned when they indicate size or are meant to be
 compared to each other. Numbers like ID numbers, phone numbers, etc. should stay left-aligned.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -324,7 +419,7 @@ compared to each other. Numbers like ID numbers, phone numbers, etc. should stay
 
 Table rows (`Tr`) can be set with either top, middle, or bottom vertical alignment. By default they are middle-aligned.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -359,10 +454,7 @@ Tables can support a `borderless` variant, which can be useful in cases where th
 containing element, such as a [modal](/components/modal/) or a [card](/components/card/). Tables have borders by default, but these can optionally be
 turned off by setting `variant="borderless"` on `Table`.
 
-<LivePreview
-  scope={{ Table, THead, TBody, TFoot, Tr, Th, Td, Card, Text }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Card, Text}} language="jsx">
   {`<Card>
   <Table variant="borderless">
     <THead>
@@ -408,7 +500,7 @@ name of an email campaign.
 
 Row headers can be added by including a `Th` as the first cell in each `Tr`, with `scope="row"`.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -462,10 +554,7 @@ the bottom of a table. In cases where you do want to show a summary or total, an
 importance to the user, you can place it above the table or at the top of the table in a regular table row,
 rather than using the `TFoot`.
 
-<LivePreview
-  scope={{ Table, THead, TBody, TFoot, Tr, Th, Td, Text }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Text}} language="jsx">
   {`<Table tableLayout="fixed">
   <THead>
     <Tr>
@@ -538,10 +627,7 @@ Tables can have zebra stripes (i.e. alternating row highlighting), which can imp
 large data sets. Tables have zebra stripes turned off by default, but these can optionally be turned on by
 setting `striped` on `Table`.
 
-<LivePreview
-  scope={{ Table, THead, TBody, TFoot, Tr, Th, Td, Text }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Text}} language="jsx">
   {`<Table striped>
   <THead>
     <Tr>
@@ -592,7 +678,7 @@ description text. In this example, the send time is not being compared across ro
 click rates are; instead, the send time is used to add additional detail that helps the user identify and
 understand data in an individual row.
 
-<LivePreview scope={{ Table, THead, TBody, Tr, Th, Td, Text }} language="jsx">
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td, Text}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -641,10 +727,7 @@ understand data in an individual row.
 Tables can be composed using Avatar, which can be used to make a table of user data more scannable.
 You can put an avatar next to a user's first and last name using `Stack` inside a single `Td`.
 
-<LivePreview
-  scope={{ Table, THead, TBody, Tr, Th, Td, Text, Avatar, Box, Stack }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, Tr, Th, Td, Text, Avatar, Box, Stack}} language="jsx">
   {`<Table>
   <THead>
     <Tr>
@@ -879,10 +962,7 @@ details placed in a [Tooltip](/components/tooltip/) or [Popover](/components/pop
 In rare cases, you may want to [truncate](/components/truncate) the text in a given cell. For example, when a table contains
 long URLs, and the user does not need to read the full URL.
 
-<LivePreview
-  scope={{ Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Truncate }}
-  language="jsx"
->
+<LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Truncate}} language="jsx">
   {`<Table tableLayout="fixed">
   <THead>
     <Tr>
@@ -935,16 +1015,8 @@ Tables are used to represent static, tabular data. For example, a list of users'
 and email addresses.
 
 <DoDont>
-  <Do
-    title="Do"
-    body="Left-align textual table data, such as an email address."
-    preview={false}
-  />
-  <Dont
-    title="Don't"
-    body="Don't right- or center-align textual table data."
-    preview={false}
-  />
+  <Do title="Do" body="Left-align textual table data, such as an email address." preview={false} />
+  <Dont title="Don't" body="Don't right- or center-align textual table data." preview={false} />
 </DoDont>
 
 <DoDont>
@@ -974,16 +1046,8 @@ and email addresses.
 </DoDont>
 
 <DoDont>
-  <Do
-    title="Do"
-    body="Include supporting text when providing a status in a table row."
-    preview={false}
-  />
-  <Dont
-    title="Don't"
-    body="Don't use color as the only indicator of status in a table row."
-    preview={false}
-  />
+  <Do title="Do" body="Include supporting text when providing a status in a table row." preview={false} />
+  <Dont title="Don't" body="Don't use color as the only indicator of status in a table row." preview={false} />
 </DoDont>
 
 ## Anatomy
@@ -1029,7 +1093,7 @@ and email addresses.
 ##### Th
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -1072,7 +1136,7 @@ and email addresses.
 ##### Td
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -1172,6 +1236,18 @@ Sets the `table-layout` style of the Table. Defaults to `auto`.
 ###### `variant?: "default" | "borderless"`
 
 Sets the `border` style of the Table. Defaults to `default`.
+
+###### `isResponsive?: boolean`
+
+Sets the table to scroll horizontally on small screens.
+
+###### `noWrap?: boolean`
+
+Sets the table cells to not line wrap.
+
+###### `isActionable?: boolean`
+
+Sets the table to visually display the actionable state of an interactive table. Mainly used for Data Grid.
 
 ##### Tr Props
 

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -266,10 +266,10 @@ THead cells (`Th`) can be given a width in order to fill a section of the Table 
 
 #### Responsive Layouts
 
-Tabular data can on small screens can be problematic. The data can often cause tables to overflow the browser window. If you need to support small screens, you can set `isResponsive` and the table will scroll horizontally when the data can no longer fit on the screen.
+Tabular data on small screens can be problematic. The data can often cause tables to overflow the browser window. If you need to support small screens, you can set `scrollHorizontally` and the table will scroll horizontally when the data can no longer fit on the screen.
 
 <LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Text, Truncate}} language="jsx">
-  {`<Table isResponsive>
+  {`<Table scrollHorizontally>
   <THead>
     <Tr>
       <Th>Date</Th>
@@ -322,7 +322,7 @@ You can control a tables vertical density by setting `noWrap` on the table. This
 Coupled with a fixed table layout and [truncation](/components/table/#table-with-truncated-cells) you can increase the data density of a table dramatically. You should be extremely mindful of readability trade-offs when doing so.
 
 <LivePreview scope={{Table, THead, TBody, TFoot, Tr, Th, Td, Anchor, Text, Truncate}} language="jsx">
-  {`<Table isResponsive noWrap>
+  {`<Table scrollHorizontally noWrap>
   <THead>
     <Tr>
       <Th>Date</Th>
@@ -1093,7 +1093,7 @@ and email addresses.
 ##### Th
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -1136,7 +1136,7 @@ and email addresses.
 ##### Td
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>
@@ -1237,7 +1237,7 @@ Sets the `table-layout` style of the Table. Defaults to `auto`.
 
 Sets the `border` style of the Table. Defaults to `default`.
 
-###### `isResponsive?: boolean`
+###### `scrollHorizontally?: boolean`
 
 Sets the table to scroll horizontally on small screens.
 

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -198,7 +198,7 @@ using the `select` function from the tab state to advance to the next tab, and g
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -198,7 +198,7 @@ using the `select` function from the tab state to advance to the next tab, and g
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -454,7 +454,7 @@ Use a textarea when users are expected to enter text that exceeds a single line,
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -454,7 +454,7 @@ Use a textarea when users are expected to enter text that exceeds a single line,
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/time-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/time-picker/index.mdx
@@ -104,7 +104,7 @@ It is used with the [Label](/components/label) and [Help Text](/components/help-
 Because browsers' implementations of the native time picker vary, this component <strong>may not be fully accessible</strong> in all cases. Chrome/Edge, Safari and Firefox all support the Time Picker, but the user experience differs browser-to-browser. Some of those differences are outlined below:
 
 <Box margin="space70">
-  <Table isResponsive variant="borderless">
+  <Table scrollHorizontally variant="borderless">
     <TBody>
       <Tr verticalAlign="middle">
         <Td textAlign="left">
@@ -403,7 +403,7 @@ Error text should:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/components/time-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/time-picker/index.mdx
@@ -104,7 +104,7 @@ It is used with the [Label](/components/label) and [Help Text](/components/help-
 Because browsers' implementations of the native time picker vary, this component <strong>may not be fully accessible</strong> in all cases. Chrome/Edge, Safari and Firefox all support the Time Picker, but the user experience differs browser-to-browser. Some of those differences are outlined below:
 
 <Box margin="space70">
-  <Table variant="borderless">
+  <Table isResponsive variant="borderless">
     <TBody>
       <Tr verticalAlign="middle">
         <Td textAlign="left">
@@ -403,7 +403,7 @@ Error text should:
 ## Anatomy
 
 <Box marginBottom="space60">
-  <Table tableLayout="fixed">
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th>Property</Th>

--- a/packages/paste-website/src/pages/patterns/empty-state/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-state/index.mdx
@@ -228,7 +228,7 @@ For all use cases:
 - Use an illustration only if it’s directly related to the message you’re communicating. Don’t use a random illustration to “fill in the blank.” The more that illustrations are used throughout our products, the more they lose their emotional and visual impact when it really matters. [Learn more about requesting a new illustration](/foundations/illustrations#request-new-illustrations).
 
 <Box marginBottom="space70">
-  <Table isResponsive>
+  <Table scrollHorizontally>
     <THead>
       <Tr>
         <Th width="200px">Use case</Th>

--- a/packages/paste-website/src/pages/patterns/empty-state/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-state/index.mdx
@@ -228,7 +228,7 @@ For all use cases:
 - Use an illustration only if it’s directly related to the message you’re communicating. Don’t use a random illustration to “fill in the blank.” The more that illustrations are used throughout our products, the more they lose their emotional and visual impact when it really matters. [Learn more about requesting a new illustration](/foundations/illustrations#request-new-illustrations).
 
 <Box marginBottom="space70">
-  <Table>
+  <Table isResponsive>
     <THead>
       <Tr>
         <Th width="200px">Use case</Th>

--- a/packages/paste-website/src/pages/patterns/index.mdx
+++ b/packages/paste-website/src/pages/patterns/index.mdx
@@ -105,7 +105,7 @@ There are two primary goals of patterns:
         </CalloutText>
       </Callout>
       <Box marginBottom="space60">
-        <Table tableLayout="fixed">
+        <Table isResponsive>
           <THead>
             <Tr>
               <Th>Pattern name</Th>

--- a/packages/paste-website/src/pages/patterns/index.mdx
+++ b/packages/paste-website/src/pages/patterns/index.mdx
@@ -105,7 +105,7 @@ There are two primary goals of patterns:
         </CalloutText>
       </Callout>
       <Box marginBottom="space60">
-        <Table isResponsive>
+        <Table scrollHorizontally>
           <THead>
             <Tr>
               <Th>Pattern name</Th>

--- a/packages/paste-website/src/pages/patterns/status/index.mdx
+++ b/packages/paste-website/src/pages/patterns/status/index.mdx
@@ -207,7 +207,7 @@ used to 3 or 4 of the most important statuses. For statuses that are not as crit
 
 #### Icon and token pairings
 
-<Table>
+<Table isResponsive>
   <THead>
     <Tr>
       <Th>Icon</Th>
@@ -315,7 +315,7 @@ Connectivity statuses are used to show if a user, object, or system is online or
 
 #### Connectivity icon and token pairings
 
-<Table>
+<Table isResponsive>
   <THead>
     <Tr>
       <Th>Icon</Th>

--- a/packages/paste-website/src/pages/patterns/status/index.mdx
+++ b/packages/paste-website/src/pages/patterns/status/index.mdx
@@ -207,7 +207,7 @@ used to 3 or 4 of the most important statuses. For statuses that are not as crit
 
 #### Icon and token pairings
 
-<Table isResponsive>
+<Table scrollHorizontally>
   <THead>
     <Tr>
       <Th>Icon</Th>
@@ -315,7 +315,7 @@ Connectivity statuses are used to show if a user, object, or system is online or
 
 #### Connectivity icon and token pairings
 
-<Table isResponsive>
+<Table scrollHorizontally>
   <THead>
     <Tr>
       <Th>Icon</Th>


### PR DESCRIPTION
By default the datagrid is responsive, and horizontally scrolls. This is unlike past Twilio tables and causes data dense grids to have a lot of content scrolled off screen.

In this PR we implement responsive table support in the base Table component. We support noWrap for not line breaking cell content. We make the default behavior for a data grid, non-responsive to mimic better the default table behaviour and inherit the responsive options from the base Table.