### PR TITLE
chore: fix resizable spelling

### DIFF
--- a/packages/paste-website/src/pages/components/textarea/index.mdx
+++ b/packages/paste-website/src/pages/components/textarea/index.mdx
@@ -196,9 +196,9 @@ The textarea should include the base textarea, along with supporting elements to
 </>`}
 </LivePreview>
 
-### Resizeable Textarea
+### Resizable Textarea
 
-By default, the textarea is not resizeable. To change this, add the prop `resize='vertical'`.
+By default, the textarea is not resizable. To change this, add the prop `resize='vertical'`.
 
 <LivePreview scope={{Label, HelpText, TextArea}} language="jsx">
   {`<>


### PR DESCRIPTION
I spelled resizable wrong on the website 🤦🏽  Wanted to fix it before sharing the link in the newsletter.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
