### PR TITLE
chore: add responsivePropValidator test

### DIFF
--- a/packages/paste-style-props/__tests__/propValidator.test.ts
+++ b/packages/paste-style-props/__tests__/propValidator.test.ts
@@ -1,5 +1,5 @@
 import {DefaultTheme} from '@twilio-paste/theme';
-import {propValidator} from '../proptypes/utils/propValidator';
+import {propValidator} from '../src/proptypes/utils/propValidator';
 
 const SpaceOptions = Object.keys(DefaultTheme.space);
 const isSpaceTokenProp = propValidator(SpaceOptions);

--- a/packages/paste-style-props/__tests__/responsivePropValidator.test.ts
+++ b/packages/paste-style-props/__tests__/responsivePropValidator.test.ts
@@ -1,0 +1,49 @@
+import * as PropTypes from 'prop-types';
+import {ResponsiveProp} from '../src/proptypes/utils/responsivePropValidator';
+
+const isDimensionProp = ResponsiveProp(PropTypes.oneOfType([PropTypes.string, PropTypes.number]));
+
+const mockPropTypes = {width: isDimensionProp};
+const mockComponentName = 'TestComponent';
+
+// prop-types recommends testing with checkPropTypes and not by running the validator directly
+// https://github.com/facebook/prop-types/blob/main/README.md#proptypescheckproptypes
+const run = (props: Record<string, unknown>): void =>
+  PropTypes.checkPropTypes(mockPropTypes, props, 'prop', mockComponentName);
+
+describe('responsivePropValidator', () => {
+  it('should return correctly based on the passed props', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    run({width: '100%'});
+    expect(console.error).toHaveBeenCalledTimes(0);
+
+    run({width: 50});
+    expect(console.error).toHaveBeenCalledTimes(0);
+
+    run({width: ['100%', 50]});
+    expect(console.error).toHaveBeenCalledTimes(0);
+
+    run({width: true});
+    expect(console.error).toHaveBeenCalledTimes(1);
+    // PropTypes.checkPropTypes only errors a message once, so need to clear it after each invalid proptype
+    PropTypes.resetWarningCache();
+
+    run({width: [true, false]});
+    expect(console.error).toHaveBeenCalledTimes(2);
+    // PropTypes.checkPropTypes only errors a message once, so need to clear it after each invalid proptype
+    PropTypes.resetWarningCache();
+
+    run({width: {foo: 'inherit'}});
+    expect(console.error).toHaveBeenCalledTimes(3);
+    // PropTypes.checkPropTypes only errors a message once, so need to clear it after each invalid proptype
+    PropTypes.resetWarningCache();
+
+    run({width: [['foo'], []]});
+    expect(console.error).toHaveBeenCalledTimes(4);
+    // PropTypes.checkPropTypes only errors a message once, so need to clear it after each invalid proptype
+    PropTypes.resetWarningCache();
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
Currently, one of the `ResponsivePropValidator` is missing unit tests. This prop validator takes a prop type and then makes the prop type either one instance of that type or an array of that type.

Example:
* the width prop can either be a string or number
* the responsive width prop can be a string, number, or an array of strings/numbers

## Changes in this PR:
Creates `isDeprecatedTheme.spec.ts` file which tests that the validator allows and throws errors correctly.

## Why does this fix it?
The test mocks `console.error` and checks that it has been called the right amount of times after each time `checkPropTypes` runs. 

## Open issues
* danger says I need a changeset, but I disagree because this is just adding a test

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
