### PR TITLE
chore(remove-knobs): Remove Storybook Knobs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,7 +7,6 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
-    '@storybook/addon-knobs',
     '@storybook/addon-actions',
     '@storybook/addon-viewport',
     'storybook-addon-gatsby',

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@storybook/addon-a11y": "6.4.20",
     "@storybook/addon-actions": "6.4.20",
     "@storybook/addon-essentials": "6.4.20",
-    "@storybook/addon-knobs": "6.4.0",
     "@storybook/addon-links": "6.4.20",
     "@storybook/addon-viewport": "6.4.20",
     "@storybook/addons": "6.4.20",

--- a/packages/paste-core/components/alert/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert/stories/index.stories.tsx
@@ -1,27 +1,15 @@
 import * as React from 'react';
-import {withKnobs, boolean, select} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {Truncate} from '@twilio-paste/truncate';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {Alert, AlertVariants} from '../src';
+import {Alert} from '../src';
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Alert',
-  decorators: [withKnobs],
   component: Alert,
-};
-
-export const AllVariant = (): React.ReactNode => {
-  const isDismissable = boolean('onDismiss', true);
-  const variantValule = select('variant', Object.keys(AlertVariants), AlertVariants.ERROR) as AlertVariants;
-  return (
-    <Alert onDismiss={isDismissable ? action('dismiss') : undefined} variant={variantValule}>
-      <Text as="div">I am an alert</Text>
-    </Alert>
-  );
 };
 
 export const Neutral = (): React.ReactNode => {

--- a/packages/paste-core/components/anchor/stories/index.stories.tsx
+++ b/packages/paste-core/components/anchor/stories/index.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {action} from '@storybook/addon-actions';
-import {withKnobs, select, text} from '@storybook/addon-knobs';
 import {Box} from '@twilio-paste/box';
 import {Stack} from '@twilio-paste/stack';
 import {Heading} from '@twilio-paste/heading';
@@ -8,50 +7,46 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import {Anchor} from '../src';
 import type {AnchorTargets, AnchorTabIndexes} from '../src/types';
 
-const AnchorTargetOptions = ['_self', '_blank', '_parent', '_top'];
-const AnchorTabIndexOptions = [0, -1];
-
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Anchor',
-  decorators: [withKnobs],
   component: Anchor,
 };
 
 export const Default = (): React.ReactNode => {
-  const tabIndexOptions = select('tabIndex', AnchorTabIndexOptions, 0) as AnchorTabIndexes;
-  const targetOptions = select('target', AnchorTargetOptions, '_self') as AnchorTargets;
+  const tabIndexOptions = 0 as AnchorTabIndexes;
+  const targetOptions = '_self' as AnchorTargets;
   return (
     <Anchor
-      href={text('href', '/app')}
+      href="/app"
       onBlur={action('handleBlur')}
       onClick={action('handleClick')}
       onFocus={action('handleFocus')}
-      rel={text('rel', '')}
+      rel=""
       tabIndex={tabIndexOptions}
       target={targetOptions}
     >
-      {text('children', 'I am a text link')}
+      I am a text link
     </Anchor>
   );
 };
 
 export const Inverse = (): React.ReactNode => {
-  const tabIndexOptions = select('tabIndex', AnchorTabIndexOptions, 0) as AnchorTabIndexes;
-  const targetOptions = select('target', AnchorTargetOptions, '_self') as AnchorTargets;
+  const tabIndexOptions = 0 as AnchorTabIndexes;
+  const targetOptions = '_self' as AnchorTargets;
   return (
     <Box backgroundColor="colorBackgroundBodyInverse" padding="space60">
       <Anchor
-        href={text('href', '/app')}
+        href="/app"
         onBlur={action('handleBlur')}
         onClick={action('handleClick')}
         onFocus={action('handleFocus')}
-        rel={text('rel', '')}
+        rel=""
         tabIndex={tabIndexOptions}
         target={targetOptions}
         variant="inverse"
       >
-        {text('children', 'I am an inverse text link')}
+        I am an inverse text link
       </Anchor>
     </Box>
   );

--- a/packages/paste-core/components/card/stories/index.stories.tsx
+++ b/packages/paste-core/components/card/stories/index.stories.tsx
@@ -1,24 +1,18 @@
 import * as React from 'react';
 import {Heading} from '@twilio-paste/heading';
-import {withKnobs, select} from '@storybook/addon-knobs';
 import {Paragraph} from '@twilio-paste/paragraph';
-import type {Padding} from '@twilio-paste/style-props';
 import {Stack} from '@twilio-paste/stack';
-import {DefaultTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Card} from '../src';
-
-const spaceOptions = Object.keys(DefaultTheme.space);
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Card',
-  decorators: [withKnobs],
   component: Card,
 };
 
 export const Default = (): React.ReactNode => (
-  <Card padding={select('padding', spaceOptions, 'space60') as Padding}>
+  <Card padding="space60">
     <Heading as="h2" variant="heading20">
       Notifications
     </Heading>

--- a/packages/paste-core/components/heading/stories/index.stories.tsx
+++ b/packages/paste-core/components/heading/stories/index.stories.tsx
@@ -1,33 +1,13 @@
 import * as React from 'react';
-import {withKnobs, text, select} from '@storybook/addon-knobs';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Card} from '@twilio-paste/card';
 import {Stack} from '@twilio-paste/stack';
-import type {asTags, HeadingVariants} from '../src';
 import {Heading} from '../src';
 
-const headingVariantOptions = ['heading10', 'heading20', 'heading30', 'heading40', 'heading50', 'heading60'];
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Heading',
-  decorators: [withKnobs],
   component: Heading,
