### PR TITLE
chore(website): add link to our copy-to-clipboard library to website

### DIFF
--- a/packages/paste-website/src/pages/core/libraries/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/index.mdx
@@ -51,6 +51,10 @@ The output will work similarly to the icons provided in Paste. This library was 
 self-service when suggesting new Paste icons or when individual product needs differ from Paste. For more
 information, see our [icon guidelines](/components/icons/usage-guidelines) and our [how-to docs](/introduction/contributing/icons).
 
+### [clipboard-copy](https://github.com/twilio-labs/paste/tree/main/packages/paste-libraries/clipboard-copy)
+
+This is a simple wrapper around [`use-clipboard-copy`](https://github.com/wsmd/use-clipboard-copy). We leverage this package to provide our baseline functionality for developers to intuitively interact with the Clipboard API.
+
 </content>
 
 </contentwrapper>

--- a/packages/paste-website/src/pages/core/libraries/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/index.mdx
@@ -53,7 +53,7 @@ information, see our [icon guidelines](/components/icons/usage-guidelines) and o
 
 ### [clipboard-copy](https://github.com/twilio-labs/paste/tree/main/packages/paste-libraries/clipboard-copy)
 
-This is a simple wrapper around [`use-clipboard-copy`](https://github.com/wsmd/use-clipboard-copy). We leverage this package to provide our baseline functionality for developers to intuitively interact with the Clipboard API.
+This is a simple wrapper around <strong>[use-clipboard-copy](https://github.com/wsmd/use-clipboard-copy)</strong>. We leverage this package to provide our baseline functionality for developers to intuitively interact with the Clipboard API.
 
 </content>
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->
## Description

Due to our temporary HAP we are not able to pick up the work of adding a copy to clipboard pattern to our docs website. This(these) commit(s) add a link to the library source code, along with some brief context on how we use it.

> <img width="842" alt="Screen Shot 2022-05-25 at 3 14 21 PM" src="https://user-images.githubusercontent.com/18120906/170359330-e715d437-1db3-40d3-a030-acc7fc3e66aa.png">

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
