### PR TITLE
chore(alert): add a pseudo-localization story

### DIFF
--- a/@types/pseudo-localization/index.d.ts
+++ b/@types/pseudo-localization/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'pseudo-localization';

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "precise-commits": "^1.0.2",
     "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
+    "pseudo-localization": "2.1.1",
     "puppeteer-core": "^10.1.0",
     "react": "^17.0.2",
     "react-16": "npm:react@^16.8.6",

--- a/packages/paste-core/components/alert/stories/i18n.stories.tsx
+++ b/packages/paste-core/components/alert/stories/i18n.stories.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import {action} from '@storybook/addon-actions';
+import {Text} from '@twilio-paste/text';
+import pseudoLocalization from 'pseudo-localization';
+import {Alert} from '../src';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Components/Alert/i18n',
+  component: Alert,
+};
+
+const i18nStrings = {
+  i18nDismissLabel: "Fermez l'alerte",
+  i18nErrorLabel: '(erreur)',
+  i18nWarningLabel: '(avertissement)',
+  i18nNeutralLabel: '(information)',
+};
+
+export const I18nAlerts = (): React.ReactNode => {
+  return (
+    <>
+      <Alert variant="error" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte d&apos;erreur.</Text>
+      </Alert>
+      <Alert variant="warning" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte d&apos;avertissement.</Text>
+      </Alert>
+      <Alert variant="neutral" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte neutre.</Text>
+      </Alert>
+    </>
+  );
+};
+I18nAlerts.storyName = 'i18n Alerts';
+
+export const I18nAlertsPseudoLocalized = (): React.ReactNode => {
+  React.useEffect(() => {
+    pseudoLocalization.start();
+
+    return () => {
+      pseudoLocalization.stop();
+    };
+  }, []);
+
+  return (
+    <>
+      <Alert variant="error" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte d&apos;erreur.</Text>
+      </Alert>
+      <Alert variant="warning" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte d&apos;avertissement.</Text>
+      </Alert>
+      <Alert variant="neutral" {...i18nStrings} onDismiss={action('dismiss')}>
+        <Text as="div">C&apos;est une alerte neutre.</Text>
+      </Alert>
+    </>
+  );
+};
+I18nAlertsPseudoLocalized.storyName = 'i18n Alerts - Pseudo-localized';

--- a/packages/paste-core/components/alert/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert/stories/index.stories.tsx
@@ -199,27 +199,3 @@ export const CustomAlert = (): React.ReactNode => {
     </CustomizationProvider>
   );
 };
-
-export const I18nAlerts = (): React.ReactNode => {
-  const i18nStrings = {
-    i18nDismissLabel: "Fermez l'alerte",
-    i18nErrorLabel: '(erreur)',
-    i18nWarningLabel: '(avertissement)',
-    i18nNeutralLabel: '(information)',
-  };
-  return (
-    <>
-      <Alert variant="error" {...i18nStrings} onDismiss={action('dismiss')}>
-        <Text as="div">C&apos;est une alerte d&apos;erreur.</Text>
-      </Alert>
-      <Alert variant="warning" {...i18nStrings} onDismiss={action('dismiss')}>
-        <Text as="div">C&apos;est une alerte d&apos;avertissement.</Text>
-      </Alert>
-      <Alert variant="neutral" {...i18nStrings} onDismiss={action('dismiss')}>
-        <Text as="div">C&apos;est une alerte neutre.</Text>
-      </Alert>
-    </>
-  );
-};
-
-I18nAlerts.storyName = 'i18n Alerts';

--- a/yarn.lock
+++ b/yarn.lock
@@ -40837,6 +40837,7 @@ is-whitespace@latest:
     precise-commits: ^1.0.2
     prettier: ^2.2.1
     prop-types: ^15.7.2
+    pseudo-localization: 2.1.1
     puppeteer-core: ^10.1.0
     react: ^17.0.2
     react-16: "npm:react@^16.8.6"
@@ -42945,6 +42946,18 @@ is-whitespace@latest:
   bin:
     ps-tree: ./bin/ps-tree.js
   checksum: e635dd00f53d30d31696cf5f95b3a8dbdf9b1aeb36d4391578ce8e8cd22949b7c5536c73b0dc18c78615ea3ddd4be96101166be59ca2e3e3cb1e2f79ba3c7f98
+  languageName: node
+  linkType: hard
+
+"pseudo-localization@npm:2.1.1":
+  version: 2.1.1
+  resolution: "pseudo-localization@npm:2.1.1"
+  dependencies:
+    get-stdin: ^7.0.0
+    yargs: ^13.3.0
+  bin:
+    pseudo-localization: ./bin/pseudo-localize
+  checksum: fd866ade5943e7768413507989925f08f437e6806e0110c6b6a0af54df41208810503f03c0c7b441bd75762bc0220a4b769d4d26585a1c71b31a5aa48aedfcf0
   languageName: node
   linkType: hard
 
@@ -53079,7 +53092,7 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"yargs@npm:^13.2.4, yargs@npm:^13.3.2":
+"yargs@npm:^13.2.4, yargs@npm:^13.3.0, yargs@npm:^13.3.2":
   version: 13.3.2
   resolution: "yargs@npm:13.3.2"
   dependencies:


### PR DESCRIPTION
## What this PR does:

- [x] Add a [pseudo-localization library](https://github.com/tryggvigy/pseudo-localization)
- [x] Adds an example story for the Alert package
- [x] Reorganizes the Alert stories to display a i18n sub-folder for those specific stories
 
## Why

> Pseudolocalization (or pseudo-localization) is a [software testing](https://en.wikipedia.org/wiki/Software_testing) method used for testing [internationalization](https://en.wikipedia.org/wiki/Internationalization_and_localization) aspects of software. Instead of translating the text of the software into a foreign language, as in the process of [localization](https://en.wikipedia.org/wiki/Language_localisation), the textual elements of an application are replaced with an altered version of the original language. For example, instead of "Account Settings", the text would be altered to display as "!!! Àççôûñţ Šéţţîñĝš !!!".[[1]](https://en.wikipedia.org/wiki/Pseudolocalization#cite_note-babblepseudo-1)

> These specific alterations make the original words appear readable, but include the most problematic characteristics of the world's languages: varying length of text or characters, language direction, fit into the interface and so on.

https://en.wikipedia.org/wiki/Pseudolocalization