### PR TITLE
fix(website): make github icon visible in dark mode

### DIFF
--- a/packages/paste-website/src/components/shortcodes/component-header/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/component-header/index.tsx
@@ -64,6 +64,8 @@ const ComponentHeader: React.FC<ComponentHeaderProps> = ({
     display: 'inline-block',
   };
 
+  const githubIconColor = theme.textColors.colorTextIcon;
+
   const categoryName = getCategoryNameFromRoute(categoryRoute);
   const isFoundations = categoryRoute === SidebarCategoryRoutes.FOUNDATIONS;
   const shouldHavePreview = [SidebarCategoryRoutes.COMPONENTS, SidebarCategoryRoutes.PRIMITIVES].includes(
@@ -111,7 +113,7 @@ const ComponentHeader: React.FC<ComponentHeaderProps> = ({
             {githubUrl && (
               <IconAnchor
                 href={githubUrl}
-                icon={<GithubIcon css={{...sharedIconStyles, color: '#191717'}} decorative />}
+                icon={<GithubIcon css={{...sharedIconStyles, color: githubIconColor}} decorative />}
               >
                 Github
               </IconAnchor>


### PR DESCRIPTION
This PR updates the color of the github icon in the page headers to be visible in both light theme and dark theme. The icon color is now coming from theme instead of being a hardcoded string.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
