### PR TITLE
fix: correct close icon hover state

### DIFF
--- a/.changeset/eleven-mice-repair.md
+++ b/.changeset/eleven-mice-repair.md
@@ -6,4 +6,4 @@
 '@twilio-paste/core': patch
 ---
 
-Adjust close icon's hover state color, which was previously being overwritten.
+[Alert, Modal, Popover, Toast] Adjust close icon's hover state color, which was previously being overwritten.

--- a/.changeset/eleven-mice-repair.md
+++ b/.changeset/eleven-mice-repair.md
@@ -1,0 +1,9 @@
+---
+'@twilio-paste/alert': patch
+'@twilio-paste/modal': patch
+'@twilio-paste/popover': patch
+'@twilio-paste/toast': patch
+'@twilio-paste/core': patch
+---
+
+Adjust close icon's hover state color, which was previously being overwritten.

--- a/packages/paste-core/components/alert/src/index.tsx
+++ b/packages/paste-core/components/alert/src/index.tsx
@@ -138,7 +138,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           {onDismiss && typeof onDismiss === 'function' && (
             <MediaFigure align="end" spacing="space60">
               <Button onClick={onDismiss} variant="secondary_icon" size="reset" element={`${element}_DISMISS_BUTTON`}>
-                <CloseIcon element={`${element}_DISMISS_ICON`} color="colorTextIcon" decorative size="sizeIcon20" />
+                <CloseIcon element={`${element}_DISMISS_ICON`} decorative size="sizeIcon20" />
                 <ScreenReaderOnly>{i18nDismissLabel}</ScreenReaderOnly>
               </Button>
             </MediaFigure>

--- a/packages/paste-core/components/modal/src/ModalHeader.tsx
+++ b/packages/paste-core/components/modal/src/ModalHeader.tsx
@@ -24,7 +24,7 @@ const ModalHeader = React.forwardRef<HTMLHeadElement, ModalHeaderProps>(
             {children}
           </Flex>
           <Button element={`${element}_CLOSE_BUTTON`} variant="secondary_icon" size="reset" onClick={() => onDismiss()}>
-            <CloseIcon element={`${element}_CLOSE_ICON`} decorative color="colorTextWeak" size="sizeIcon60" />
+            <CloseIcon element={`${element}_CLOSE_ICON`} decorative size="sizeIcon60" />
             <ScreenReaderOnly>{i18nDismissLabel}</ScreenReaderOnly>
           </Button>
         </Flex>

--- a/packages/paste-core/components/popover/src/Popover.tsx
+++ b/packages/paste-core/components/popover/src/Popover.tsx
@@ -57,7 +57,7 @@ const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
                 // https://reakit.io/docs/popover/#initial-focus
                 onClick={popover.hide}
               >
-                <CloseIcon element={`${element}_CLOSE_ICON`} decorative color="colorTextWeak" size="sizeIcon10" />
+                <CloseIcon element={`${element}_CLOSE_ICON`} decorative size="sizeIcon10" />
                 <ScreenReaderOnly>{i18nDismissLabel}</ScreenReaderOnly>
               </Button>
             </Box>

--- a/packages/paste-core/components/toast/src/Toast.tsx
+++ b/packages/paste-core/components/toast/src/Toast.tsx
@@ -118,7 +118,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                 size="reset"
                 element={`${element}_CLOSE_BUTTON`}
               >
-                <CloseIcon color="colorTextIcon" decorative size="sizeIcon20" element={`${element}_CLOSE_ICON`} />
+                <CloseIcon decorative size="sizeIcon20" element={`${element}_CLOSE_ICON`} />
                 <ScreenReaderOnly>{i18nDismissLabel}</ScreenReaderOnly>
               </Button>
             </MediaFigure>


### PR DESCRIPTION
Hover states for the close icons on our components weren't showing up; as conjectured in the ticket, this is because they were being overwritten by color props in the CloseIcon components that were left behind from the previous implementation (before the `secondary_icon` variant in button). Taking those props out fixes this.

- [x] I acknowledge that all my contributions will be made under the project's license.
