### PR TITLE
fix(tabs): enable left right arrows on vertical tabs

### DIFF
--- a/.changeset/fifty-snails-end.md
+++ b/.changeset/fifty-snails-end.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/tabs': patch
+'@twilio-paste/core': patch
+---
+
+[Tabs] Enable left/right arrow key tab switching on vertical tabs in addition to up/down

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -109,7 +109,13 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element, ...t
   const elementName = getElementName(orientation, 'TAB', element);
 
   return (
-    <TabPrimitive {...(tab as any)} {...tabProps} ref={ref}>
+    <TabPrimitive
+      {...(tab as any)}
+      {...tabProps}
+      // Setting orientation to undefined for vertical tabs enables up/down and left/right arrow key control
+      orientation={orientation === 'vertical' ? undefined : 'horizontal'}
+      ref={ref}
+    >
       {(props: TabProps) => {
         return (
           <Box
@@ -134,13 +140,11 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({children, element, ...t
   );
 });
 
-if (process.env.NODE_ENV === 'development') {
-  Tab.propTypes = {
-    id: PropTypes.string,
-    focusable: PropTypes.bool,
-    disabled: PropTypes.bool,
-  };
-}
+Tab.propTypes = {
+  id: PropTypes.string,
+  focusable: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
 
 Tab.displayName = 'Tab';
 

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -56,14 +56,12 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>(({children, eleme
   );
 });
 
-if (process.env.NODE_ENV === 'development') {
-  TabList.propTypes = {
-    'aria-label': PropTypes.string.isRequired,
-    focusable: PropTypes.bool,
-    disabled: PropTypes.bool,
-    element: PropTypes.string,
-  };
-}
+TabList.propTypes = {
+  'aria-label': PropTypes.string.isRequired,
+  focusable: PropTypes.bool,
+  disabled: PropTypes.bool,
+  element: PropTypes.string,
+};
 
 TabList.displayName = 'TabList';
 export {TabList};

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -45,14 +45,12 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   }
 );
 
-if (process.env.NODE_ENV === 'development') {
-  Tabs.propTypes = {
-    element: PropTypes.string,
-    selectedId: PropTypes.string,
-    orientation: PropTypes.oneOf(['horizontal', 'vertical', undefined]),
-    variant: PropTypes.oneOf(['fitted', null]),
-  };
-}
+Tabs.propTypes = {
+  element: PropTypes.string,
+  selectedId: PropTypes.string,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical', undefined]),
+  variant: PropTypes.oneOf(['fitted', null]),
+};
 
 Tabs.displayName = 'Tabs';
 export {Tabs};


### PR DESCRIPTION
Setting orientation to undefined for Reakit's keyboard control (https://reakit.io/docs/tab/#usetabstate)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