-};
-
-export const AllVariants = (): React.ReactNode => {
-  const asOptions = text('as', 'h2') as asTags;
-  const headingVariantValue = select('variant', headingVariantOptions, 'heading20') as HeadingVariants;
-  // eslint-disable-next-line unicorn/no-useless-undefined
-  const marginBottomValue = select('marginBottom', [undefined, 'space0'], undefined);
-  return (
-    <Heading as={asOptions} marginBottom={marginBottomValue} variant={headingVariantValue}>
-      I am a Very Large Heading
-    </Heading>
-  );
-};
-
-AllVariants.story = {
-  name: 'All variants',
 };
 
 export const Heading10 = (): React.ReactNode => {

--- a/packages/paste-core/components/input/stories/input.stories.tsx
+++ b/packages/paste-core/components/input/stories/input.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {useUID} from '@twilio-paste/uid-library';
 import {action} from '@storybook/addon-actions';
-import {withKnobs, boolean, text, select} from '@storybook/addon-knobs';
 import {Anchor} from '@twilio-paste/anchor';
 import {useTheme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
@@ -9,55 +8,14 @@ import {Text} from '@twilio-paste/text';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
-import type {HelpTextVariants} from '@twilio-paste/help-text';
 import {Stack} from '@twilio-paste/stack';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Input} from '../src';
-import type {InputTypes} from '../src';
-
-const inputTypeOptions = ['text', 'email', 'hidden', 'number', 'password', 'search', 'tel'];
-const helpVariantOptions = ['default', 'error'];
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Input',
-  decorators: [withKnobs],
   component: Input,
-};
-
-export const InputOptions = (): React.ReactNode => {
-  const hasError = boolean('hasError', false);
-  const isDisabled = boolean('disabled', false);
-  const isReadOnly = boolean('readOnly', false);
-  const isRequired = boolean('required', false);
-  const inputTypeValue = select('type', inputTypeOptions, 'text') as InputTypes;
-  const helpVariantValue = select('help variant', helpVariantOptions, 'default') as HelpTextVariants;
-  const [value, setValue] = React.useState('Input Options');
-  return (
-    <>
-      <Label htmlFor={text('htmlFor', 'input_field')} disabled={isDisabled} required={isRequired}>
-        Label
-      </Label>
-      <Input
-        disabled={isDisabled}
-        hasError={hasError}
-        id={text('id', 'input_field')}
-        name={text('name', '')}
-        placeholder={text('placeholder', 'Placeholder')}
-        readOnly={isReadOnly}
-        required={isRequired}
-        type={inputTypeValue}
-        value={value}
-        onChange={(event) => {
-          setValue(event.target.value);
-          action('handleChange');
-        }}
-        onFocus={action('handleFocus')}
-        onBlur={action('handleBlur')}
-      />
-      <HelpText variant={helpVariantValue}>{text('help text', 'Info that helps a user with this field.')}</HelpText>
-    </>
-  );
 };
 
 export const DefaultInput = (): React.ReactNode => {

--- a/packages/paste-core/components/select/stories/select.stories.tsx
+++ b/packages/paste-core/components/select/stories/select.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {useUID, useUIDSeed} from '@twilio-paste/uid-library';
 import {action} from '@storybook/addon-actions';
-import {withKnobs, boolean, text, select, array, number} from '@storybook/addon-knobs';
 import {useTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Box} from '@twilio-paste/box';
@@ -10,111 +9,37 @@ import {Anchor} from '@twilio-paste/anchor';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
-import type {HelpTextVariants} from '@twilio-paste/help-text';
 import {Select, Option, OptionGroup} from '../src';
-
-const kebabCase = require('lodash/kebabCase');
-
-const helpVariantOptions = ['default', 'error'];
-const optionGroup = (idx: number): string => `option group ${idx}`;
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Select',
-  decorators: [withKnobs],
   component: Select,
   subcomponents: {Option, OptionGroup},
 };
 
 export const DefaultSelect = (): React.ReactNode => {
-  const selectGroupId = 'select group';
-  const id = text('id', 'select_input_field', selectGroupId);
-  const htmlFor = text('htmlFor', 'select_input_field', selectGroupId);
-  const hasError = boolean('hasError', false, selectGroupId);
-  const isDisabled = boolean('disabled', false, selectGroupId);
-  const isRequired = boolean('required', false, selectGroupId);
-  const isMultiple = boolean('multiple', false, selectGroupId);
-  const multiSelectSize = number('multiselect list size', 3, {}, selectGroupId);
-  const helpVariantValue = select('help variant', helpVariantOptions, 'default', selectGroupId) as HelpTextVariants;
-  const helpText = text('help text', 'Info that helps a user with this field.', selectGroupId);
-  const insertBefore = boolean('insertBefore', false, selectGroupId);
-  const insertAfter = boolean('insertAfter', false, selectGroupId);
-
-  const defaultOptions = ['Option 1', 'Option 2', 'Option 3'];
-  const optionValues = array('option values', defaultOptions, ', ', selectGroupId);
-
-  const KnobOption: React.FC<{idx: number; initialValue: string}> = ({idx, initialValue}) => {
-    const optionGroupId = optionGroup(idx);
-    const disabled = boolean('disabled', false, optionGroupId);
-    const optionValue = text('value', initialValue || `option-value-${idx}`, optionGroupId);
-    const label = text('label', `Option ${idx}`, optionGroupId);
-
-    return (
-      <>
-        <Option value={optionValue} disabled={disabled}>
-          {label}
-        </Option>
-      </>
-    );
-  };
-
-  const [value, setValue] = React.useState(isMultiple ? [] : 'Select | Options');
-
+  const uid = useUID();
+  const [value, setValue] = React.useState('Select');
   return (
     <>
-      <Label htmlFor={htmlFor} disabled={isDisabled} required={isRequired}>
-        Label
-      </Label>
+      <Label htmlFor={uid}>Label</Label>
       <Select
-        ref={React.createRef()}
-        disabled={isDisabled}
-        hasError={hasError}
-        id={id}
-        required={isRequired}
-        value={value}
+        id={uid}
         onChange={(event) => {
-          const {
-            target: {value: targetValue, options},
-          } = event;
-          if (isMultiple) {
-            const update: [] = Object.keys(options).reduce((optionTargetValues: [], key): [] => {
-              // @ts-ignore implicit any issue with key
-              const {selected, value: optionValue} = options[key];
-              if (selected) {
-                return [...optionTargetValues, optionValue] as unknown as [];
-              }
-              return optionTargetValues;
-            }, []);
-            setValue(update);
-          } else {
-            setValue(targetValue);
-          }
+          setValue(event.target.value);
           action('handleChange');
         }}
         onFocus={action('handleFocus')}
         onBlur={action('handleBlur')}
-        multiple={isMultiple}
-        size={isMultiple ? multiSelectSize : undefined}
-        insertBefore={
-          insertBefore && (
-            <Text as="span" fontWeight="fontWeightSemibold">
-              $10.99
-            </Text>
-          )
-        }
-        insertAfter={
-          insertAfter && (
-            <Anchor href="#" display="flex">
-              <InformationIcon decorative={false} size="sizeIcon20" title="Get more info" />
-            </Anchor>
-          )
-        }
+        value={value}
       >
-        {optionValues.map((option, idx) => (
-          <KnobOption idx={idx + 1} initialValue={kebabCase(option)} key={useUID()} />
-        ))}
+        <Option value="option-1">Option 1</Option>
+        <Option value="option-2">Option 2</Option>
+        <Option value="option-3">Option 3</Option>
+        <Option value="option-4">Option 4</Option>
       </Select>
-      <HelpText variant={helpVariantValue}>{helpText}</HelpText>
+      <HelpText>Info that helps a user with this field.</HelpText>
     </>
   );
 };

