### PR TITLE
fix(combobox): grouped combobox scroll

### DIFF
--- a/.changeset/loud-bags-jog.md
+++ b/.changeset/loud-bags-jog.md
@@ -1,5 +1,6 @@
 ---
 '@twilio-paste/combobox': minor
+'@twilio-paste/core': minor
 ---
 
 [Fix] Remediate erratic scrolling behavior for grouped combobox. Scroll function for the virtualization library was being called even though grouped comboboxes are not virtualized. The jumping behavior on scroll was observed because the indices in the virtual list and the actual list did not match. Added guard to prevent the scroll function from the virtualization library from being called.

--- a/.changeset/loud-bags-jog.md
+++ b/.changeset/loud-bags-jog.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/combobox': minor
+---
+
+[Fix] Remediate erratic scrolling behavior for grouped combobox. Scroll function for the virtualization library was being called even though grouped comboboxes are not virtualized. The jumping behavior on scroll was observed because the indices in the virtual list and the actual list did not match. Added guard to prevent the scroll function from the virtualization library from being called.

--- a/packages/paste-codemods/tools/.cache/mappings.json
+++ b/packages/paste-codemods/tools/.cache/mappings.json
@@ -20,7 +20,6 @@
   "Card": "@twilio-paste/core/card",
   "ChatBubble": "@twilio-paste/core/chat-log",
   "ChatMessage": "@twilio-paste/core/chat-log",
-  "MessageVariantContext": "@twilio-paste/core/chat-log",
   "Checkbox": "@twilio-paste/core/checkbox",
   "CheckboxDisclaimer": "@twilio-paste/core/checkbox",
   "CheckboxGroup": "@twilio-paste/core/checkbox",

--- a/packages/paste-codemods/tools/.cache/mappings.json
+++ b/packages/paste-codemods/tools/.cache/mappings.json
@@ -20,6 +20,7 @@
   "Card": "@twilio-paste/core/card",
   "ChatBubble": "@twilio-paste/core/chat-log",
   "ChatMessage": "@twilio-paste/core/chat-log",
+  "MessageVariantContext": "@twilio-paste/core/chat-log",
   "Checkbox": "@twilio-paste/core/checkbox",
   "CheckboxDisclaimer": "@twilio-paste/core/checkbox",
   "CheckboxGroup": "@twilio-paste/core/checkbox",

--- a/packages/paste-core/components/combobox/src/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/Combobox.tsx
@@ -103,10 +103,13 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
     });
 
     React.useEffect(() => {
-      if (highlightedIndex !== undefined && typeof scrollToIndex === 'function' && highlightedIndex > -1) {
-        scrollToIndex(highlightedIndex);
+      const comboboxIsVirtualized = typeof groupItemsBy !== 'string';
+      if (comboboxIsVirtualized) {
+        if (highlightedIndex !== undefined && typeof scrollToIndex === 'function' && highlightedIndex > -1) {
+          scrollToIndex(highlightedIndex);
+        }
       }
-    }, [highlightedIndex, scrollToIndex]);
+    }, [highlightedIndex, scrollToIndex, groupItemsBy]);
 
     if (
       getComboboxProps === undefined ||


### PR DESCRIPTION
## Description
Issue reported: [Issue 2308](https://github.com/twilio-labs/paste/issues/2308)

**tl;dr** Adds a conditional guard to a side effect hook that syncs virtual scroll position with current highlighted index when the combobox has grouped items.

### Summary of changes
Grouped comboboxes are not yet virtualized because we cannot yet do so accessibly. The main component ([Combobox.tsx](https://github.com/twilio-labs/paste/pull/2335/files#diff-22b2d509777ec919245d83593056eb5d0c5ac23808f3b543b288425b985cb360L106)) was running a side effect (`useEffect`) that syncs the virtualized list position according to the highlighted index. This caused increasingly erratic scrolling behavior (with continued scrolling) because the scrolling function is not "calibrated" correctly for the non-virtualized grouped list.

To resolve this we:
- check if the combobox is grouped by determining if a key was provided by which to group items (`groupItemsBy` prop)
- If grouped, the effect logic is skipped; if not, it runs
- added unit tests for grouped, controlled, and basic comboboxes to confirm that the scroll function runs or not as is appropriate

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
