### PR TITLE
fix(spinner): match title prop types to types

### DIFF
--- a/.changeset/mean-starfishes-share.md
+++ b/.changeset/mean-starfishes-share.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/spinner': patch
+'@twilio-paste/core': patch
+---
+
+[Spinner] title is no longer required. Matching prop types to typescript types

--- a/packages/paste-core/components/spinner/src/index.tsx
+++ b/packages/paste-core/components/spinner/src/index.tsx
@@ -60,7 +60,7 @@ const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
 Spinner.displayName = 'Spinner';
 
 Spinner.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   delay: PropTypes.number,
   element: PropTypes.string,
   size: isIconSizeTokenProp,


### PR DESCRIPTION
When up dating the spinner title requirements we forgot to update the prop types to go with it.

It is hard to tell when prop types don't match types as we don't explicitly check them anywhere.

This became visible in the newer jest setup.