--- a/packages/paste-core/components/skeleton-loader/stories/index.stories.tsx
+++ b/packages/paste-core/components/skeleton-loader/stories/index.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {withKnobs} from '@storybook/addon-knobs';
 import {Avatar} from '@twilio-paste/avatar';
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
@@ -18,7 +17,6 @@ import {SkeletonLoader} from '../src';
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Skeleton Loader',
-  decorators: [withKnobs],
   component: SkeletonLoader,
 };
 

--- a/packages/paste-core/components/spinner/stories/index.stories.tsx
+++ b/packages/paste-core/components/spinner/stories/index.stories.tsx
@@ -4,9 +4,8 @@ import {Card} from '@twilio-paste/card';
 import {Button} from '@twilio-paste/button';
 import {useTheme, DefaultTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {withKnobs, text, select, boolean, number} from '@storybook/addon-knobs';
 import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
-import type {IconSize, TextColor, TextColorOptions} from '@twilio-paste/style-props';
+import type {IconSize, TextColorOptions} from '@twilio-paste/style-props';
 import {styled} from '@twilio-paste/styling-library';
 
 import {Spinner} from '../src';
@@ -14,29 +13,8 @@ import {Spinner} from '../src';
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Spinner',
-  decorators: [withKnobs],
   component: Spinner,
   excludeStories: ['LoadingOverlay', 'StyledLoadingOverlay', 'StyledLoadingOverlayContent'],
-};
-
-export const SpinnerWithKnobs = (): React.ReactNode => {
-  const {textColors, iconSizes} = useTheme();
-  const colorOptions = React.useMemo(() => Object.keys(textColors), [textColors]);
-  const sizeOptions = React.useMemo(() => Object.keys(iconSizes), [iconSizes]);
-  const colorValue = select('color', colorOptions, 'currentColor') as TextColor;
-  const sizeValue = select('size', sizeOptions, 'sizeIcon40') as IconSize;
-  const decorativeValue = boolean('decorative', false);
-  const delay = number('delay', 250);
-
-  return (
-    <Spinner
-      color={colorValue as TextColorOptions}
-      size={sizeValue}
-      title={text('title', 'Now loading')}
-      decorative={decorativeValue}
-      delay={delay}
-    />
-  );
 };
 
 const {textColors: defaultThemeTextColors, iconSizes} = DefaultTheme;

--- a/packages/paste-core/components/textarea/stories/textarea.stories.tsx
+++ b/packages/paste-core/components/textarea/stories/textarea.stories.tsx
@@ -1,56 +1,21 @@
 import * as React from 'react';
 import {useUID} from '@twilio-paste/uid-library';
 import {action} from '@storybook/addon-actions';
-import {withKnobs, boolean, text, select} from '@storybook/addon-knobs';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
 import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
 import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
-import type {HelpTextVariants} from '@twilio-paste/help-text';
 import {useTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Stack} from '@twilio-paste/stack';
 import {TextArea} from '../src';
 
-const helpVariantOptions = ['default', 'error'];
-
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Textarea',
-  decorators: [withKnobs],
   component: TextArea,
