### PR TITLE
chore(select): set background color

### DIFF
--- a/.changeset/curvy-hounds-yawn.md
+++ b/.changeset/curvy-hounds-yawn.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/select': patch
+'@twilio-paste/core': patch
+---
+
+[Select] set background color on Select to colorBackgroundBody

--- a/packages/paste-core/components/select/src/Select.tsx
+++ b/packages/paste-core/components/select/src/Select.tsx
@@ -31,7 +31,7 @@ export const SelectElement = React.forwardRef<HTMLSelectElement, SelectProps>(
         // We want the size attribute on the HTML element to set the height, not the css
         height={undefined}
         appearance="none"
-        backgroundColor={variant === 'inverse' ? 'colorBackgroundInverse' : 'colorBackground'}
+        backgroundColor={variant === 'inverse' ? 'colorBackgroundInverse' : 'colorBackgroundBody'}
         border="none"
         borderRadius="borderRadius20"
         boxShadow="none"


### PR DESCRIPTION
Updates the background color of Select to `colorBackgroundBody` so that the Select doesn't look disabled. Updates a change from PR #2242 to fix an issue found in Discussion #2305.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
