### PR TITLE
chore: track github actions metrics

### DIFF
--- a/.github/workflows/track-workflow-metrics.yml
+++ b/.github/workflows/track-workflow-metrics.yml
@@ -1,6 +1,6 @@
 name: Track workflow metrics
 
-# Controls when the workflow will run
+# Run when workflows complete, on pull request and on push
 on:
   workflow_run:
     workflows:
@@ -13,7 +13,7 @@ on:
 jobs:
   send:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: int128/datadog-actions-metrics@v1
         with:

--- a/.github/workflows/track-workflow-metrics.yml
+++ b/.github/workflows/track-workflow-metrics.yml
@@ -1,0 +1,22 @@
+name: Track workflow metrics
+
+# Controls when the workflow will run
+on:
+  workflow_run:
+    workflows:
+      - "**"
+    types:
+      - completed
+  pull_request:
+  push:
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: int128/datadog-actions-metrics@v1
+        with:
+          # create an API key in https://docs.datadoghq.com/account_management/api-app-keys/
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          collect-job-metrics: true


### PR DESCRIPTION
Track some event data in PRs about their workflow jobs and step in GH actions when:

- A workflow completes
- PR open or closed
- Commit pushed

It should be noted the data pushed to Datadog, differs per event type as they are tracking different things. https://github.com/int128/datadog-actions-metrics#metrics-for-workflow_run-event

**NOTE:** I'm not seeing workflow data being posted to DD yet, because of this caveat on the workflow_run event in the Github docs:

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run

So, until this is merged, no workflow data. Frustrating