-};
-
-export const TextareaOptions = (): React.ReactNode => {
-  const hasError = boolean('hasError', false);
-  const isDisabled = boolean('disabled', false);
-  const isReadOnly = boolean('readOnly', false);
-  const isRequired = boolean('required', false);
-  const helpVariantValue = select('help variant', helpVariantOptions, 'default') as HelpTextVariants;
-  return (
-    <>
-      <Label htmlFor={text('htmlFor', 'textarea_field')} disabled={isDisabled} required={isRequired}>
-        Label
-      </Label>
-      <TextArea
-        disabled={isDisabled}
-        hasError={hasError}
-        id={text('id', 'textarea_field')}
-        name={text('name', '')}
-        placeholder={text('placeholder', 'Placeholder')}
-        readOnly={isReadOnly}
-        required={isRequired}
-        onChange={action('handleChange')}
-        onFocus={action('handleFocus')}
-        onBlur={action('handleBlur')}
-      >
-        Value of textarea
-      </TextArea>
-      <HelpText variant={helpVariantValue}>{text('help text', 'Info that helps a user with this field.')}</HelpText>
-    </>
-  );
 };
 
 export const Textarea = (): React.ReactNode => {

--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {withKnobs, text} from '@storybook/addon-knobs';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
@@ -36,7 +35,6 @@ export const StateHookExample: React.FC = () => {
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Tooltip',
-  decorators: [withKnobs],
   excludeStories: ['StateHookExample'],
   component: Tooltip,
   parameters: {
@@ -48,7 +46,7 @@ export default {
 export const Default = (): React.ReactNode => {
   return (
     <Box as="div" minHeight="400px">
-      <Tooltip visible text={text('text', 'Welcome to Paste!')}>
+      <Tooltip visible text="Welcome to Paste!">
         <Button variant="primary">Open tooltip</Button>
       </Tooltip>
     </Box>
@@ -197,10 +195,10 @@ export const CustomizedTooltip = (): React.ReactNode => {
       }}
     >
       <Box as="div" display="flex" columnGap="space80">
-        <Tooltip visible text={text('text', 'Welcome to Paste!')}>
+        <Tooltip visible text="Welcome to Paste!">
           <Button variant="primary">Open tooltip</Button>
         </Tooltip>
-        <Tooltip element="CUSTOM_TOOLTIP" visible text={text('text', 'Welcome to Paste!')}>
+        <Tooltip element="CUSTOM_TOOLTIP" visible text="Welcome to Paste!">
           <Button variant="primary">Open tooltip</Button>
         </Tooltip>
       </Box>

--- a/packages/paste-core/layout/aspect-ratio/stories/index.stories.tsx
+++ b/packages/paste-core/layout/aspect-ratio/stories/index.stories.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {withKnobs, text} from '@storybook/addon-knobs';
 import {Box} from '@twilio-paste/box';
 import {AspectRatio} from '../src';
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Layout/Aspect Ratio',
-  decorators: [withKnobs],
   component: AspectRatio,
 };
 
@@ -19,7 +17,7 @@ export const Default = (): React.ReactNode => {
       borderStyle="solid"
       borderWidth="borderWidth10"
     >
-      <AspectRatio ratio={text('ratio', '4:3')}>
+      <AspectRatio ratio="4:3">
         <Box position="absolute" top={0} right={0} bottom={0} left={0} backgroundColor="colorBackgroundBrand" />
       </AspectRatio>
     </Box>

--- a/packages/paste-core/layout/flex/stories/index.stories.tsx
+++ b/packages/paste-core/layout/flex/stories/index.stories.tsx
@@ -1,64 +1,22 @@
 import * as React from 'react';
-import {withKnobs, select, boolean, number, text} from '@storybook/addon-knobs';
 import {Box} from '@twilio-paste/box';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Text} from '@twilio-paste/text';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {Truncate} from '@twilio-paste/truncate';
 import {Flex} from '../src';
-import type {Display, VerticalAlign, HorizontalAlign} from '../src/types';
-
-const flexDisplayOptions = ['flex', 'inline-flex'];
-const flexVerticalAlignOptions = ['top', 'center', 'bottom', 'stretch'];
-const flexHorizontalAlignOptions = ['left', 'center', 'right', 'around', 'between'];
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Layout/Flex',
-  decorators: [withKnobs],
   component: Flex,
-};
-
-export const FlexAlignmentOptions = (): React.ReactNode => {
-  const asValue = text('as', 'div') as keyof JSX.IntrinsicElements;
-  const flexDisplayValue = select('display', flexDisplayOptions, 'flex') as Display;
-  const flexVerticalAlignValue = select('vAlignContent', flexVerticalAlignOptions, 'top') as VerticalAlign;
-  const flexHorizontalAlignValue = select('hAlignContent', flexHorizontalAlignOptions, 'left') as HorizontalAlign;
-  return (
-    <Box padding="space30" borderStyle="solid">
-      <Flex
-        as={asValue}
-        display={flexDisplayValue}
-        vertical={boolean('vertical', false)}
-        hAlignContent={flexHorizontalAlignValue}
-        vAlignContent={flexVerticalAlignValue}
-        wrap={boolean('wrap', false)}
-      >
-        <Flex shrink>
-          <Box margin="space20" padding="space20" backgroundColor="colorBackgroundBrand" minWidth="size30">
-            <Text as="span" color="colorTextInverse" textAlign="center">
-              Item 1
-            </Text>
-          </Box>
-        </Flex>
-        <Flex grow>
-          <Box margin="space20" padding="space20" backgroundColor="colorBackgroundBrandHighlight">
-            <Text as="span" color="colorTextInverse" textAlign="center">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras in nunc mi. Duis faucibus, quam id tempus
-              porta, libero sem faucibus odio, ut egestas massa dolor quis mi.
-            </Text>
-          </Box>
-        </Flex>
-      </Flex>
-    </Box>
-  );
 };
 
 export const FlexOptions = (): React.ReactNode => {
   return (
     <Box padding="space30" borderStyle="solid">
       <Flex display="flex">
-        <Flex grow={number('grow', 0)} shrink={number('shrink', 1)} basis={number('basis', 100)}>
+        <Flex grow={0} shrink={1} basis={100}>
           <Box backgroundColor="colorBackgroundBrand" width="100%" minHeight="size10" />
         </Flex>
         <Flex>

--- a/packages/paste-core/layout/grid/stories/index.stories.tsx
+++ b/packages/paste-core/layout/grid/stories/index.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import {withKnobs, select, text} from '@storybook/addon-knobs';
 import type {ThemeShape} from '@twilio-paste/theme';
-import {DefaultTheme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
@@ -12,19 +10,16 @@ import {Truncate} from '@twilio-paste/truncate';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Grid, Column} from '../src';
 
-const spaceOptions = Object.keys(DefaultTheme.space);
-
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Layout/Grid',
-  decorators: [withKnobs],
   component: Grid,
   subcomponents: {Column},
 };
 
 export const Grid12ColumnAndGutterSupport = (): React.ReactNode => {
-  const asValue = text('as', 'div') as keyof JSX.IntrinsicElements;
-  const gutterValue = select('gutter', spaceOptions, 'space0') as keyof ThemeShape['space'];
+  const asValue = 'div' as keyof JSX.IntrinsicElements;
+  const gutterValue = 'space0' as keyof ThemeShape['space'];
   return (
     <Grid as={asValue} gutter={gutterValue}>
       <Column as={asValue}>

--- a/packages/paste-core/layout/media-object/stories/index.stories.tsx
+++ b/packages/paste-core/layout/media-object/stories/index.stories.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import {withKnobs, select, text} from '@storybook/addon-knobs';
 import {Text} from '@twilio-paste/text';
 import {Box} from '@twilio-paste/box';
 import {Truncate} from '@twilio-paste/truncate';
-import {DefaultTheme} from '@twilio-paste/theme';
 import type {ThemeShape} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {MediaObject, MediaFigure, MediaBody} from '../src';
@@ -11,22 +9,17 @@ import {MediaObject, MediaFigure, MediaBody} from '../src';
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Layout/Media Object',
-  decorators: [withKnobs],
   component: MediaObject,
   subcomponents: {MediaFigure, MediaBody},
   argTypes: {verticalAlign: {defaultValue: 'top'}},
 };
 
 export const Default = (): React.ReactNode => {
-  const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
-  const marginBottomValue = select(
-    'marginBottom',
-    Object.keys(DefaultTheme.space),
-    'space0'
-  ) as keyof ThemeShape['space'];
-  const marginTopValue = select('marginTop', Object.keys(DefaultTheme.space), 'space0') as keyof ThemeShape['space'];
-  const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
-  const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
+  const spaceValue = 'space20' as keyof ThemeShape['space'];
+  const marginBottomValue = 'space0' as keyof ThemeShape['space'];
+  const marginTopValue = 'space0' as keyof ThemeShape['space'];
+  const verticalAlignValue = 'top';
+  const asValue = 'span' as keyof JSX.IntrinsicElements;
   return (
     <MediaObject
       as={asValue}
@@ -45,15 +38,11 @@ export const Default = (): React.ReactNode => {
 };
 
 export const DoubleFigure = (): React.ReactNode => {
-  const spaceValue = select('spacing', Object.keys(DefaultTheme.space), 'space20') as keyof ThemeShape['space'];
-  const marginBottomValue = select(
-    'marginBottom',
-    Object.keys(DefaultTheme.space),
-    'space0'
-  ) as keyof ThemeShape['space'];
-  const marginTopValue = select('marginTop', Object.keys(DefaultTheme.space), 'space0') as keyof ThemeShape['space'];
-  const verticalAlignValue = select('verticalAlign', ['center', 'top'], 'top');
-  const asValue = text('as', 'span') as keyof JSX.IntrinsicElements;
+  const spaceValue = 'space20' as keyof ThemeShape['space'];
+  const marginBottomValue = 'space0' as keyof ThemeShape['space'];
+  const marginTopValue = 'space0' as keyof ThemeShape['space'];
+  const verticalAlignValue = 'top';
+  const asValue = 'span' as keyof JSX.IntrinsicElements;
   return (
     <MediaObject
       as={asValue}

--- a/packages/paste-core/layout/stack/stories/index.stories.tsx
+++ b/packages/paste-core/layout/stack/stories/index.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import {withKnobs, select} from '@storybook/addon-knobs';
 import type {ThemeShape} from '@twilio-paste/theme';
-import {DefaultTheme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
 import {Heading} from '@twilio-paste/heading';
@@ -10,19 +8,15 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import type {StackOrientation} from '../src';
 import {Stack} from '../src';
 
-const orientationOptions = ['horizontal', 'vertical'];
-const spaceOptions = Object.keys(DefaultTheme.space);
-
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Layout/Stack',
-  decorators: [withKnobs],
   component: Stack,
 };
 
 export const DefaultStack = (): React.ReactNode => {
-  const orientaionValue = select('orientation', orientationOptions, 'vertical') as StackOrientation;
-  const spaceValue = select('spacing', spaceOptions, 'space40') as keyof ThemeShape['space'];
+  const orientaionValue = 'vertical' as StackOrientation;
+  const spaceValue = 'space40' as keyof ThemeShape['space'];
   return (
     <Stack orientation={orientaionValue} spacing={spaceValue}>
       <Card>

--- a/packages/paste-core/primitives/box/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/box/stories/index.stories.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import {withKnobs, select, text} from '@storybook/addon-knobs';
-import {DefaultTheme} from '@twilio-paste/theme';
 import type {ThemeShape} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import {Separator} from '@twilio-paste/separator';
@@ -8,85 +6,46 @@ import {Text} from '@twilio-paste/text';
 import {Box} from '../src';
 import {CustomizableBoxExample} from '../__fixtures__/CustomizableBox';
 
-const backgroundColorOptions = Object.keys(DefaultTheme.backgroundColors);
-const spaceOptions = Object.keys(DefaultTheme.space);
-const widthOptions = Object.keys(DefaultTheme.widths);
-const minWidthOptions = Object.keys(DefaultTheme.minWidths);
-const maxWidthOptions = Object.keys(DefaultTheme.maxWidths);
-const heightOptions = Object.keys(DefaultTheme.heights);
-const minHeightOptions = Object.keys(DefaultTheme.minHeights);
-const maxHeightOptions = Object.keys(DefaultTheme.maxHeights);
-const borderRadiusOptions = Object.keys(DefaultTheme.radii);
-const borderColorOptions = Object.keys(DefaultTheme.borderColors);
-const borderWidthOptions = Object.keys(DefaultTheme.borderWidths);
-const boxShadowOptions = Object.keys(DefaultTheme.shadows);
-const zIndexOptions = Object.keys(DefaultTheme.zIndices);
-
 const demoString = `I'm some text in a box`;
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Primitives/Box',
-  decorators: [withKnobs],
   component: Box,
 };
 
 export const Default = (): React.ReactNode => {
-  const backgroudColorValue = select(
-    'backgroundColor',
-    backgroundColorOptions,
-    'colorBackgroundPrimaryWeak'
-  ) as keyof ThemeShape['backgroundColors'];
+  const backgroudColorValue = 'colorBackgroundPrimaryWeak' as keyof ThemeShape['backgroundColors'];
 
-  const borderRadiusValue = select('borderRadius', borderRadiusOptions, 'borderRadius20') as keyof ThemeShape['radii'];
-  const borderTopLeftRadiusValue = select('borderTopLeftRadius', borderRadiusOptions, '') as keyof ThemeShape['radii'];
-  const borderTopRightRadiusValue = select(
-    'borderTopRightRadius',
-    borderRadiusOptions,
-    ''
-  ) as keyof ThemeShape['radii'];
-  const borderBottomLeftRadiusValue = select(
-    'borderBottomLeftRadius',
-    borderRadiusOptions,
-    ''
-  ) as keyof ThemeShape['radii'];
+  const borderRadiusValue = 'borderRadius20' as keyof ThemeShape['radii'];
+  const borderTopLeftRadiusValue = '' as keyof ThemeShape['radii'];
+  const borderTopRightRadiusValue = '' as keyof ThemeShape['radii'];
+  const borderBottomLeftRadiusValue = '' as keyof ThemeShape['radii'];
 
-  const borderBottomRightRadiusValue = select(
-    'borderBottomRightRadius',
-    borderRadiusOptions,
-    ''
-  ) as keyof ThemeShape['radii'];
+  const borderBottomRightRadiusValue = '' as keyof ThemeShape['radii'];
 
-  const borderWidthValue = select('borderWidth', borderWidthOptions, '') as keyof ThemeShape['borderWidths'];
-  const borderTopWidthValue = select('borderTopWidth', borderWidthOptions, '') as keyof ThemeShape['borderWidths'];
-  const borderRightWidthValue = select('borderRightWidth', borderWidthOptions, '') as keyof ThemeShape['borderWidths'];
-  const borderBottomWidthValue = select(
-    'borderBottomWidth',
-    borderWidthOptions,
-    ''
-  ) as keyof ThemeShape['borderWidths'];
-  const borderLeftWidthValue = select('borderLeftWidth', borderWidthOptions, '') as keyof ThemeShape['borderWidths'];
-  const borderColorValue = select(
-    'borderColor',
-    borderColorOptions,
-    'colorBorderPrimaryStrong'
-  ) as keyof ThemeShape['borderColors'];
-  const borderStyleValue = text('borderStyle', 'solid');
+  const borderWidthValue = '' as keyof ThemeShape['borderWidths'];
+  const borderTopWidthValue = '' as keyof ThemeShape['borderWidths'];
+  const borderRightWidthValue = '' as keyof ThemeShape['borderWidths'];
+  const borderBottomWidthValue = '' as keyof ThemeShape['borderWidths'];
+  const borderLeftWidthValue = '' as keyof ThemeShape['borderWidths'];
+  const borderColorValue = 'colorBorderPrimaryStrong' as keyof ThemeShape['borderColors'];
+  const borderStyleValue = 'solid';
 
-  const paddingValue = select('padding', spaceOptions, 'space20') as keyof ThemeShape['space'];
-  const marginValue = select('margin', spaceOptions, 'space40') as keyof ThemeShape['space'];
+  const paddingValue = 'space20' as keyof ThemeShape['space'];
+  const marginValue = 'space40' as keyof ThemeShape['space'];
 
-  const widthValue = select('width', widthOptions, '') as keyof ThemeShape['widths'];
-  const minWidthValue = select('minWidth', minWidthOptions, '') as keyof ThemeShape['minWidths'];
-  const maxWidthValue = select('maxWidth', maxWidthOptions, '') as keyof ThemeShape['maxWidths'];
-  const heightValue = select('height', heightOptions, 'size10') as keyof ThemeShape['heights'];
-  const minHeightValue = select('minHeight', minHeightOptions, '') as keyof ThemeShape['minHeights'];
-  const maxHeightValue = select('maxHeight', maxHeightOptions, '') as keyof ThemeShape['maxHeights'];
+  const widthValue = '' as keyof ThemeShape['widths'];
+  const minWidthValue = '' as keyof ThemeShape['minWidths'];
+  const maxWidthValue = '' as keyof ThemeShape['maxWidths'];
+  const heightValue = 'size10' as keyof ThemeShape['heights'];
+  const minHeightValue = '' as keyof ThemeShape['minHeights'];
+  const maxHeightValue = '' as keyof ThemeShape['maxHeights'];
 
-  const boxShadowValue = select('boxShadow', boxShadowOptions, '') as keyof ThemeShape['shadows'];
-  const zIndexValue = select('zIndex', zIndexOptions, '') as keyof ThemeShape['zIndices'];
-  const displayValue = text('display', 'block');
-  const overflowValue = text('overflow', 'hidden');
+  const boxShadowValue = '' as keyof ThemeShape['shadows'];
+  const zIndexValue = '' as keyof ThemeShape['zIndices'];
+  const displayValue = 'block';
+  const overflowValue = 'hidden';
 
   return (
     <Box

--- a/packages/paste-core/primitives/modal-dialog/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/modal-dialog/stories/index.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {withKnobs, boolean} from '@storybook/addon-knobs';
 import {styled} from '@twilio-paste/styling-library';
 import {Text} from '@twilio-paste/text';
 import {Button} from '@twilio-paste/button';
@@ -35,12 +34,7 @@ const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}
   const inputRef: React.RefObject<HTMLInputElement> = React.useRef(null);
 
   return (
-    <StyledModalDialogOverlay
-      isOpen={isOpen}
-      onDismiss={handleClose}
-      allowPinchZoom={boolean('allowPinchZoom', true)}
-      initialFocusRef={inputRef}
-    >
+    <StyledModalDialogOverlay isOpen={isOpen} onDismiss={handleClose} allowPinchZoom initialFocusRef={inputRef}>
       <StyledModalDialogContent>
         <input type="text" value="first" />
         <br />
@@ -56,7 +50,6 @@ const BasicModalDialog: React.FC<BasicModalDialogProps> = ({isOpen, handleClose}
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Primitives/ModalDialog',
-  decorators: [withKnobs],
   component: ModalDialogPrimitiveOverlay,
   subcomponents: {ModalDialogPrimitiveContent},
 };

--- a/packages/paste-core/primitives/text/stories/index.stories.tsx
+++ b/packages/paste-core/primitives/text/stories/index.stories.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import {withKnobs, text, select} from '@storybook/addon-knobs';
-import {DefaultTheme} from '@twilio-paste/theme';
 import {Separator} from '@twilio-paste/separator';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {
@@ -25,51 +23,43 @@ import type {
 import {Text} from '../src';
 import {CustomizableTextExample} from '../__fixtures__/CustomizableText';
 
-const fontSizeOptions = Object.keys(DefaultTheme.fontSizes);
-const fontFamilyOptions = [''].concat(Object.keys(DefaultTheme.fonts));
-const fontWeightOptions = [''].concat(Object.keys(DefaultTheme.fontWeights));
-const lineHeightOptions = Object.keys(DefaultTheme.lineHeights);
-const spaceOptions = [''].concat(Object.keys(DefaultTheme.space));
-const textColorOptions = Object.keys(DefaultTheme.textColors);
-
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Primitives/Text',
-  decorators: [withKnobs],
   component: Text,
 };
 
 export const Default = (): React.ReactNode => {
-  const asValue = text('as', 'p') as keyof JSX.IntrinsicElements;
-  const displayValue = text('display', '') as Display;
+  const asValue = 'p' as keyof JSX.IntrinsicElements;
+  const displayValue = '' as Display;
 
-  const fontFamilyValue = select('fontFamily', fontFamilyOptions, '') as FontFamily;
-  const fontSizeValue = select('fontSize', fontSizeOptions, 'fontSize30') as FontSize;
-  const fontStyleValue = text('fontStyle', '') as FontStyle;
-  const fontWeightValue = select('fontWeight', fontWeightOptions, '') as FontWeight;
-  const letterSpacingValue = text('letterSpacing', '') as LetterSpacing;
-  const lineHeightValue = select('lineHeight', lineHeightOptions, 'lineHeight30') as LineHeight;
-  const textAlignValue = text('textAlign', '') as TextAlign;
-  const textColorValue = select('color', textColorOptions, 'colorText') as TextColor;
-  const textDecorationValue = text('textDecoration', '') as TextDecoration;
+  const fontFamilyValue = '' as FontFamily;
+  const fontSizeValue = 'fontSize30' as FontSize;
+  const fontStyleValue = '' as FontStyle;
+  const fontWeightValue = '' as FontWeight;
+  const letterSpacingValue = '' as LetterSpacing;
+  const lineHeightValue = '' as LineHeight;
+  const textAlignValue = '' as TextAlign;
+  const textColorValue = 'colorText' as TextColor;
+  const textDecorationValue = '' as TextDecoration;
 
-  const overflowValue = text('overflow', '') as Overflow;
-  const overflowXValue = text('overflowX', '') as OverflowX;
-  const overflowYValue = text('overflowY', '') as OverflowY;
-  const textOverflowValue = text('textOverflow', '') as TextOverflow;
-  const whiteSpaceValue = text('whiteSpace', '') as WhiteSpace;
-  const fontVariantNumericValue = text('fontVariantNumeric', '');
+  const overflowValue = '' as Overflow;
+  const overflowXValue = '' as OverflowX;
+  const overflowYValue = '' as OverflowY;
+  const textOverflowValue = '' as TextOverflow;
+  const whiteSpaceValue = '' as WhiteSpace;
+  const fontVariantNumericValue = '';
 
-  const paddingValue = select('padding', spaceOptions, '') as Padding;
-  const paddingBottomValue = select('paddingBottom', spaceOptions, '') as Padding;
-  const paddingLeftValue = select('paddingLeft', spaceOptions, '') as Padding;
-  const paddingRightValue = select('paddingRight', spaceOptions, '') as Padding;
-  const paddingTopValue = select('paddingTop', spaceOptions, '') as Padding;
-  const marginValue = select('margin', spaceOptions, '') as Margin;
-  const marginBottomValue = select('marginBottom', spaceOptions, '') as Margin;
-  const marginLeftValue = select('marginLeft', spaceOptions, '') as Margin;
-  const marginRightValue = select('marginRight', spaceOptions, '') as Margin;
-  const marginTopValue = select('marginTop', spaceOptions, '') as Margin;
+  const paddingValue = '' as Padding;
+  const paddingBottomValue = '' as Padding;
+  const paddingLeftValue = '' as Padding;
+  const paddingRightValue = '' as Padding;
+  const paddingTopValue = '' as Padding;
+  const marginValue = '' as Margin;
+  const marginBottomValue = '' as Margin;
+  const marginLeftValue = '' as Margin;
+  const marginRightValue = '' as Margin;
+  const marginTopValue = '' as Margin;
   return (
     <Text
       as={asValue}

--- a/packages/paste-icons/stories/index.stories.tsx
+++ b/packages/paste-icons/stories/index.stories.tsx
@@ -5,35 +5,40 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import {Stack} from '@twilio-paste/stack';
 import {Text} from '@twilio-paste/text';
 import {Flex} from '@twilio-paste/flex';
-import {withKnobs, select, text, boolean} from '@storybook/addon-knobs';
 import {CopyIcon} from '../src/CopyIcon';
 
-const ColorOptions = Object.keys(DefaultTheme.textColors) as TextColorOptions[];
 const SizeOptions = Object.keys(DefaultTheme.iconSizes) as IconSizeOptions[];
+const ColorOptions = Object.keys(DefaultTheme.textColors) as TextColorOptions[];
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: 'Components/Icon',
-  decorators: [withKnobs],
   component: CopyIcon,
 };
 
 export const Default = (): React.ReactNode => {
-  const sizeValue = select('size', SizeOptions, 'sizeIcon30');
-  const colorValue = select('color', ColorOptions, 'currentColor');
+  const sizeValue = 'sizeIcon30';
+  const colorValue = 'currentColor';
 
-  return (
-    <CopyIcon
-      size={sizeValue}
-      color={colorValue}
-      title={text('title', 'Icon text')}
-      decorative={boolean('decorative', true)}
-    />
-  );
+  return <CopyIcon size={sizeValue} color={colorValue} title="Icon text" decorative />;
 };
 
 Default.story = {
   name: 'default',
+};
+
+export const Colors = (): React.ReactNode => {
+  return (
+    <Stack orientation="horizontal" spacing="space40">
+      {ColorOptions.map((color: TextColorOptions) => (
+        <CopyIcon color={color} decorative />
+      ))}
+    </Stack>
+  );
+};
+
+Colors.story = {
+  name: 'colors',
 };
 
 export const Sizes = (): React.ReactNode => {

--- a/tools/plop-templates/component-stories.hbs
+++ b/tools/plop-templates/component-stories.hbs
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import {withKnobs} from '@storybook/addon-knobs';
 {{import component-name}} from '../src';
 
 
 // eslint-disable-next-line import/no-default-export
 export default {
   title: '{{titleCase component-type}}/{{titleCase component-name}}',
-  decorators: [withKnobs],
   component: {{pascalCase component-name}},
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,7 +2123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.13.17, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.13.17, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.17.8
   resolution: "@babel/runtime@npm:7.17.8"
   dependencies:
@@ -2961,7 +2961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^10.0.27, @emotion/cache@npm:^10.0.9":
+"@emotion/cache@npm:^10.0.27":
   version: 10.0.29
   resolution: "@emotion/cache@npm:10.0.29"
   dependencies:
@@ -2989,7 +2989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/css@npm:^10.0.27, @emotion/css@npm:^10.0.9":
+"@emotion/css@npm:^10.0.27":
   version: 10.0.27
   resolution: "@emotion/css@npm:10.0.27"
   dependencies:
@@ -7449,38 +7449,6 @@ __metadata:
     webpack:
       optional: true
   checksum: ee23765b5939fdb1abb026c6a3dffd0689c435ea44ad70475470312c5fd3823c790e9739ea07994abb7b842164117d59b1cc94656b1c60fe382221a9d32073d9
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-knobs@npm:6.4.0":
-  version: 6.4.0
-  resolution: "@storybook/addon-knobs@npm:6.4.0"
-  dependencies:
-    copy-to-clipboard: ^3.3.1
-    core-js: ^3.8.2
-    escape-html: ^1.0.3
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.20
-    prop-types: ^15.7.2
-    qs: ^6.10.0
-    react-colorful: ^5.1.2
-    react-lifecycles-compat: ^3.0.4
-    react-select: ^3.2.0
-  peerDependencies:
-    "@storybook/addons": ^6.4.0
-    "@storybook/api": ^6.4.0
-    "@storybook/components": ^6.4.0
-    "@storybook/core-events": ^6.4.0
-    "@storybook/theming": ^6.4.0
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: d9ea65af55e3983e7150aa0492f99027db06ca267eae5be19ace88f9733d1e858a35ba6cd0ff324f42fc32c03665ebf39e0f04777ec3b715300a2504de81a493
   languageName: node
   linkType: hard
 
@@ -20287,16 +20255,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-helpers@npm:^5.0.1":
-  version: 5.1.4
-  resolution: "dom-helpers@npm:5.1.4"
-  dependencies:
-    "@babel/runtime": ^7.8.7
-    csstype: ^2.6.7
-  checksum: e516325d662f57db7724e6fe26ae5b36b6974f74ae2513998f408bf056670c05ed010bb3be866ac454110249a9e88aaa6451e63e4efa87f834041ef8303ace68
-  languageName: node
-  linkType: hard
-
 "dom-iterator@npm:^1.0.0":
   version: 1.0.0
   resolution: "dom-iterator@npm:1.0.0"
@@ -21441,7 +21399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
+"escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -31421,7 +31379,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"memoize-one@npm:^5.0.0, memoize-one@npm:^5.2.1":
+"memoize-one@npm:^5.2.1":
   version: 5.2.1
   resolution: "memoize-one@npm:5.2.1"
   checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
@@ -34667,7 +34625,6 @@ fsevents@~2.1.2:
     "@storybook/addon-a11y": 6.4.20
     "@storybook/addon-actions": 6.4.20
     "@storybook/addon-essentials": 6.4.20
-    "@storybook/addon-knobs": 6.4.0
     "@storybook/addon-links": 6.4.20
     "@storybook/addon-viewport": 6.4.20
     "@storybook/addons": 6.4.20
@@ -36659,7 +36616,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.6, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.6, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -37394,17 +37351,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-input-autosize@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "react-input-autosize@npm:3.0.0"
-  dependencies:
-    prop-types: ^15.5.8
-  peerDependencies:
-    react: ^16.3.0 || ^17.0.0
-  checksum: cc3309ddc87446ade742c7d0e88ef089dd8b6981f21506a2bb27daf01a8803ac697f64157c4ffc7e81dfcf3892b54a4072dbc3652fd9addcf6d22dd0b87ab723
-  languageName: node
-  linkType: hard
-
 "react-inspector@npm:^5.1.0":
   version: 5.1.1
   resolution: "react-inspector@npm:5.1.1"
@@ -37657,25 +37603,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-select@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "react-select@npm:3.2.0"
-  dependencies:
-    "@babel/runtime": ^7.4.4
-    "@emotion/cache": ^10.0.9
-    "@emotion/core": ^10.0.9
-    "@emotion/css": ^10.0.9
-    memoize-one: ^5.0.0
-    prop-types: ^15.6.0
-    react-input-autosize: ^3.0.0
-    react-transition-group: ^4.3.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 082c818369fb8c7ce50bbd51260b21794f58dd41e9df5e0798c10e10478fb44b9fd88247f24720d5b443d77a6ec8afa733ecdd15a7722fde85c27bb87c379962
-  languageName: node
-  linkType: hard
-
 "react-side-effect@npm:^2.1.0":
   version: 2.1.1
   resolution: "react-side-effect@npm:2.1.1"
@@ -37752,21 +37679,6 @@ fsevents@~2.1.2:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
   checksum: da3d0192825df3d9f27eef33e7eddf928359a7e3e2b01ae7f7f672ecf4e5c1f7a34f27bdde9ccc24e2e9fbe1d1b9dd2a39c7d47323c9bdf63e7b9bd05c325a71
-  languageName: node
-  linkType: hard
-
-"react-transition-group@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "react-transition-group@npm:4.3.0"
-  dependencies:
-    "@babel/runtime": ^7.5.5
-    dom-helpers: ^5.0.1
-    loose-envify: ^1.4.0
-    prop-types: ^15.6.2
-  peerDependencies:
-    react: ">=16.6.0"
-    react-dom: ">=16.6.0"
-  checksum: a47f2d16e695adfc6ba1830b25ac9eeb1a2890f90949472bc8516b74dfc134591a2a0cabe0e83b5c2ba3c63aac6f4c87d49d24e2b340a12bc3d8de9d064f930a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Removes deprecated Storybook knobs from dependencies, config, and all stories that had been using them.
  * In certain cases (eg: Alert, Heading, Input), we removed stories which were built to be primarily used with Knobs controls.
  * In other cases (eg: Anchor, Card), we simply removed the Knobs controlled variables and replaced the values with the declared defaults.
* Removes Knobs references from plop template.
* PR also removes the Knobs addon from the Storybook config, and the Knobs dependency in our package.json.
