### PR TITLE
feat: add a stickyHeader prop to the THead element

### DIFF
--- a/packages/paste-core/components/data-grid/stories/components/StickyHeaderDataGrid.tsx
+++ b/packages/paste-core/components/data-grid/stories/components/StickyHeaderDataGrid.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import type {BoxProps} from '@twilio-paste/box';
+import {DataGrid, DataGridHead, DataGridRow, DataGridHeader, DataGridBody, DataGridCell, DataGridFoot} from '../../src';
+
+export const StickyHeaderDataGrid: React.FC<{element?: BoxProps['element']}> = ({element = 'DATA_GRID'}) => {
+  /* eslint-disable react/no-array-index-key */
+  return (
+    <>
+      <DataGrid aria-label="User information table" data-testid="data-grid" element={element}>
+        <DataGridHead data-testid="data-grid-head" element={`${element}_HEAD`} stickyHeader={true}>
+          <DataGridRow element={`${element}_ROW`}>
+            <DataGridHeader element={`${element}_HEADER`}>
+              Header should stick on the top while scrolling
+            </DataGridHeader>
+          </DataGridRow>
+        </DataGridHead>
+        <DataGridBody data-testid="data-grid-body" element={`${element}_BODY`}>
+          {[...Array(100).keys()].map((rowIndex) => (
+            <DataGridRow key={`row-${rowIndex}`} data-testid={'data-grid-row'} element={`${element}_ROW`}>
+              <DataGridCell element={`${element}_CELL`} key={`col-0`} data-testid={'data-grid-cell'}>
+                content
+              </DataGridCell>
+            </DataGridRow>
+          ))}
+        </DataGridBody>
+        <DataGridFoot data-testid="data-grid-foot" element={`${element}_FOOT`}>
+          <DataGridRow>
+            <DataGridCell element={`${element}_CELL`}>Footer</DataGridCell>
+          </DataGridRow>
+        </DataGridFoot>
+      </DataGrid>
+    </>
+  );
+  /* eslint-enable react/no-array-index-key */
+};

--- a/packages/paste-core/components/data-grid/stories/index.stories.tsx
+++ b/packages/paste-core/components/data-grid/stories/index.stories.tsx
@@ -7,6 +7,7 @@ export {SortableColumnsDataGrid} from './components/SortableColumnsDataGrid';
 export {KitchenSinkDataGrid} from './components/KitchenSinkDataGrid';
 export {I18nDataGrid} from './components/I18nDataGrid';
 export {DataGridLayouts} from './components/DataGridLayouts';
+export {StickyHeaderDataGrid} from './components/StickyHeaderDataGrid';
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/packages/paste-core/components/table/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/table/__tests__/index.spec.tsx
@@ -127,6 +127,22 @@ describe('Table', () => {
     expect(renderedTr).toHaveStyleRule('vertical-align', 'bottom');
   });
 
+  it('should render thead with sticky header css if prop is passed', (): void => {
+    render(
+      <Table>
+        <THead stickyHeader={true} data-testid="mockTHead">
+          <Tr>
+            <Th>Column 1</Th>
+          </Tr>
+        </THead>
+      </Table>
+    );
+    const renderedTh = screen.getByTestId('mockTHead');
+    expect(renderedTh).toHaveStyleRule('position', 'sticky');
+    expect(renderedTh).toHaveStyleRule('top', '-1px');
+    expect(renderedTh).toHaveStyleRule('z-index', 'zIndex10');
+  });
+
   it('should render Th width and left textAlign styles', (): void => {
     render(
       <Table>

--- a/packages/paste-core/components/table/src/THead.tsx
+++ b/packages/paste-core/components/table/src/THead.tsx
@@ -3,20 +3,25 @@ import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import type {THeadProps} from './types';
 import {THeadPropTypes} from './proptypes';
 
-const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(({element = 'THEAD', ...props}, ref) => {
-  return (
-    <Box
-      {...safelySpreadBoxProps(props)}
-      ref={ref}
-      as="thead"
-      backgroundColor="colorBackground"
-      borderBottomColor="colorBorderWeaker"
-      borderBottomStyle="solid"
-      borderBottomWidth="borderWidth20"
-      element={element}
-    />
-  );
-});
+const THead = React.forwardRef<HTMLTableSectionElement, THeadProps>(
+  ({element = 'THEAD', stickyHeader = false, ...props}, ref) => {
+    return (
+      <Box
+        {...safelySpreadBoxProps(props)}
+        ref={ref}
+        as="thead"
+        backgroundColor="colorBackground"
+        borderBottomColor="colorBorderWeaker"
+        borderBottomStyle="solid"
+        borderBottomWidth="borderWidth20"
+        element={element}
+        position={stickyHeader ? 'sticky' : null}
+        top={stickyHeader ? '-1px' : null}
+        zIndex={stickyHeader ? 'zIndex10' : null}
+      />
+    );
+  }
+);
 
 THead.displayName = 'THead';
 

--- a/packages/paste-core/components/table/src/types.ts
+++ b/packages/paste-core/components/table/src/types.ts
@@ -39,6 +39,7 @@ export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> 
 export interface THeadProps extends React.TableHTMLAttributes<HTMLTableSectionElement> {
   children: NonNullable<React.ReactNode>;
   element?: BoxProps['element'];
+  stickyHeader?: boolean;
 }
 export interface TBodyProps extends React.TableHTMLAttributes<HTMLTableSectionElement> {
   children: NonNullable<React.ReactNode>;

--- a/packages/paste-core/components/table/stories/index.stories.tsx
+++ b/packages/paste-core/components/table/stories/index.stories.tsx
@@ -943,6 +943,33 @@ RowHeaders.story = {
   name: 'Row headers',
 };
 
+export const StickyHeaders = (): React.ReactNode => {
+  return (
+    <Table>
+      <THead stickyHeader={true}>
+        <Tr>
+          <Th>Column 1</Th>
+          <Th>Column 2</Th>
+          <Th>Column 3</Th>
+        </Tr>
+      </THead>
+      <TBody>
+        {[...Array(100).keys()].map((index) => (
+          <Tr key={index}>
+            <Td>Content</Td>
+            <Td>Content</Td>
+            <Td>Content</Td>
+          </Tr>
+        ))}
+      </TBody>
+    </Table>
+  );
+};
+
+StickyHeaders.story = {
+  name: 'Sticky headers',
+};
+
 export const Truncation = (): React.ReactNode => {
   return (
     <Table tableLayout="fixed">


### PR DESCRIPTION
add a stickyHeader prop to the THead element.
This will be used by Table component and the Datagrid component

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
