### PR TITLE
chore: track github action workflow metrics in datadog

### DIFF
--- a/.github/workflows/track-workflow-metrics.yml
+++ b/.github/workflows/track-workflow-metrics.yml
@@ -1,6 +1,6 @@
 name: Track workflow metrics
 
-# Controls when the workflow will run
+# Run when workflows complete, on pull request and on push
 on:
   workflow_run:
     workflows:
@@ -13,7 +13,7 @@ on:
 jobs:
   send:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: int128/datadog-actions-metrics@v1
         with:

--- a/.github/workflows/track-workflow-metrics.yml
+++ b/.github/workflows/track-workflow-metrics.yml
@@ -1,0 +1,22 @@
+name: Track workflow metrics
+
+# Controls when the workflow will run
+on:
+  workflow_run:
+    workflows:
+      - "**"
+    types:
+      - completed
+  pull_request:
+  push:
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: int128/datadog-actions-metrics@v1
+        with:
+          # create an API key in https://docs.datadoghq.com/account_management/api-app-keys/
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          collect-job-metrics: true


### PR DESCRIPTION
Notice Console doing this, so I'm stealing the idea.

In an effort to reduce our build minutes, we need to get a baseline, and actually track what we're using so we can prove success. 

This github action fires all the workflow data into datadog so we can create dashboard around that data. 

I'm unsure if my application key will work, might need a full API key.

*Answer to that is no, investigating*