### PR TITLE
chore: adjust styling library changeset to prevent sweeping major versions

### DIFF
--- a/.changeset/spotty-lobsters-impress.md
+++ b/.changeset/spotty-lobsters-impress.md
@@ -1,6 +1,6 @@
 ---
-'@twilio-paste/styling-library': minor
-'@twilio-paste/core': minor
+'@twilio-paste/styling-library': patch
+'@twilio-paste/core': patch
 ---
 
 [Styling library] two new exports from styled system, `props` and `createShouldForwardProp`.


### PR DESCRIPTION
Right now, because styling library is still a v0.x.x, a minor update will cause a range mismatch, and trigger a major version bump for everything down the dependency tree. This is a little bit of a limitation of changesets versioning approach to peer dependencies. If it was a v1.x.x this wouldn't happen with a minor.

Ideally, we wouldn't trigger a major version bump just for that right now.  see https://github.com/twilio-labs/paste/pull/2314

We can address all non-alpha packages, not being v1.x.x in a later PR to prevent further instances of this.