### PR TITLE
chore(truncate): fix alignment

### DIFF
--- a/.changeset/odd-pumpkins-count.md
+++ b/.changeset/odd-pumpkins-count.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/truncate': patch
+'@twilio-paste/core': patch
+---
+
+[Truncate] fix alignment when truncate is within another component

--- a/packages/paste-core/components/truncate/src/index.tsx
+++ b/packages/paste-core/components/truncate/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {Box, BoxProps} from '@twilio-paste/box';
-
+import {Box} from '@twilio-paste/box';
+import type {BoxProps} from '@twilio-paste/box';
 export interface TruncateProps extends Omit<React.HtmlHTMLAttributes<HTMLSpanElement>, 'color'>, Pick<BoxProps, 'as'> {
   children: NonNullable<React.ReactNode>;
   title: string;
@@ -13,6 +13,8 @@ const Truncate = React.forwardRef<HTMLSpanElement, TruncateProps>(({children, ..
       {...props}
       as="span"
       display="inline-block"
+      verticalAlign="bottom"
+      textDecoration="inherit"
       maxWidth="100%"
       overflow="hidden"
       ref={ref}

--- a/packages/paste-core/components/truncate/stories/index.stories.tsx
+++ b/packages/paste-core/components/truncate/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
+import {Anchor} from '@twilio-paste/anchor';
 import {Truncate} from '../src';
 
 // eslint-disable-next-line import/no-default-export
@@ -15,6 +16,16 @@ export const Default = (): React.ReactNode => {
       <Text as="p">
         <Truncate title="Some very long text to truncate">Some very long text to truncate</Truncate>
       </Text>
+    </Box>
+  );
+};
+
+export const TruncateInAnchor = (): React.ReactNode => {
+  return (
+    <Box maxWidth="size20">
+      <Anchor href="https://paste.twilio.design">
+        <Truncate title="A very very long anchor to truncate">A very very long anchor to truncate</Truncate>
+      </Anchor>
     </Box>
   );
 };


### PR DESCRIPTION
Currently, there is a bug where if you put a Truncate component where it pushes the container its in down and it makes it look like there's extra padding. 

Before:
<img width="368" alt="" src="https://user-images.githubusercontent.com/8482334/174408632-f5ad3e02-4c50-49b4-8385-d33755dfc13b.png">

After:
<img width="299" alt="" src="https://user-images.githubusercontent.com/8482334/174407543-4e14091d-e636-40cb-a4e7-1160fcb70374.png">

## Changes in this PR
* sets `verticalAlign: 'bottom'` to fix how the Truncate contents are aligned
* sets `textDecoration: 'inherit'` because I noticed that the Anchor text isn't underlined when it is truncated
* adds a `TruncateInAnchor` story


## Why does this fix it?
When you set `display: 'inline-block'`, `verticalAlign` defaults to `'baseline'` [which behaves differently between HTML elements and browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#values_for_inline_elements) and can end up looking weird.

Instead, I set it to `'bottom'`, which aligns the content to the bottom of the entire line. To confirm this was correct, I checked that the focus state on Anchor looked the same with and without the text in a Truncate component.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
