### PR TITLE
chore(docs): add element prop to all component props tables

### DIFF
--- a/packages/paste-website/src/pages/components/alert-dialog/index.mdx
+++ b/packages/paste-website/src/pages/components/alert-dialog/index.mdx
@@ -215,15 +215,16 @@ const AlertDialogExample = () => {
 
 #### Props
 
-| Prop           | Type                 | Description | Default |
-| -------------- | -------------------- | ----------- | ------- |
-| children       | `ReactNode`          |             | null    |
-| isOpen         | `boolean`            |             | null    |
-| destructive?   | `boolean`            |             | null    |
-| onConfirmLabel | `string`             |             | null    |
-| onConfirm      | `Function() => void` |             | null    |
-| onDismissLabel | `string`             |             | null    |
-| onDismiss      | `Function() => void` |             | null    |
+| Prop           | Type                 | Description                                                                               | Default        |
+| -------------- | -------------------- | ----------------------------------------------------------------------------------------- | -------------- |
+| children       | `ReactNode`          |                                                                                           | null           |
+| isOpen         | `boolean`            |                                                                                           | null           |
+| destructive?   | `boolean`            |                                                                                           | null           |
+| onConfirmLabel | `string`             |                                                                                           | null           |
+| onConfirm      | `Function() => void` |                                                                                           | null           |
+| onDismissLabel | `string`             |                                                                                           | null           |
+| onDismiss      | `Function() => void` |                                                                                           | null           |
+| element?       | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'ALERT_DIALOG' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/alert/index.mdx
+++ b/packages/paste-website/src/pages/components/alert/index.mdx
@@ -393,6 +393,7 @@ const Component = () => (
 | i18nErrorLabel?   | `string`     | Icon label text for the `error` variant                                                          | '(error)'       |
 | i18nNeutralLabel? | `string`     | Icon label text for the `neutral` variant                                                        | '(information)' |
 | i18nWarningLabel? | `string`     | Icon label text for the `warning` variant                                                        | '(warning)'     |
+| element?          | `string`     | Overrides the default element name to apply unique styles with the Customization Provider        | 'ALERT'         |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -210,6 +210,7 @@ const Component = () => <Anchor href="https://paste.twilio.design">Go to Paste</
 | onFocus?              | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                         | null                                   |
 | onBlur?               | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                         | null                                   |
 | i18nExternalLinkLabel | string                                   | Title for `showExternal` icon                                                                           | '(link takes you to an external page)' |
+| element?              | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider               | 'ANCHOR'                               |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -263,6 +263,10 @@ Used to set the image `src` attribute when setting an image as the Avatar.
 
 Specify a Paste Icon to be displayed in the Avatar.
 
+##### `element` string
+
+Overrides the default element name ('AVATAR') to apply unique styles with the Customization Provider.
+
 <ChangelogRevealer>
   <Changelog />
 </ChangelogRevealer>

--- a/packages/paste-website/src/pages/components/badge/index.mdx
+++ b/packages/paste-website/src/pages/components/badge/index.mdx
@@ -605,6 +605,7 @@ const BadgeExample = () => (
 | as       | `BadgeBaseElements`                    | The HTML tag to use as base - `span`, `button`, `a`                                                                                                 | `null`      |
 | href?    | `string`                               | A URL to route to. Must use `as="a"` for this prop to work.                                                                                         | `undefined` |
 | onClick? | `MouseEventHandler<HTMLButtonElement>` | React event handler. Must use `as="button"` for this prop to work.                                                                                  | `undefined` |
+| element? | `string`                               | Overrides the default element name to apply unique styles with the Customization Provider                                                           | 'BADGE'     |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/breadcrumb/index.mdx
+++ b/packages/paste-website/src/pages/components/breadcrumb/index.mdx
@@ -304,11 +304,12 @@ const BreadcrumbExample: React.FC = () => {
 
 #### BreadcrumbItem Props
 
-| Prop     | Type        | Description                                                                | Default |
-| -------- | ----------- | -------------------------------------------------------------------------- | ------- |
-| children | `ReactNode` |                                                                            | null    |
-| href?    | `string`    | The URL the breadcrumb routes to.                                          | null    |
-| last?    | `boolean`   | If true, removes the `BreadcrumbSeparator` after the last breadcrumb item. | null    |
+| Prop     | Type        | Description                                                                               | Default      |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | ------------ |
+| children | `ReactNode` |                                                                                           | null         |
+| href?    | `string`    | The URL the breadcrumb routes to.                                                         | null         |
+| last?    | `boolean`   | If true, removes the `BreadcrumbSeparator` after the last breadcrumb item.                | null         |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'BREADCRUMB' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/button/index.mdx
+++ b/packages/paste-website/src/pages/components/button/index.mdx
@@ -575,6 +575,7 @@ All the valid HTML attributes for `Button` are supported including the following
 | onMouseLeave?          | `(event: React.MouseEvent<HTMLElement>)` |                                                                                                                                                                                      | null                                   |
 | onFocus?               | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                                                                      | null                                   |
 | onBlur?                | `(event: React.FocusEvent<HTMLElement>)` |                                                                                                                                                                                      | null                                   |
+| element?               | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider                                                                                            | 'BUTTON'                               |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/card/index.mdx
+++ b/packages/paste-website/src/pages/components/card/index.mdx
@@ -286,11 +286,12 @@ const Card = () => <Card>Hello world</Card>;
 
 #### Props
 
-| Prop            | Type            | Description                              | Default   |
-| --------------- | --------------- | ---------------------------------------- | --------- |
-| children?       | React.ReactNode | Child components to render into the card | undefined |
-| padding         | Spacing         | Internal spacing of the card             | space60   |
-| globalHtmlAttrs | string          | Any html attrs like aria, data etc.      | undefined |
+| Prop            | Type              | Description                                                                               | Default   |
+| --------------- | ----------------- | ----------------------------------------------------------------------------------------- | --------- |
+| children?       | `React.ReactNode` | Child components to render into the card                                                  | undefined |
+| padding         | `Spacing`         | Internal spacing of the card                                                              | space60   |
+| globalHtmlAttrs | `string`          | Any html attrs like aria, data etc.                                                       | undefined |
+| element?        | `string`          | Overrides the default element name to apply unique styles with the Customization Provider | 'CARD'    |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/checkbox/index.mdx
+++ b/packages/paste-website/src/pages/components/checkbox/index.mdx
@@ -445,51 +445,54 @@ const Component = () => (
 
 All the valid HTML attributes for `input[type=checkbox]` are supported including the following props:
 
-| Prop              | Type                                     | Description | Default |
-| ----------------- | ---------------------------------------- | ----------- | ------- |
-| children          | `ReactNode`                              |             | null    |
-| id?               | `string`                                 |             | null    |
-| checked?          | `boolean`                                |             | false   |
-| defaultChecked?   | `boolean`                                |             | null    |
-| hasError?         | `boolean`                                |             | false   |
-| helpText?         | `string` or `ReactNode`                  |             | null    |
-| indeterminate?    | `boolean`                                |             | false   |
-| isSelectAll?      | `boolean`                                |             | false   |
-| isSelectAllChild? | `boolean`                                |             | false   |
-| onChange?         | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onFocus?          | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onBlur?           | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
+| Prop              | Type                                     | Description                                                                               | Default    |
+| ----------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ---------- |
+| children          | `ReactNode`                              |                                                                                           | null       |
+| id?               | `string`                                 |                                                                                           | null       |
+| checked?          | `boolean`                                |                                                                                           | false      |
+| defaultChecked?   | `boolean`                                |                                                                                           | null       |
+| hasError?         | `boolean`                                |                                                                                           | false      |
+| helpText?         | `string` or `ReactNode`                  |                                                                                           | null       |
+| indeterminate?    | `boolean`                                |                                                                                           | false      |
+| isSelectAll?      | `boolean`                                |                                                                                           | false      |
+| isSelectAllChild? | `boolean`                                |                                                                                           | false      |
+| onChange?         | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| onFocus?          | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| onBlur?           | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| element?          | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'CHECKBOX' |
 
 #### CheckboxGroup props
 
-| Prop               | Type                                | Description                                   | Default      |
-| ------------------ | ----------------------------------- | --------------------------------------------- | ------------ |
-| children           | `ReactNode`                         |                                               | null         |
-| legend             | `string` or `ReactNode`             |                                               | null         |
-| name               | `string`                            |                                               | null         |
-| value              | `string`                            |                                               | null         |
-| orientation        | `oneOf(['vertical', 'horizontal'])` |                                               | vertical     |
-| errorText?         | `string` or `ReactNode`             |                                               | null         |
-| helpText?          | `string` or `ReactNode`             |                                               | null         |
-| disabled?          | `boolean`                           |                                               | false        |
-| required?          | `boolean`                           |                                               | false        |
-| isSelectAll?       | `boolean`                           |                                               | false        |
-| i18nRequiredLabel? | string                              | Label text for the required dot in the legend | '(required)' |
+| Prop               | Type                                | Description                                                                               | Default          |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| children           | `ReactNode`                         |                                                                                           | null             |
+| legend             | `string` or `ReactNode`             |                                                                                           | null             |
+| name               | `string`                            |                                                                                           | null             |
+| value              | `string`                            |                                                                                           | null             |
+| orientation        | `oneOf(['vertical', 'horizontal'])` |                                                                                           | vertical         |
+| errorText?         | `string` or `ReactNode`             |                                                                                           | null             |
+| helpText?          | `string` or `ReactNode`             |                                                                                           | null             |
+| disabled?          | `boolean`                           |                                                                                           | false            |
+| required?          | `boolean`                           |                                                                                           | false            |
+| isSelectAll?       | `boolean`                           |                                                                                           | false            |
+| i18nRequiredLabel? | `string`                            | Label text for the required dot in the legend                                             | '(required)'     |
+| element?           | `string`                            | Overrides the default element name to apply unique styles with the Customization Provider | 'CHECKBOX_GROUP' |
 
 #### CheckboxDisclaimer props
 
 All the valid HTML attributes for `input[type=checkbox]` are supported including the following props:
 
-| Prop            | Type                                     | Description | Default |
-| --------------- | ---------------------------------------- | ----------- | ------- |
-| children        | `ReactNode`                              |             | null    |
-| id?             | `string`                                 |             | null    |
-| checked?        | `boolean`                                |             | false   |
-| defaultChecked? | `boolean`                                |             | null    |
-| errorText?      | `string` or `ReactNode`                  |             | null    |
-| onChange?       | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onFocus?        | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onBlur?         | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
+| Prop            | Type                                     | Description                                                                               | Default               |
+| --------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
+| children        | `ReactNode`                              |                                                                                           | null                  |
+| id?             | `string`                                 |                                                                                           | null                  |
+| checked?        | `boolean`                                |                                                                                           | false                 |
+| defaultChecked? | `boolean`                                |                                                                                           | null                  |
+| errorText?      | `string` or `ReactNode`                  |                                                                                           | null                  |
+| onChange?       | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null                  |
+| onFocus?        | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null                  |
+| onBlur?         | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null                  |
+| element?        | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'CHECKBOX_DISCLAIMER' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -467,6 +467,10 @@ Used to set the Selected Item of the Combobox.
 
 Used as a replacement the state props when coupled with using the `useCombobox` hook. When using this prop, all other state props are **ignored**. They must be passed to `useCombobox` as arguments instead.
 
+##### `element?: string`
+
+Overrides the default element name ('COMBOBOX') to apply unique styles with the Customization Provider
+
 #### useCombobox arguments
 
 See the [Combobox Primitive](/primitives/combobox-primitive#usecomboboxprimitive-arguments).

--- a/packages/paste-website/src/pages/components/data-grid/index.mdx
+++ b/packages/paste-website/src/pages/components/data-grid/index.mdx
@@ -351,74 +351,74 @@ const Component = () => (
 
 #### DataGrid Props
 
-| Prop                | Type                    | Description                                                     | Default     |
-| ------------------- | ----------------------- | --------------------------------------------------------------- | ----------- |
-| aria-label          | `string`                | Defines a string value that labels the current element.         | null        |
-| striped?            | `boolean`               | Toggles row zebra striping                                      | false       |
-| scrollHorizontally? | `boolean`               | Sets the table to scroll horizontally on small screens.         | false       |
-| noWrap?             | `boolean`               | Sets the table cells to not line wrap.                          | false       |
-| tableLayout?        | "auto", "fixed"         | Sets the `table-layout` style of the Table. Defaults to `auto`. | false       |
-| variant?            | "default", "borderless" | Sets the `border` style of the Table. Defaults to `default`.    | false       |
-| element?            | `string`                | Override for customization element name                         | `DATA_GRID` |
-| children?           | `ReactNode`             |                                                                 | null        |
+| Prop                | Type                    | Description                                                                               | Default     |
+| ------------------- | ----------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| aria-label          | `string`                | Defines a string value that labels the current element.                                   | null        |
+| striped?            | `boolean`               | Toggles row zebra striping                                                                | false       |
+| scrollHorizontally? | `boolean`               | Sets the table to scroll horizontally on small screens.                                   | false       |
+| noWrap?             | `boolean`               | Sets the table cells to not line wrap.                                                    | false       |
+| tableLayout?        | "auto", "fixed"         | Sets the `table-layout` style of the Table. Defaults to `auto`.                           | false       |
+| variant?            | "default", "borderless" | Sets the `border` style of the Table. Defaults to `default`.                              | false       |
+| element?            | `string`                | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID` |
+| children?           | `ReactNode`             |                                                                                           | null        |
 
 #### DataGridHead Props
 
-| Prop      | Type        | Description                             | Default          |
-| --------- | ----------- | --------------------------------------- | ---------------- |
-| element?  | `string`    | Override for customization element name | `DATA_GRID_HEAD` |
-| children? | `ReactNode` |                                         | null             |
+| Prop      | Type        | Description                                                                               | Default          |
+| --------- | ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| element?  | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_HEAD` |
+| children? | `ReactNode` |                                                                                           | null             |
 
 #### DataGridBody Props
 
-| Prop      | Type        | Description                             | Default          |
-| --------- | ----------- | --------------------------------------- | ---------------- |
-| element?  | `string`    | Override for customization element name | `DATA_GRID_BODY` |
-| children? | `ReactNode` |                                         | null             |
+| Prop      | Type        | Description                                                                               | Default          |
+| --------- | ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| element?  | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_BODY` |
+| children? | `ReactNode` |                                                                                           | null             |
 
 #### DataGridFoot Props
 
-| Prop      | Type        | Description                             | Default          |
-| --------- | ----------- | --------------------------------------- | ---------------- |
-| element?  | `string`    | Override for customization element name | `DATA_GRID_FOOT` |
-| children? | `ReactNode` |                                         | null             |
+| Prop      | Type        | Description                                                                               | Default          |
+| --------- | ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| element?  | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_FOOT` |
+| children? | `ReactNode` |                                                                                           | null             |
 
 #### DataGridHeader Props
 
-| Prop       | Type        | Description                                  | Default            |
-| ---------- | ----------- | -------------------------------------------- | ------------------ |
-| textAlign? | `string`    | CSS text align for this cell                 | `left`             |
-| width?     | `string`    | Allows setting column width programmatically | null               |
-| element?   | `string`    | Override for customization element name      | `DATA_GRID_HEADER` |
-| children?  | `ReactNode` |                                              | null               |
+| Prop       | Type        | Description                                                                               | Default            |
+| ---------- | ----------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| textAlign? | `string`    | CSS text align for this cell                                                              | `left`             |
+| width?     | `string`    | Allows setting column width programmatically                                              | null               |
+| element?   | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_HEADER` |
+| children?  | `ReactNode` |                                                                                           | null               |
 
 #### DataGridHeaderSort Props
 
-| Prop                 | Type                              | Description                                                       | Default                 |
-| -------------------- | --------------------------------- | ----------------------------------------------------------------- | ----------------------- |
-| direction            | "ascending", "descending", "none" | Sort direction matching aria spec                                 | null                    |
-| onClick?             | `() => {}`                        | Callback when the sort button is pressed. Used to handle sorting. | null                    |
-| element?             | `string`                          | Override for customization element name                           | `DATA_GRID_HEADER_SORT` |
-| i18nAscendingLabel?  | `string`                          | Sort button label text when `direction` is "ascending"            | `'Sort ascending'`      |
-| i18nDescendingLabel? | `string`                          | Sort button label text when `direction` is "descending"           | `'Sort descending'`     |
-| i18nUnsortedLabel?   | `string`                          | Sort button label text when `direction` is "none"                 | `'Unsorted'`            |
+| Prop                 | Type                              | Description                                                                               | Default                 |
+| -------------------- | --------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
+| direction            | "ascending", "descending", "none" | Sort direction matching aria spec                                                         | null                    |
+| onClick?             | `() => {}`                        | Callback when the sort button is pressed. Used to handle sorting.                         | null                    |
+| element?             | `string`                          | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_HEADER_SORT` |
+| i18nAscendingLabel?  | `string`                          | Sort button label text when `direction` is "ascending"                                    | `'Sort ascending'`      |
+| i18nDescendingLabel? | `string`                          | Sort button label text when `direction` is "descending"                                   | `'Sort descending'`     |
+| i18nUnsortedLabel?   | `string`                          | Sort button label text when `direction` is "none"                                         | `'Unsorted'`            |
 
 #### DataGridRow Props
 
-| Prop      | Type        | Description                                                                    | Default         |
-| --------- | ----------- | ------------------------------------------------------------------------------ | --------------- |
-| selected? | `boolean`   | Visally displays a row highlight indicating selection and sets `aria-selected` | false           |
-| element?  | `string`    | Override for customization element name                                        | `DATA_GRID_ROW` |
-| children? | `ReactNode` |                                                                                | null            |
+| Prop      | Type        | Description                                                                               | Default         |
+| --------- | ----------- | ----------------------------------------------------------------------------------------- | --------------- |
+| selected? | `boolean`   | Visally displays a row highlight indicating selection and sets `aria-selected`            | false           |
+| element?  | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_ROW` |
+| children? | `ReactNode` |                                                                                           | null            |
 
 #### DataGridCell Props
 
-| Prop       | Type        | Description                                             | Default          |
-| ---------- | ----------- | ------------------------------------------------------- | ---------------- |
-| as?        | "th", "td"  | Cells can either be th or td, so rows can have headers. | `td`             |
-| textAlign? | `string`    | CSS text align for this cell                            | `left`           |
-| element?   | `string`    | Override for customization element name                 | `DATA_GRID_CELL` |
-| children?  | `ReactNode` |                                                         | null             |
+| Prop       | Type        | Description                                                                               | Default          |
+| ---------- | ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| as?        | "th", "td"  | Cells can either be th or td, so rows can have headers.                                   | `td`             |
+| textAlign? | `string`    | CSS text align for this cell                                                              | `left`           |
+| element?   | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | `DATA_GRID_CELL` |
+| children?  | `ReactNode` |                                                                                           | null             |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/date-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/date-picker/index.mdx
@@ -574,21 +574,22 @@ const DatePickerExample = () => {
 
 All the valid HTML attributes for `input` (except `type`) are supported, including the following props:
 
-| Prop      | Type                                     | Description                                                          | Default   |
-| --------- | ---------------------------------------- | -------------------------------------------------------------------- | --------- |
-| id?       | string                                   | Sets the id of the date picker. Should match the htmlFor of `Label`. | null      |
-| name?     | string                                   | Sets the name of the date picker.                                    | null      |
-| value?    | string                                   | Sets the value of the date picker.                                   | null      |
-| disabled? | boolean                                  | Disables the date picker.                                            | false     |
-| readOnly? | boolean                                  | Sets the date picker to readonly.                                    | false     |
-| required? | boolean                                  | Sets the date picker as required.                                    | false     |
-| hasError? | boolean                                  | Sets the date picker to an error state.                              | false     |
-| min?      | string                                   | Sets the earliest valid date value.                                  | null      |
-| max?      | string                                   | Sets the last valid date value.                                      | null      |
-| onChange? | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| variant?  | 'default', 'inverse'                     |                                                                      | 'default' |
+| Prop      | Type                                     | Description                                                                               | Default      |
+| --------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ------------ |
+| id?       | string                                   | Sets the id of the date picker. Should match the htmlFor of `Label`.                      | null         |
+| name?     | string                                   | Sets the name of the date picker.                                                         | null         |
+| value?    | string                                   | Sets the value of the date picker.                                                        | null         |
+| disabled? | boolean                                  | Disables the date picker.                                                                 | false        |
+| readOnly? | boolean                                  | Sets the date picker to readonly.                                                         | false        |
+| required? | boolean                                  | Sets the date picker as required.                                                         | false        |
+| hasError? | boolean                                  | Sets the date picker to an error state.                                                   | false        |
+| min?      | string                                   | Sets the earliest valid date value.                                                       | null         |
+| max?      | string                                   | Sets the last valid date value.                                                           | null         |
+| onChange? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| variant?  | 'default', 'inverse'                     |                                                                                           | 'default'    |
+| element?  | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'DATEPICKER' |
 
 #### formatReturnDate() props
 

--- a/packages/paste-website/src/pages/components/disclosure/index.mdx
+++ b/packages/paste-website/src/pages/components/disclosure/index.mdx
@@ -501,6 +501,10 @@ Whether it's visible or not.
 
 Changes the styling on the component based on the variant selected.
 
+##### `element?: string`
+
+Overrides the default element name ('DISCLOSURE') to apply unique styles with the Customization Provider
+
 #### DisclosureHeading Props
 
 All the regular HTML attributes (`role`, `aria-*`, `type`, and so on).
@@ -517,9 +521,17 @@ Same as the HTML attribute.
 
 When an element is `disabled`, it may still be `focusable`. It works similarly to `readOnly` on form elements. In this case, only `aria-disabled` will be set.
 
+##### `element?: string`
+
+Overrides the default element name ('DISCLOSURE_HEADING') to apply unique styles with the Customization Provider
+
 #### DisclosureContent Props
 
 All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
+
+##### `element?: string`
+
+Overrides the default element name ('DISCLOSURE_CONTENT') to apply unique styles with the Customization Provider
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/display-pill-group/index.mdx
+++ b/packages/paste-website/src/pages/components/display-pill-group/index.mdx
@@ -205,7 +205,7 @@ Defines a string value that labels the current element.
 
 ###### `element?: string`
 
-Set a custom element name. Default: `DISPLAY_PILL_GROUP`
+Overrides the default element name ('DISPLAY_PILL_GROUP') to apply unique styles with the Customization Provider
 
 ---
 
@@ -215,7 +215,7 @@ Set a custom element name. Default: `DISPLAY_PILL_GROUP`
 
 ###### `element?: string`
 
-Set a custom element name. Default: `DISPLAY_PILL`
+Overrides the default element name ('DISPLAY_PILL') to apply unique styles with the Customization Provider
 
 ###### `href?: string`
 

--- a/packages/paste-website/src/pages/components/form-pill-group/index.mdx
+++ b/packages/paste-website/src/pages/components/form-pill-group/index.mdx
@@ -288,7 +288,7 @@ Lists all the pill items with their id, DOM ref, disabled state and groupId if a
 
 ###### `element?: string`
 
-Set a custom element name. Default: `FORM_PILL_GROUP`
+Overrides the default element name ('FORM_PILL_GROUP') to apply unique styles with the Customization Provider
 
 ###### `focusable?: boolean`
 
@@ -448,7 +448,7 @@ Set if a pill is in a selected state.
 
 ###### `element?: string`
 
-Set a custom element name. Default: `FORM_PILL`
+Overrides the default element name ('FORM_PILL') to apply unique styles with the Customization Provider
 
 ###### `onSelect?: () => void`
 

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -235,13 +235,14 @@ const Component = () => (
 
 #### Props
 
-| Prop          | Type                           | Description                                                                               | Default |
-| ------------- | ------------------------------ | ----------------------------------------------------------------------------------------- | ------- |
-| as            | `asTags`                       | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                                | null    |
-| id?           | `string`                       |                                                                                           | null    |
-| marginBottom? | `oneOf(['space0'])`            | Currently we only allow `space0` to remove bottom margin                                  | null    |
-| variant       | `headingVariants`              | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'              | null    |
-| display?      | `CSS display property options` | 'block', 'inline', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid', and more | "block" |
+| Prop          | Type                           | Description                                                                               | Default   |
+| ------------- | ------------------------------ | ----------------------------------------------------------------------------------------- | --------- |
+| as            | `asTags`                       | 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'label', 'span'                                | null      |
+| id?           | `string`                       |                                                                                           | null      |
+| marginBottom? | `oneOf(['space0'])`            | Currently we only allow `space0` to remove bottom margin                                  | null      |
+| variant       | `headingVariants`              | 'heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'              | null      |
+| display?      | `CSS display property options` | 'block', 'inline', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid', and more | "block"   |
+| element?      | `string`                       | Overrides the default element name to apply unique styles with the Customization Provider | 'HEADING' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/help-text/index.mdx
+++ b/packages/paste-website/src/pages/components/help-text/index.mdx
@@ -358,11 +358,12 @@ const Component = () => (
 
 All the [valid HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) (role, aria-\*, type, and so on) are supported including the following props:
 
-| Prop       | Type                                           | Description                               | Default   |
-| ---------- | ---------------------------------------------- | ----------------------------------------- | --------- |
-| children?  | `ReactNode`                                    |                                           | null      |
-| marginTop? | 'space0'                                       | Sets the top margin on the `div` element. | 'space30' |
-| variant?   | 'default', 'error', 'error_inverse', 'inverse' | Changes the render state.                 | 'default' |
+| Prop       | Type                                           | Description                                                                               | Default     |
+| ---------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| children?  | `ReactNode`                                    |                                                                                           | null        |
+| marginTop? | 'space0'                                       | Sets the top margin on the `div` element.                                                 | 'space30'   |
+| variant?   | 'default', 'error', 'error_inverse', 'inverse' | Changes the render state.                                                                 | 'default'   |
+| element?   | `string`                                       | Overrides the default element name to apply unique styles with the Customization Provider | 'HELP_TEXT' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/icons/usage-guidelines/index.mdx
+++ b/packages/paste-website/src/pages/components/icons/usage-guidelines/index.mdx
@@ -199,6 +199,7 @@ import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
 | decorative | boolean                                | Whether or not the SVG is just visual flair or adds meaning to the page. Specifically for screenreaders to know whether to read out the title or not. |                |
 | size?      | IconSize                               | `sizeIcon10` `sizeIcon20` `sizeIcon30` `sizeIcon40`                                                                                                   | `sizeIcon20`   |
 | color?     | TextColor                              | Sets the icon color to any of our text color tokens or `currentColor`, which inherits text color from the parent element.                             | `currentColor` |
+| element?   | `string`                               | Overrides the default element name to apply unique styles with the Customization Provider                                                             | 'ICON'         |
 
 ---
 

--- a/packages/paste-website/src/pages/components/input/index.mdx
+++ b/packages/paste-website/src/pages/components/input/index.mdx
@@ -694,21 +694,22 @@ const Component = () => (
 
 All the valid HTML attributes for `input` are supported including the following props:
 
-| Prop         | Type                                                             | Description                                                    | Default   |
-| ------------ | ---------------------------------------------------------------- | -------------------------------------------------------------- | --------- |
-| id?          | string                                                           | Sets the id of the input. Should match the htmlFor of `Label`. | null      |
-| type         | 'text', 'email', 'hidden', 'number', 'password', 'search', 'tel' | Sets the type of the input. Required.                          | null      |
-| name?        | string                                                           | Sets the name of the input.                                    | null      |
-| value?       | string                                                           | Sets the value of the input.                                   | null      |
-| placeholder? | string                                                           | Sets the placeholder of the input.                             | null      |
-| disabled?    | boolean                                                          | Disables the input.                                            | false     |
-| readOnly?    | boolean                                                          | Sets the input to readonly.                                    | false     |
-| required?    | boolean                                                          | Sets the input as required.                                    | false     |
-| hasError?    | boolean                                                          | Sets the input to an error state.                              | false     |
-| onChange?    | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                | null      |
-| onFocus?     | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                | null      |
-| onBlur?      | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                | null      |
-| variant?     | 'default', 'inverse'                                             |                                                                | 'default' |
+| Prop         | Type                                                             | Description                                                                               | Default   |
+| ------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| id?          | string                                                           | Sets the id of the input. Should match the htmlFor of `Label`.                            | null      |
+| type         | 'text', 'email', 'hidden', 'number', 'password', 'search', 'tel' | Sets the type of the input. Required.                                                     | null      |
+| name?        | string                                                           | Sets the name of the input.                                                               | null      |
+| value?       | string                                                           | Sets the value of the input.                                                              | null      |
+| placeholder? | string                                                           | Sets the placeholder of the input.                                                        | null      |
+| disabled?    | boolean                                                          | Disables the input.                                                                       | false     |
+| readOnly?    | boolean                                                          | Sets the input to readonly.                                                               | false     |
+| required?    | boolean                                                          | Sets the input as required.                                                               | false     |
+| hasError?    | boolean                                                          | Sets the input to an error state.                                                         | false     |
+| onChange?    | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                                           | null      |
+| onFocus?     | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                                           | null      |
+| onBlur?      | `(event: React.MouseEvent<HTMLElement>)`                         |                                                                                           | null      |
+| variant?     | 'default', 'inverse'                                             |                                                                                           | 'default' |
+| element?     | `string`                                                         | Overrides the default element name to apply unique styles with the Customization Provider | 'INPUT'   |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/label/index.mdx
+++ b/packages/paste-website/src/pages/components/label/index.mdx
@@ -336,16 +336,17 @@ const Component = () => (
 
 All the valid HTML attributes for `label` are supported including the following props:
 
-| Prop               | Type                 | Description                                                          | Default   |
-| ------------------ | -------------------- | -------------------------------------------------------------------- | --------- |
-| as?                | 'label', 'legend'    | Choose the semantic HTML element the label is rendered as            | label     |
-| children?          | `ReactNode`          |                                                                      | null      |
-| htmlFor            | string               | Sets the for of the label. Should match the id of `Input`. Required. | null      |
-| disabled?          | boolean              | Shows the input is disabled.                                         | false     |
-| required?          | boolean              | Shows the input is required.                                         | false     |
-| marginBottom?      | 'space0', 'space10'  |                                                                      | 'space10' |
-| variant?           | 'default', 'inverse' |                                                                      | 'default' |
-| i18nRequiredLabel? | string               | Label text for the required dot                                      | ''        |
+| Prop               | Type                 | Description                                                                               | Default   |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| as?                | 'label', 'legend'    | Choose the semantic HTML element the label is rendered as                                 | label     |
+| children?          | `ReactNode`          |                                                                                           | null      |
+| htmlFor            | string               | Sets the for of the label. Should match the id of `Input`. Required.                      | null      |
+| disabled?          | boolean              | Shows the input is disabled.                                                              | false     |
+| required?          | boolean              | Shows the input is required.                                                              | false     |
+| marginBottom?      | 'space0', 'space10'  |                                                                                           | 'space10' |
+| variant?           | 'default', 'inverse' |                                                                                           | 'default' |
+| i18nRequiredLabel? | string               | Label text for the required dot                                                           | ''        |
+| element?           | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'LABEL'   |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/list/index.mdx
+++ b/packages/paste-website/src/pages/components/list/index.mdx
@@ -347,11 +347,12 @@ const Component = () => (
 
 #### Props
 
-| Prop          | Type                                         | Description | Default   |
-| ------------- | -------------------------------------------- | ----------- | --------- |
-| children?     | `ReactNode`                                  |             | null      |
-| marginTop?    | `ResponsiveValue<keyof ThemeShape['space']>` |             | null      |
-| marginBottom? | `ResponsiveValue<keyof ThemeShape['space']>` |             | 'space70' |
+| Prop          | Type                                         | Description                                                                               | Default   |
+| ------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| children?     | `ReactNode`                                  |                                                                                           | null      |
+| marginTop?    | `ResponsiveValue<keyof ThemeShape['space']>` |                                                                                           | null      |
+| marginBottom? | `ResponsiveValue<keyof ThemeShape['space']>` |                                                                                           | 'space70' |
+| element?      | `string`                                     | Overrides the default element name to apply unique styles with the Customization Provider | 'LIST'    |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/media-object/index.mdx
+++ b/packages/paste-website/src/pages/components/media-object/index.mdx
@@ -327,26 +327,29 @@ const Component = (props) => (
 
 #### MediaObject Props
 
-| Prop          | Type                              | Description                | Default |
-| ------------- | --------------------------------- | -------------------------- | ------- |
-| as            | keyof JSX.IntrinsicElements       |                            | 'span'  |
-| marginBottom  | [Spacing](/tokens/list/#spacings) |                            | null    |
-| marginTop     | [Spacing](/tokens/list/#spacings) |                            | null    |
-| verticalAlign | `center`, `top`                   | Aligns the figure and body | null    |
+| Prop          | Type                              | Description                                                                               | Default        |
+| ------------- | --------------------------------- | ----------------------------------------------------------------------------------------- | -------------- |
+| as            | keyof JSX.IntrinsicElements       |                                                                                           | 'span'         |
+| marginBottom  | [Spacing](/tokens/list/#spacings) |                                                                                           | null           |
+| marginTop     | [Spacing](/tokens/list/#spacings) |                                                                                           | null           |
+| verticalAlign | `center`, `top`                   | Aligns the figure and body                                                                | null           |
+| element?      | `string`                          | Overrides the default element name to apply unique styles with the Customization Provider | 'MEDIA_OBJECT' |
 
 #### MediaFigure Props
 
-| Prop    | Type                              | Description                       | Default |
-| ------- | --------------------------------- | --------------------------------- | ------- |
-| align   | `start`, `end`                    |                                   | 'start' |
-| as      | keyof JSX.IntrinsicElements       |                                   | 'span'  |
-| spacing | [Spacing](/tokens/list/#spacings) | Space between the figure and body | null    |
+| Prop     | Type                              | Description                                                                               | Default        |
+| -------- | --------------------------------- | ----------------------------------------------------------------------------------------- | -------------- |
+| align    | `start`, `end`                    |                                                                                           | 'start'        |
+| as       | keyof JSX.IntrinsicElements       |                                                                                           | 'span'         |
+| spacing  | [Spacing](/tokens/list/#spacings) | Space between the figure and body                                                         | null           |
+| element? | `string`                          | Overrides the default element name to apply unique styles with the Customization Provider | 'MEDIA_FIGURE' |
 
 #### MediaBody Props
 
-| Prop | Type                        | Description | Default |
-| ---- | --------------------------- | ----------- | ------- |
-| as   | keyof JSX.IntrinsicElements |             | 'span'  |
+| Prop     | Type                        | Description                                                                               | Default      |
+| -------- | --------------------------- | ----------------------------------------------------------------------------------------- | ------------ |
+| as       | keyof JSX.IntrinsicElements |                                                                                           | 'span'       |
+| element? | `string`                    | Overrides the default element name to apply unique styles with the Customization Provider | 'MEDIA_BODY' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/menu/index.mdx
+++ b/packages/paste-website/src/pages/components/menu/index.mdx
@@ -394,64 +394,36 @@ These props are returned by the state hook. You can spread them into this compon
 
 ##### Menu
 
-| Prop               | Type                 | Description                                                    | Default |
-| ------------------ | -------------------- | -------------------------------------------------------------- | ------- |
-| hideOnClickOutside | `boolean, undefined` | When enabled, user can hide the dialog by clicking outside it. |         |
-| disabled           | `boolean, undefined` | Same as the HTML attribute.                                    |         |
-
-##### MenuArrow
-
-| Prop | Type                        | Description | Default |
-| ---- | --------------------------- | ----------- | ------- |
-| size | `string, number, undefined` |             |         |
+| Prop               | Type                 | Description                                                                               | Default |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| hideOnClickOutside | `boolean, undefined` | When enabled, user can hide the dialog by clicking outside it.                            |         |
+| disabled           | `boolean, undefined` | Same as the HTML attribute.                                                               |         |
+| element?           | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'MENU'  |
 
 ##### MenuButton
 
-| Prop     | Type                 | Description                 | Default |
-| -------- | -------------------- | --------------------------- | ------- |
-| disabled | `boolean, undefined` | Same as the HTML attribute. |         |
-
-##### MenuDisclosure
-
-| Prop     | Type                 | Description                 | Default |
-| -------- | -------------------- | --------------------------- | ------- |
-| disabled | `boolean, undefined` | Same as the HTML attribute. |         |
+| Prop     | Type                 | Description                                                                               | Default       |
+| -------- | -------------------- | ----------------------------------------------------------------------------------------- | ------------- |
+| disabled | `boolean, undefined` | Same as the HTML attribute.                                                               |               |
+| element? | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'MENU_BUTTON' |
 
 ##### MenuGroup
 
-| Prop  | Type              | Description                                     | Default |
-| ----- | ----------------- | ----------------------------------------------- | ------- |
-| label | `string`          | Names the grouping                              |         |
-| icon  | `React.ReactNode` | One of our icon components. Must be decorative. |         |
+| Prop     | Type              | Description                                                                               | Default      |
+| -------- | ----------------- | ----------------------------------------------------------------------------------------- | ------------ |
+| label    | `string`          | Names the grouping                                                                        |              |
+| icon     | `React.ReactNode` | One of our icon components. Must be decorative.                                           |              |
+| element? | `string`          | Overrides the default element name to apply unique styles with the Customization Provider | 'MENU_GROUP' |
 
 ##### MenuItem
 
-| Prop     | Type                 | Description                 | Default |
-| -------- | -------------------- | --------------------------- | ------- |
-| disabled | `boolean, undefined` | Same as the HTML attribute. |         |
-| id       | `string, undefined`  | Same as the HTML attribute. |         |
-| onClick  | `() => void`         | Same as the HTML attribute. |         |
-| href     | `string, undefined`  | Same as the HTML attribute. |         |
-
-##### MenuItemCheckbox
-
-| Prop     | Type                        | Description                                                                                                                                        | Default |
-| -------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| disabled | `boolean, undefined`        | Same as the HTML attribute.                                                                                                                        |         |
-| value    | `string, number, undefined` | Checkbox's value is going to be used when multiple checkboxes share the same state. Checking a checkbox with value will add it to the state array. |         |
-| checked  | `boolean, undefined`        | Checkbox's checked state. If present, it's used instead of `state`.                                                                                |         |
-| id       | `string, undefined`         | Same as the HTML attribute.                                                                                                                        |         |
-| name     | `string`                    | MenuItemCheckbox's name as in `menu.values`.                                                                                                       |         |
-
-##### MenuItemRadio
-
-| Prop     | Type                        | Description                                                                                                                                        | Default |
-| -------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| disabled | `boolean, undefined`        | Same as the HTML attribute.                                                                                                                        |         |
-| value    | `string, number, undefined` | Checkbox's value is going to be used when multiple checkboxes share the same state. Checking a checkbox with value will add it to the state array. |         |
-| checked  | `boolean, undefined`        | Checkbox's checked state. If present, it's used instead of `state`.                                                                                |         |
-| id       | `string, undefined`         | Same as the HTML attribute.                                                                                                                        |         |
-| name     | `string`                    | MenuItemRadio's name as in `menu.values`.                                                                                                          |         |
+| Prop     | Type                 | Description                                                                               | Default     |
+| -------- | -------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| disabled | `boolean, undefined` | Same as the HTML attribute.                                                               |             |
+| id       | `string, undefined`  | Same as the HTML attribute.                                                               |             |
+| onClick  | `() => void`         | Same as the HTML attribute.                                                               |             |
+| href     | `string, undefined`  | Same as the HTML attribute.                                                               |             |
+| element? | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'MENU_ITEM' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/modal/index.mdx
+++ b/packages/paste-website/src/pages/components/modal/index.mdx
@@ -435,49 +435,55 @@ const ModalTrigger = () => {
 
 #### Modal Props
 
-| Prop              | Type                         | Description                                               | Default |
-| ----------------- | ---------------------------- | --------------------------------------------------------- | ------- |
-| children          | `ReactNode`                  |                                                           | null    |
-| isOpen            | `boolean`                    |                                                           | null    |
-| onDismiss         | `Function() => void`         |                                                           | null    |
-| allowPinchZoom?   | `boolean`                    |                                                           | true    |
-| size              | `oneOf(['default', 'wide'])` |                                                           | null    |
-| initialFocusRef?  | `RefObject`                  |                                                           | null    |
-| ariaLabelledby    | `string`                     |                                                           | null    |
-| `__console_patch` | `boolean`                    | Enable to fix Console's marginBottom bug when modal opens | null    |
+| Prop              | Type                         | Description                                                                               | Default |
+| ----------------- | ---------------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| children          | `ReactNode`                  |                                                                                           | null    |
+| isOpen            | `boolean`                    |                                                                                           | null    |
+| onDismiss         | `Function() => void`         |                                                                                           | null    |
+| allowPinchZoom?   | `boolean`                    |                                                                                           | true    |
+| size              | `oneOf(['default', 'wide'])` |                                                                                           | null    |
+| initialFocusRef?  | `RefObject`                  |                                                                                           | null    |
+| ariaLabelledby    | `string`                     |                                                                                           | null    |
+| `__console_patch` | `boolean`                    | Enable to fix Console's marginBottom bug when modal opens                                 | null    |
+| element?          | `string`                     | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL' |
 
 #### ModalHeader Props
 
-| Prop              | Type        | Description | Default       |
-| ----------------- | ----------- | ----------- | ------------- |
-| children          | `ReactNode` |             | null          |
-| i18nDismissLabel? | `string`    |             | 'Close modal' |
+| Prop              | Type        | Description                                                                               | Default        |
+| ----------------- | ----------- | ----------------------------------------------------------------------------------------- | -------------- |
+| children          | `ReactNode` |                                                                                           | null           |
+| i18nDismissLabel? | `string`    |                                                                                           | 'Close modal'  |
+| element?          | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL_HEADER' |
 
 #### ModalHeading Props
 
-| Prop     | Type                                          | Description | Default |
-| -------- | --------------------------------------------- | ----------- | ------- |
-| children | `ReactNode`                                   |             | null    |
-| as       | `oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])` |             | null    |
+| Prop     | Type                                          | Description                                                                               | Default         |
+| -------- | --------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
+| children | `ReactNode`                                   |                                                                                           | null            |
+| as       | `oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])` |                                                                                           | null            |
+| element? | `string`                                      | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL_HEADING' |
 
 #### ModalBody Props
 
-| Prop     | Type        | Description | Default |
-| -------- | ----------- | ----------- | ------- |
-| children | `ReactNode` |             | null    |
+| Prop     | Type        | Description                                                                               | Default      |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | ------------ |
+| children | `ReactNode` |                                                                                           | null         |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL_BODY' |
 
 #### ModalFooter Props
 
-| Prop     | Type        | Description | Default |
-| -------- | ----------- | ----------- | ------- |
-| children | `ReactNode` |             | null    |
+| Prop     | Type        | Description                                                                               | Default        |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | -------------- |
+| children | `ReactNode` |                                                                                           | null           |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL_FOOTER' |
 
 #### ModalFooterActions Props
 
-| Prop     | Type                      | Description | Default |
-| -------- | ------------------------- | ----------- | ------- |
-| children | `ReactNode`               |             | null    |
-| justify? | `oneOf(['start', 'end'])` |             | null    |
+| Prop     | Type                      | Description                                                                               | Default                |
+| -------- | ------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- |
+| children | `ReactNode`               |                                                                                           | null                   |
+| justify? | `oneOf(['start', 'end'])` |                                                                                           | null                   |
+| element? | `string`                  | Overrides the default element name to apply unique styles with the Customization Provider | 'MODAL_FOOTER_ACTIONS' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/pagination/index.mdx
+++ b/packages/paste-website/src/pages/components/pagination/index.mdx
@@ -611,56 +611,63 @@ const Component = () => {
 
 #### Pagination Props
 
-| Prop     | Type        | Description                                        | Default |
-| -------- | ----------- | -------------------------------------------------- | ------- |
-| children | `ReactNode` |                                                    | null    |
-| label    | `string`    | `aria-label` for the pagination navigation element | null    |
+| Prop     | Type        | Description                                                                               | Default      |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | ------------ |
+| children | `ReactNode` |                                                                                           | null         |
+| label    | `string`    | `aria-label` for the pagination navigation element                                        | null         |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION' |
 
 #### PaginationItems Props
 
-| Prop     | Type        | Description | Default |
-| -------- | ----------- | ----------- | ------- |
-| children | `ReactNode` |             | null    |
+| Prop     | Type        | Description                                                                               | Default            |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| children | `ReactNode` |                                                                                           | null               |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_ITEMS' |
 
 #### PaginationLabel Props
 
-| Prop     | Type        | Description | Default |
-| -------- | ----------- | ----------- | ------- |
-| children | `ReactNode` |             | null    |
+| Prop     | Type        | Description                                                                               | Default            |
+| -------- | ----------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| children | `ReactNode` |                                                                                           | null               |
+| element? | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_LABEL' |
 
 #### PaginationArrow Props
 
-| Prop          | Type      | Description                                             | Default  |
-| ------------- | --------- | ------------------------------------------------------- | -------- |
-| as?           | `string`  | `a` / `button`                                          | `button` |
-| disabled?     | `boolean` | Sets `aria-hidden` to be true, and `visibility: hidden` | null     |
-| href?         | `string`  | href used when as `a`                                   | null     |
-| label         | `string`  | `aria-label` text                                       | null     |
-| variant       | `string`  | `back` / `forward`                                      | null     |
-| visibleLabel? | `string`  | Visible text of the button or anchor                    | null     |
+| Prop          | Type      | Description                                                                               | Default            |
+| ------------- | --------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| as?           | `string`  | `a` / `button`                                                                            | `button`           |
+| disabled?     | `boolean` | Sets `aria-hidden` to be true, and `visibility: hidden`                                   | null               |
+| href?         | `string`  | href used when as `a`                                                                     | null               |
+| label         | `string`  | `aria-label` text                                                                         | null               |
+| variant       | `string`  | `back` / `forward`                                                                        | null               |
+| visibleLabel? | `string`  | Visible text of the button or anchor                                                      | null               |
+| element?      | `string`  | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_ARROW' |
 
 #### PaginationNumbers Props
 
-| Prop       | Type        | Description                               | Default |
-| ---------- | ----------- | ----------------------------------------- | ------- |
-| children   | `ReactNode` |                                           | null    |
-| pageLabel? | `string`    | Page label text used in `PaginationLabel` | null    |
+| Prop       | Type        | Description                                                                               | Default              |
+| ---------- | ----------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| children   | `ReactNode` |                                                                                           | null                 |
+| pageLabel? | `string`    | Page label text used in `PaginationLabel`                                                 | null                 |
+| element?   | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_NUMBERS' |
 
 #### PaginationNumber Props
 
-| Prop       | Type        | Description                        | Default  |
-| ---------- | ----------- | ---------------------------------- | -------- |
-| as?        | `string`    | `a` / `button`                     | `button` |
-| children?  | `ReactNode` |                                    | null     |
-| href?      | `string`    | href used when as `a`              | null     |
-| isCurrent? | `boolean`   | Sets the `aria-current` to be true | null     |
-| label      | `string`    | `aria-label` text                  | null     |
+| Prop       | Type        | Description                                                                               | Default             |
+| ---------- | ----------- | ----------------------------------------------------------------------------------------- | ------------------- |
+| as?        | `string`    | `a` / `button`                                                                            | `button`            |
+| children?  | `ReactNode` |                                                                                           | null                |
+| href?      | `string`    | href used when as `a`                                                                     | null                |
+| isCurrent? | `boolean`   | Sets the `aria-current` to be true                                                        | null                |
+| label      | `string`    | `aria-label` text                                                                         | null                |
+| element?   | `string`    | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_NUMBER' |
 
 #### PaginationEllipsis Props
 
-| Prop  | Type     | Description       | Default |
-| ----- | -------- | ----------------- | ------- |
-| label | `string` | `aria-label` text | null    |
+| Prop     | Type     | Description                                                                               | Default               |
+| -------- | -------- | ----------------------------------------------------------------------------------------- | --------------------- |
+| label    | `string` | `aria-label` text                                                                         | null                  |
+| element? | `string` | Overrides the default element name to apply unique styles with the Customization Provider | 'PAGINATION_ELLIPSIS' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/paragraph/index.mdx
+++ b/packages/paste-website/src/pages/components/paragraph/index.mdx
@@ -245,16 +245,11 @@ const Component = () => (
 
 #### Props
 
-| Prop         | Type        | Default |
-| ------------ | ----------- | ------- |
-| marginBottom | 'space0'    |         |
-| children?    | `ReactNode` | null    |
-
-##### marginBottom prop
-
-Only allows passing 'space0' to unset the bottom margin. Useful
-when using Paragraph as the last child of a wrapping component, like
-a Card.
+| Prop         | Type        | Default                                                                                                                                      |
+| ------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| marginBottom | 'space0'    | Only allows passing 'space0' to unset the bottom margin. Useful when using Paragraph as the last child of a wrapping component, like a Card. |             |
+| children?    | `ReactNode` | null                                                                                                                                         |             |
+| element?     | `string`    | Overrides the default element name to apply unique styles with the Customization Provider                                                    | 'PARAGRAPH' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/popover/index.mdx
+++ b/packages/paste-website/src/pages/components/popover/index.mdx
@@ -471,6 +471,10 @@ Required label for this Popover component. Titles the entire popover context for
 
 Label for the dismiss button in the popover. The default value is 'Close popover'.
 
+###### `element?: string`
+
+Overrides the default element name ('POPOVER') to apply unique styles with the Customization Provider
+
 <ChangelogRevealer>
   <Changelog />
 </ChangelogRevealer>

--- a/packages/paste-website/src/pages/components/radio-group/index.mdx
+++ b/packages/paste-website/src/pages/components/radio-group/index.mdx
@@ -262,34 +262,36 @@ const Component = () => (
 
 All the valid HTML attributes for `input[type=radio]` are supported including the following props:
 
-| Prop      | Type                                     | Description | Default |
-| --------- | ---------------------------------------- | ----------- | ------- |
-| children  | `ReactNode`                              |             | null    |
-| id?       | `string`                                 |             | null    |
-| value?    | `string`                                 |             | null    |
-| hasError? | `boolean`                                |             | false   |
-| helpText? | `string` or `ReactNode`                  |             | null    |
-| onChange? | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
-| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |             | null    |
+| Prop      | Type                                     | Description                                                                               | Default |
+| --------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| children  | `ReactNode`                              |                                                                                           | null    |
+| id?       | `string`                                 |                                                                                           | null    |
+| value?    | `string`                                 |                                                                                           | null    |
+| hasError? | `boolean`                                |                                                                                           | false   |
+| helpText? | `string` or `ReactNode`                  |                                                                                           | null    |
+| onChange? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null    |
+| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null    |
+| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null    |
+| element?  | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'RADIO' |
 
 #### RadioGroup props
 
-| Prop               | Type                                     | Description                                   | Default      |
-| ------------------ | ---------------------------------------- | --------------------------------------------- | ------------ |
-| children           | `ReactNode`                              |                                               | null         |
-| legend             | `string` or `ReactNode`                  |                                               | null         |
-| name               | `string`                                 |                                               | null         |
-| value              | `string`                                 |                                               | null         |
-| orientation        | `oneOf(['vertical', 'horizontal'])`      |                                               | vertical     |
-| errorText?         | `string` or `ReactNode`                  |                                               | null         |
-| helpText?          | `string` or `ReactNode`                  |                                               | null         |
-| disabled?          | `boolean`                                |                                               | false        |
-| required?          | `boolean`                                |                                               | false        |
-| onChange           | `(event: React.MouseEvent<HTMLElement>)` |                                               | null         |
-| onFocus?           | `(event: React.MouseEvent<HTMLElement>)` |                                               | null         |
-| onBlur?            | `(event: React.MouseEvent<HTMLElement>)` |                                               | null         |
-| i18nRequiredLabel? | `string`                                 | Label text for the required dot in the legend | '(required)' |
+| Prop               | Type                                     | Description                                                                               | Default       |
+| ------------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ------------- |
+| children           | `ReactNode`                              |                                                                                           | null          |
+| legend             | `string` or `ReactNode`                  |                                                                                           | null          |
+| name               | `string`                                 |                                                                                           | null          |
+| value              | `string`                                 |                                                                                           | null          |
+| orientation        | `oneOf(['vertical', 'horizontal'])`      |                                                                                           | vertical      |
+| errorText?         | `string` or `ReactNode`                  |                                                                                           | null          |
+| helpText?          | `string` or `ReactNode`                  |                                                                                           | null          |
+| disabled?          | `boolean`                                |                                                                                           | false         |
+| required?          | `boolean`                                |                                                                                           | false         |
+| onChange           | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null          |
+| onFocus?           | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null          |
+| onBlur?            | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null          |
+| i18nRequiredLabel? | `string`                                 | Label text for the required dot in the legend                                             | '(required)'  |
+| element?           | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'RADIO_GROUP' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/select/index.mdx
+++ b/packages/paste-website/src/pages/components/select/index.mdx
@@ -870,41 +870,44 @@ import {HelpText} from '@twilio-paste/core/help-text';
 
 All the <Anchor target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select">valid HTML attributes</Anchor> for `select` are supported including the following props:
 
-| Prop          | Type                                            | Description                                                                | Default   |
-| ------------- | ----------------------------------------------- | -------------------------------------------------------------------------- | --------- |
-| id?           | string                                          | Sets the id of the input. Should match the htmlFor of `Label`.             | null      |
-| name?         | string                                          | Sets the name of the select.                                               | null      |
-| value?        | string, string[]                                | Sets the value of the select. Expects an array when `multiple` is present. | null      |
-| children      | `NonNullable>React.ReactNode>`                  | Must be `Option` or `OptionGroup`. Required.                               | null      |
-| disabled?     | boolean                                         | Disables the input.                                                        | false     |
-| insertBefore? | `React.ReactNode`                               | Add Prefix to the select input.                                            | null      |
-| insertAfter?  | `React.ReactNode`                               | Add Suffix to the select input.                                            | null      |
-| required?     | boolean                                         | Sets the input as required.                                                | false     |
-| hasError?     | boolean                                         | Sets the input to an error state.                                          | false     |
-| onChange?     | `(event: React.ChangeEvent<HTMLSelectElement>)` |                                                                            | null      |
-| onFocus?      | `(event: React.MouseEvent<HTMLElement>)`        |                                                                            | null      |
-| onBlur?       | `(event: React.MouseEvent<HTMLElement>)`        |                                                                            | null      |
-| variant?      | 'default', 'inverse'                            |                                                                            | 'default' |
+| Prop          | Type                                            | Description                                                                               | Default   |
+| ------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| id?           | string                                          | Sets the id of the input. Should match the htmlFor of `Label`.                            | null      |
+| name?         | string                                          | Sets the name of the select.                                                              | null      |
+| value?        | string, string[]                                | Sets the value of the select. Expects an array when `multiple` is present.                | null      |
+| children      | `NonNullable>React.ReactNode>`                  | Must be `Option` or `OptionGroup`. Required.                                              | null      |
+| disabled?     | boolean                                         | Disables the input.                                                                       | false     |
+| insertBefore? | `React.ReactNode`                               | Add Prefix to the select input.                                                           | null      |
+| insertAfter?  | `React.ReactNode`                               | Add Suffix to the select input.                                                           | null      |
+| required?     | boolean                                         | Sets the input as required.                                                               | false     |
+| hasError?     | boolean                                         | Sets the input to an error state.                                                         | false     |
+| onChange?     | `(event: React.ChangeEvent<HTMLSelectElement>)` |                                                                                           | null      |
+| onFocus?      | `(event: React.MouseEvent<HTMLElement>)`        |                                                                                           | null      |
+| onBlur?       | `(event: React.MouseEvent<HTMLElement>)`        |                                                                                           | null      |
+| variant?      | 'default', 'inverse'                            |                                                                                           | 'default' |
+| element?      | `string`                                        | Overrides the default element name to apply unique styles with the Customization Provider | 'SELECT'  |
 
 #### Option props
 
 All the <Anchor target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option">valid HTML attributes</Anchor> for `option` are supported including the following props:
 
-| Prop      | Type             | Description                                                                          | Default |
-| --------- | ---------------- | ------------------------------------------------------------------------------------ | ------- |
-| id        | string           | Sets the id of the input. Should match the htmlFor of `Label`. Required.             | null    |
-| name      | string           | Sets the name of the select. Required.                                               | null    |
-| value     | string, string[] | Sets the value of the select. Expects an array when `multiple` is present. Required. | null    |
-| disabled? | boolean          | Disables the input.                                                                  | false   |
+| Prop      | Type             | Description                                                                               | Default  |
+| --------- | ---------------- | ----------------------------------------------------------------------------------------- | -------- |
+| id        | string           | Sets the id of the input. Should match the htmlFor of `Label`. Required.                  | null     |
+| name      | string           | Sets the name of the select. Required.                                                    | null     |
+| value     | string, string[] | Sets the value of the select. Expects an array when `multiple` is present. Required.      | null     |
+| disabled? | boolean          | Disables the input.                                                                       | false    |
+| element?  | `string`         | Overrides the default element name to apply unique styles with the Customization Provider | 'OPTION' |
 
 #### OptionGroup props
 
 All the <Anchor target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup">valid HTML attributes</Anchor> for `optgroup` are supported including the following props:
 
-| Prop     | Type                           | Description                               | Default |
-| -------- | ------------------------------ | ----------------------------------------- | ------- |
-| label    | string                         | Sets the label of the optgroup. Required. | null    |
-| children | `<NonNullable>React.ReactNode` | Must be `Option`. Required.               | null    |
+| Prop     | Type                           | Description                                                                               | Default        |
+| -------- | ------------------------------ | ----------------------------------------------------------------------------------------- | -------------- |
+| label    | string                         | Sets the label of the optgroup. Required.                                                 | null           |
+| children | `<NonNullable>React.ReactNode` | Must be `Option`. Required.                                                               | null           |
+| element? | `string`                       | Overrides the default element name to apply unique styles with the Customization Provider | 'OPTION_GROUP' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/separator/index.mdx
+++ b/packages/paste-website/src/pages/components/separator/index.mdx
@@ -179,13 +179,16 @@ import {Separator} from '@twilio-paste/core/separator';
 const Component = () => <Separator orientation="horizontal" />;
 ```
 
+#### Separator props
+
 All the regular HTML attributes (`role`, `aria-*`, `type`, and so on) including the following custom props:
 
-| Prop               | Type                                               | Description                           | Default |
-| ------------------ | -------------------------------------------------- | ------------------------------------- | ------- |
-| orientation?       | 'horizontal', 'vertical'                           | Separator direction                   |         |
-| horizontalSpacing? | ResponsiveValue<[Spacing](/tokens/list/#spacings)> | Space left and right of the separator |         |
-| verticalSpacing?   | ResponsiveValue<[Spacing](/tokens/list/#spacings)> | Space top and bottom of the separator |         |
+| Prop               | Type                                               | Description                                                                               | Default     |
+| ------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| orientation?       | 'horizontal', 'vertical'                           | Separator direction                                                                       |             |
+| horizontalSpacing? | ResponsiveValue<[Spacing](/tokens/list/#spacings)> | Space left and right of the separator                                                     |             |
+| verticalSpacing?   | ResponsiveValue<[Spacing](/tokens/list/#spacings)> | Space top and bottom of the separator                                                     |             |
+| element?           | `string`                                           | Overrides the default element name to apply unique styles with the Customization Provider | 'SEPARATOR' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/skeleton-loader/index.mdx
+++ b/packages/paste-website/src/pages/components/skeleton-loader/index.mdx
@@ -208,21 +208,22 @@ const SkeletonLoaderExample = () => {
 
 #### Props
 
-| Prop                     | Type                                         | Description | Default           |
-| ------------------------ | -------------------------------------------- | ----------- | ----------------- |
-| display?                 | `ResponsiveValue<CSS.DisplayProperty>`       |             |                   |
-| width?                   | `ResponsiveValue<WidthOptions>`              |             |                   |
-| minWidth?                | `ResponsiveValue<MinWidthOptions>`           |             |                   |
-| maxWidth?                | `ResponsiveValue<MaxWidthOptions>`           |             |                   |
-| height?                  | `ResponsiveValue<HeightOptions>`             |             | `sizeIcon20`      |
-| minHeight?               | `ResponsiveValue<MinHeightOptions>`          |             |                   |
-| maxHeight?               | `ResponsiveValue<MaxHeightOptions>`          |             |                   |
-| size?                    | `ResponsiveValue<WidthOptions>`              |             |                   |
-| borderRadius?            | `ResponsiveValue<keyof ThemeShape['radii']>` |             | `borderRadius20 ` |
-| borderTopLeftRadius?     | `ResponsiveValue<keyof ThemeShape['radii']>` |             |                   |
-| borderTopRightRadius?    | `ResponsiveValue<keyof ThemeShape['radii']>` |             |                   |
-| borderBottomRightRadius? | `ResponsiveValue<keyof ThemeShape['radii']>` |             |                   |
-| borderBottomLeftRadius?  | `ResponsiveValue<keyof ThemeShape['radii']>` |             |                   |
+| Prop                     | Type                                         | Description                                                                               | Default           |
+| ------------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------- |
+| display?                 | `ResponsiveValue<CSS.DisplayProperty>`       |                                                                                           |                   |
+| width?                   | `ResponsiveValue<WidthOptions>`              |                                                                                           |                   |
+| minWidth?                | `ResponsiveValue<MinWidthOptions>`           |                                                                                           |                   |
+| maxWidth?                | `ResponsiveValue<MaxWidthOptions>`           |                                                                                           |                   |
+| height?                  | `ResponsiveValue<HeightOptions>`             |                                                                                           | `sizeIcon20`      |
+| minHeight?               | `ResponsiveValue<MinHeightOptions>`          |                                                                                           |                   |
+| maxHeight?               | `ResponsiveValue<MaxHeightOptions>`          |                                                                                           |                   |
+| size?                    | `ResponsiveValue<WidthOptions>`              |                                                                                           |                   |
+| borderRadius?            | `ResponsiveValue<keyof ThemeShape['radii']>` |                                                                                           | `borderRadius20 ` |
+| borderTopLeftRadius?     | `ResponsiveValue<keyof ThemeShape['radii']>` |                                                                                           |                   |
+| borderTopRightRadius?    | `ResponsiveValue<keyof ThemeShape['radii']>` |                                                                                           |                   |
+| borderBottomRightRadius? | `ResponsiveValue<keyof ThemeShape['radii']>` |                                                                                           |                   |
+| borderBottomLeftRadius?  | `ResponsiveValue<keyof ThemeShape['radii']>` |                                                                                           |                   |
+| element?                 | `string`                                     | Overrides the default element name to apply unique styles with the Customization Provider | 'SKELETON_LOADER' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -191,6 +191,10 @@ Sets the icon color to any of our text color tokens or currentColor, which inher
 
 Time delay in milliseconds of the animation.
 
+###### `element?: string`
+
+Overrides the default element name ('SPINNER') to apply unique styles with the Customization Provider
+
 <ChangelogRevealer>
   <Changelog />
 </ChangelogRevealer>

--- a/packages/paste-website/src/pages/components/stack/index.mdx
+++ b/packages/paste-website/src/pages/components/stack/index.mdx
@@ -168,10 +168,11 @@ import {Stack} from '@twilio-paste/core/stack';
 
 #### Props
 
-| Prop        | Type                                      | Description | Default |
-| ----------- | ----------------------------------------- | ----------- | ------- |
-| orientation | ResponsiveValue<'horizontal', 'vertical'> |             | null    |
-| spacing     | [Spacing](/tokens/list/#spacings)         |             | null    |
+| Prop        | Type                                      | Description                                                                               | Default |
+| ----------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| orientation | ResponsiveValue<'horizontal', 'vertical'> |                                                                                           | null    |
+| spacing     | [Spacing](/tokens/list/#spacings)         |                                                                                           | null    |
+| element?    | `string`                                  | Overrides the default element name to apply unique styles with the Customization Provider | 'STACK' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/table/index.mdx
+++ b/packages/paste-website/src/pages/components/table/index.mdx
@@ -1249,6 +1249,10 @@ Sets the table cells to not line wrap.
 
 Sets the table to visually display the actionable state of an interactive table. Mainly used for Data Grid.
 
+###### `element?: string`
+
+Overrides the default element name ('TABLE') to apply unique styles with the Customization Provider.
+
 ##### Tr Props
 
 All the valid HTML attributes for `tr` are supported including the following props:
@@ -1256,6 +1260,10 @@ All the valid HTML attributes for `tr` are supported including the following pro
 ###### `verticalAlign?: "top" | "middle" | "bottom"`
 
 Sets the vertical alignment of the content within the Table row. Defaults to `middle`.
+
+###### `element?: string`
+
+Overrides the default element name ('TR') to apply unique styles with the Customization Provider.
 
 ##### Th Props
 
@@ -1269,6 +1277,10 @@ Sets the text alignment of the content within the Table cell. Defaults to `left`
 
 Sets the width of a Table cell.
 
+###### `element?: string`
+
+Overrides the default element name ('TH') to apply unique styles with the Customization Provider.
+
 ##### Td Props
 
 All the valid HTML attributes for `td` are supported including the following props:
@@ -1276,6 +1288,10 @@ All the valid HTML attributes for `td` are supported including the following pro
 ###### `textAlign?: "left" | "center" | "right"`
 
 Sets the text alignment of the content within the Table cell. Defaults to `left`.
+
+###### `element?: string`
+
+Overrides the default element name ('TD') to apply unique styles with the Customization Provider.
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/tabs/index.mdx
+++ b/packages/paste-website/src/pages/components/tabs/index.mdx
@@ -323,18 +323,25 @@ Changes the Tabs' to either fit the width of the containing element or not.
 
 ##### `selectedId?: string | null`
 
-Tells the Tabs which panel to load when it mounts. Important to provide, otherwise the first render may be
-a little delayed.
+Tells the Tabs which panel to load when it mounts. Important to provide, otherwise the first render may be a little delayed.
 
 ##### `baseId?: string`
 
 Sets the prefix for the auto-generated ids on each Tab and TabPanel. Useful for consistent renders, like for tests.
+
+###### `element?: string`
+
+Overrides the default element name ('HORIZONTAL_TABS') to apply unique styles with the Customization Provider. If the Tabs are vertical, the default element value is 'VERTICAL_TABS'.
 
 #### TabList Props
 
 ##### `aria-label: string`
 
 Required label for this Tabs component. Titles the entire Tabbing context for screen readers.
+
+###### `element?: string`
+
+Overrides the default element name ('HORIZONTAL_TAB_LIST') to apply unique styles with the Customization Provider. If the Tabs are vertical, the default element value is 'VERTICAL_TAB_LIST'.
 
 #### Tab Props
 
@@ -351,9 +358,15 @@ It works similarly to readOnly on form elements. In this case, only aria-disable
 
 Same as the HTML attribute.
 
+###### `element?: string`
+
+Overrides the default element name ('HORIZONTAL_TAB') to apply unique styles with the Customization Provider. If the Tabs are vertical, the default element value is 'VERTICAL_TAB'.
+
 #### TabPanels Props
 
-None available.
+###### `element?: string`
+
+Overrides the default element name ('HORIZONTAL_TAB_PANELS') to apply unique styles with the Customization Provider. If the Tabs are vertical, the default element value is 'VERTICAL_TAB_PANELS'.
 
 #### TabPanel Props
 
@@ -364,6 +377,10 @@ Same as the HTML attribute.
 ##### `tabId?: string | undefined`
 
 The ID of the Tab component this Panel pairs with.
+
+###### `element?: string`
+
+Overrides the default element name ('HORIZONTAL_TAB_PANEL') to apply unique styles with the Customization Provider. If the Tabs are vertical, the default element value is 'VERTICAL_TAB_PANEL'.
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -632,19 +632,20 @@ const Component = () => (
 
 All the valid HTML attributes for `textarea` are supported including the following props:
 
-| Prop         | Type                                     | Description                                                       | Default   |
-| ------------ | ---------------------------------------- | ----------------------------------------------------------------- | --------- |
-| id?          | string                                   | Sets the id of the textarea. Should match the htmlFor of `Label`. | null      |
-| name?        | string                                   | Sets the name of the textarea.                                    | null      |
-| placeholder? | string                                   | Sets the placeholder of the textarea.                             | null      |
-| disabled?    | boolean                                  | Disables the textarea.                                            | false     |
-| readOnly?    | boolean                                  | Sets the textarea to readonly.                                    | false     |
-| required?    | boolean                                  | Sets the textarea as required.                                    | false     |
-| hasError?    | boolean                                  | Sets the textarea to an error state.                              | false     |
-| onChange?    | `(event: React.MouseEvent<HTMLElement>)` |                                                                   | null      |
-| onFocus?     | `(event: React.MouseEvent<HTMLElement>)` |                                                                   | null      |
-| onBlur?      | `(event: React.MouseEvent<HTMLElement>)` |                                                                   | null      |
-| variant?     | 'default', 'inverse'                     |                                                                   | 'default' |
+| Prop         | Type                                     | Description                                                                               | Default    |
+| ------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ---------- |
+| id?          | string                                   | Sets the id of the textarea. Should match the htmlFor of `Label`.                         | null       |
+| name?        | string                                   | Sets the name of the textarea.                                                            | null       |
+| placeholder? | string                                   | Sets the placeholder of the textarea.                                                     | null       |
+| disabled?    | boolean                                  | Disables the textarea.                                                                    | false      |
+| readOnly?    | boolean                                  | Sets the textarea to readonly.                                                            | false      |
+| required?    | boolean                                  | Sets the textarea as required.                                                            | false      |
+| hasError?    | boolean                                  | Sets the textarea to an error state.                                                      | false      |
+| onChange?    | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| onFocus?     | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| onBlur?      | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null       |
+| variant?     | 'default', 'inverse'                     |                                                                                           | 'default'  |
+| element?     | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'TEXTAREA' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/components/time-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/time-picker/index.mdx
@@ -563,21 +563,22 @@ const TimePickerExample = () => {
 
 All the valid HTML attributes for `input` (except `type`) are supported, including the following props:
 
-| Prop      | Type                                     | Description                                                          | Default   |
-| --------- | ---------------------------------------- | -------------------------------------------------------------------- | --------- |
-| id?       | string                                   | Sets the id of the time picker. Should match the htmlFor of `Label`. | null      |
-| name?     | string                                   | Sets the name of the time picker.                                    | null      |
-| value?    | string                                   | Sets the value of the time picker.                                   | null      |
-| disabled? | boolean                                  | Disables the time picker.                                            | false     |
-| readOnly? | boolean                                  | Sets the time picker to readonly.                                    | false     |
-| required? | boolean                                  | Sets the time picker as required.                                    | false     |
-| hasError? | boolean                                  | Sets the time picker to an error state.                              | false     |
-| min?      | string                                   | Sets the earliest valid time value.                                  | null      |
-| max?      | string                                   | Sets the last valid time value.                                      | null      |
-| onChange? | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                      | null      |
-| variant?  | 'default', 'inverse'                     |                                                                      | 'default' |
+| Prop      | Type                                     | Description                                                                               | Default      |
+| --------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ------------ |
+| id?       | string                                   | Sets the id of the time picker. Should match the htmlFor of `Label`.                      | null         |
+| name?     | string                                   | Sets the name of the time picker.                                                         | null         |
+| value?    | string                                   | Sets the value of the time picker.                                                        | null         |
+| disabled? | boolean                                  | Disables the time picker.                                                                 | false        |
+| readOnly? | boolean                                  | Sets the time picker to readonly.                                                         | false        |
+| required? | boolean                                  | Sets the time picker as required.                                                         | false        |
+| hasError? | boolean                                  | Sets the time picker to an error state.                                                   | false        |
+| min?      | string                                   | Sets the earliest valid time value.                                                       | null         |
+| max?      | string                                   | Sets the last valid time value.                                                           | null         |
+| onChange? | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| onFocus?  | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| onBlur?   | `(event: React.MouseEvent<HTMLElement>)` |                                                                                           | null         |
+| variant?  | 'default', 'inverse'                     |                                                                                           | 'default'    |
+| element?  | `string`                                 | Overrides the default element name to apply unique styles with the Customization Provider | 'TIMEPICKER' |
 
 #### formatReturnTime() props
 

--- a/packages/paste-website/src/pages/components/toast/index.mdx
+++ b/packages/paste-website/src/pages/components/toast/index.mdx
@@ -475,16 +475,17 @@ If you choose to handle state entirely yourself, you can use `<Toaster />` on it
 
 #### Toast Props
 
-| Prop             | Type         | Description                                                 | Default         |
-| ---------------- | ------------ | ----------------------------------------------------------- | --------------- |
-| children         | `ReactNode`  |                                                             | null            |
-| onDismiss?       | `() => void` | Create dismissable toast by providing an onDismiss callback | null            |
-| variant          | `string`     | `error` / `neutral` / `sucess` / `warning`                  | null            |
-| i18nDismissLabel | `string`     | Label for the dismiss button in a dismissable toast         | 'Dismiss toast' |
-| i18nErrorLabel   | `string`     | Icon label text for the `error` variant                     | '(error)'       |
-| i18nNeutralLabel | `string`     | Icon label text for the `neutral` variant                   | '(information)' |
-| i18nSuccessLabel | `string`     | Icon label text for the `success` variant                   | '(success)'     |
-| i18nWarningLabel | `string`     | Icon label text for the `warning` variant                   | '(warning)'     |
+| Prop             | Type         | Description                                                                               | Default         |
+| ---------------- | ------------ | ----------------------------------------------------------------------------------------- | --------------- |
+| children         | `ReactNode`  |                                                                                           | null            |
+| onDismiss?       | `() => void` | Create dismissable toast by providing an onDismiss callback                               | null            |
+| variant          | `string`     | `error` / `neutral` / `sucess` / `warning`                                                | null            |
+| i18nDismissLabel | `string`     | Label for the dismiss button in a dismissable toast                                       | 'Dismiss toast' |
+| i18nErrorLabel   | `string`     | Icon label text for the `error` variant                                                   | '(error)'       |
+| i18nNeutralLabel | `string`     | Icon label text for the `neutral` variant                                                 | '(information)' |
+| i18nSuccessLabel | `string`     | Icon label text for the `success` variant                                                 | '(success)'     |
+| i18nWarningLabel | `string`     | Icon label text for the `warning` variant                                                 | '(warning)'     |
+| element?         | `string`     | Overrides the default element name to apply unique styles with the Customization Provider | 'TOAST'         |
 
 #### useToaster return state
 

--- a/packages/paste-website/src/pages/components/tooltip/index.mdx
+++ b/packages/paste-website/src/pages/components/tooltip/index.mdx
@@ -393,6 +393,10 @@ Sets the placement of tooltip in relation to the child element. Available option
 
 The text content of the Tooltip.
 
+###### `element?: string`
+
+Overrides the default element name ('TOOLTIP') to apply unique styles with the Customization Provider
+
 <ChangelogRevealer>
   <Changelog />
 </ChangelogRevealer>


### PR DESCRIPTION
[Jira Ticket](https://issues.corp.twilio.com/browse/DSYS-3074)

Adding the `element` prop to all component docs pages.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
