### PR TITLE
fix(avatar): prefer image over icon

### DIFF
--- a/.changeset/wicked-carrots-greet.md
+++ b/.changeset/wicked-carrots-greet.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/avatar': patch
+'@twilio-paste/core': patch
+---
+
+[Avatar] prefer image over icon

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -11,6 +11,9 @@ const DEFAULT_SIZE = 'sizeIcon70';
 
 const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE, src, icon: Icon}) => {
   const computedTokenNames = getComputedTokenNames(size);
+  if (src != null) {
+    return <Box as="img" alt={name} maxWidth="100%" src={src} size={size} title={name} />;
+  }
   if (Icon != null) {
     if (!isValidElementType(Icon) || typeof Icon.displayName !== 'string' || !Icon.displayName.includes('Icon')) {
       throw new Error('[Paste Avatar]: icon prop expected to be a Paste icon only.');
@@ -20,9 +23,6 @@ const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE
         <Icon decorative={false} title={name} size={computedTokenNames.iconSize} />
       </Box>
     );
-  }
-  if (src != null) {
-    return <Box as="img" alt={name} maxWidth="100%" src={src} size={size} title={name} />;
   }
   return (
     <Text
@@ -59,11 +59,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         size={size}
         color="colorText"
       >
-        {src ? (
-          <AvatarContents name={name} size={size} src={src} />
-        ) : (
-          <AvatarContents name={name} size={size} icon={icon} />
-        )}
+        <AvatarContents name={name} size={size} icon={icon} src={src} />
       </Box>
     );
   }

--- a/packages/paste-website/src/pages/components/avatar/index.mdx
+++ b/packages/paste-website/src/pages/components/avatar/index.mdx
@@ -121,7 +121,7 @@ Provide the Avatar with a source path via the `src` prop to render the Avatar as
   <CalloutTitle>A note about Avatar contents</CalloutTitle>
   <CalloutText>
     The Avatar component can either display an image or an icon, but not both. If both are present, the Avatar will
-    display the icon.
+    display the image.
   </CalloutText>
 </Callout>
 
@@ -152,7 +152,7 @@ Provide the Avatar with an `icon` prop to display an icon. You must import the i
   <CalloutTitle>A note about Avatar contents</CalloutTitle>
   <CalloutText>
     The Avatar component can either display an image or an icon, but not both. If both are present, the Avatar will
-    display the icon.
+    display the image.
   </CalloutText>
 </Callout>
 
@@ -207,7 +207,7 @@ The Avatar `size` can be set as a responsive array of sizes.
 
 ## Composition Notes
 
-The Avatar displays its contents in this priority: icon, then image, then initials.
+The Avatar displays its contents in this priority: image, then icon, then initials.
 
 ## Anatomy
 


### PR DESCRIPTION
Fast fix for: https://github.com/twilio-labs/paste/pull/2452

Image should be preferred to icon.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
