### PR TITLE
chore(avatar): allow both src and icon prop to be passed

### DIFF
--- a/.changeset/itchy-poems-promise.md
+++ b/.changeset/itchy-poems-promise.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/avatar': patch
+'@twilio-paste/core': patch
+---
+
+[Avatar] allow both src and icon props at the same

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -46,10 +46,6 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
     if (name === undefined) {
       console.error('[Paste Avatar]: name prop is required');
     }
-    if (src && icon) {
-      console.error('[Paste Avatar]: do not set both src and icon on Avatar');
-      return null;
-    }
 
     return (
       <Box
@@ -79,17 +75,8 @@ Avatar.propTypes = {
   size: isIconSizeTokenProp,
   name: PropTypes.string.isRequired,
   element: PropTypes.string,
-  src: (props) => {
-    // eslint-disable-next-line no-new
-    if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
-    // eslint-disable-next-line no-new
-    if (typeof props.src !== 'string') new Error('[Paste Avatar]: src prop must be a string');
-    return null;
-  },
+  src: PropTypes.string,
   icon: (props) => {
-    // eslint-disable-next-line no-new
-    if (props.src && props.icon) new Error('[Paste Avatar]: do not set both src and icon on Avatar');
-    // eslint-disable-next-line no-new
     if (typeof props.icon !== 'function') new Error('[Paste Avatar]: icon prop must be a Paste Icon');
     return null;
   },

--- a/packages/paste-core/components/avatar/src/types.ts
+++ b/packages/paste-core/components/avatar/src/types.ts
@@ -2,23 +2,17 @@ import type {IconSize} from '@twilio-paste/style-props';
 import type {GenericIconProps} from '@twilio-paste/icons/esm/types';
 import type {BoxProps} from '@twilio-paste/box';
 
-type AvatarImage = {
-  src?: string;
-  icon?: never;
-};
-type AvatarIcon = {
-  src?: never;
-  icon?: React.FC<GenericIconProps>;
-};
-
 export type AvatarProps = React.HTMLAttributes<'div'> &
-  Pick<BoxProps, 'element'> &
-  (AvatarImage | AvatarIcon) & {
+  Pick<BoxProps, 'element'> & {
     name: string;
     size?: IconSize;
+    icon?: React.FC<GenericIconProps>;
+    src?: string;
   };
 
-export type AvatarContentProps = (AvatarImage | AvatarIcon) & {
+export type AvatarContentProps = {
   name: string;
   size?: IconSize;
+  icon?: React.FC<GenericIconProps>;
+  src?: string;
 };

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -119,7 +119,10 @@ Provide the Avatar with a source path via the `src` prop to render the Avatar as
 
 <Callout>
   <CalloutTitle>A note about Avatar contents</CalloutTitle>
-  <CalloutText>The Avatar component can either display an image or an icon, but not both.</CalloutText>
+  <CalloutText>
+    The Avatar component can either display an image or an icon, but not both. If both are present, the Avatar will
+    display the icon.
+  </CalloutText>
 </Callout>
 
 <LivePreview
@@ -147,7 +150,10 @@ Provide the Avatar with an `icon` prop to display an icon. You must import the i
 
 <Callout>
   <CalloutTitle>A note about Avatar contents</CalloutTitle>
-  <CalloutText>The Avatar component can either display an image or an icon, but not both.</CalloutText>
+  <CalloutText>
+    The Avatar component can either display an image or an icon, but not both. If both are present, the Avatar will
+    display the icon.
+  </CalloutText>
 </Callout>
 
 <LivePreview
@@ -198,6 +204,10 @@ The Avatar `size` can be set as a responsive array of sizes.
   />
 </Stack>`}
 </LivePreview>
+
+## Composition Notes
+
+The Avatar displays its contents in this priority: icon, then image, then initials.
 
 ## Anatomy
 


### PR DESCRIPTION
Made for: https://github.com/twilio-labs/paste/discussions/2437

We want to allow users to pass both src and icon so that they can display one or the other depending on if the image loads correctly.

This PR includes:
* updated AvatarProps
* updated Avatar prop types
* note on the docs site that if both src and icon are passed, the avatar will display the icon

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
