### PR TITLE
feat: add ChatLog component

### DIFF
--- a/.changeset/smart-files-kiss.md
+++ b/.changeset/smart-files-kiss.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/chat-log': minor
+'@twilio-paste/core': minor
+---
+
+[Chat Log] add a ChatLog component

--- a/packages/paste-core/components/chat-log/__tests__/chatLog.spec.tsx
+++ b/packages/paste-core/components/chat-log/__tests__/chatLog.spec.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {screen, render} from '@testing-library/react';
+// @ts-ignore typescript doesn't like js imports
+import axe from '../../../../../.jest/axe-helper';
+import {CustomizationProvider} from '@twilio-paste/customization';
+import type {PasteCustomCSS} from '@twilio-paste/customization';
+import {ChatLog} from '../src';
+
+const CustomizationWrapper: React.FC<{elements?: {[key: string]: PasteCustomCSS}}> = ({children, elements}) => (
+  <CustomizationProvider baseTheme="default" theme={TestTheme} elements={{CHAT_LOG: {padding: 'space100'}}}>
+    {children}
+  </CustomizationProvider>
+);
+
+const CustomizationFooWrapper: React.FC = ({children}) => (
+  <CustomizationProvider baseTheme="default" theme={TestTheme} elements={{foo_log: {padding: 'space100'}}}>
+    {children}
+  </CustomizationProvider>
+);
+
+describe('ChatLog', () => {
+  it('should render', () => {
+    render(<ChatLog></ChatLog>);
+    expect(screen.getByRole('log')).toBeDefined();
+    expect(screen.getByRole('list')).toBeDefined();
+  });
+});
+
+describe('Accessibility', () => {
+  it('Should have no accessibility violations', async () => {
+    const {container} = render(<ChatLog></ChatLog>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Customization', () => {
+  it('should add custom styles', () => {
+    render(<ChatLog />, {wrapper: CustomizationWrapper});
+
+    const chatLog = screen.getByRole('log');
+    expect(chatLog).toHaveStyleRule('padding', '2.25rem');
+  });
+
+  it('should set element data attribute', () => {
+    render(<ChatLog />, {wrapper: CustomizationWrapper});
+
+    const chatLog = screen.getByRole('log');
+    expect(chatLog.getAttribute('data-paste-element')).toEqual('CHAT_LOG');
+  });
+
+  it('should add custom styles with a custom element data attribute', () => {
+    render(<ChatLog element="foo_log" />, {wrapper: CustomizationFooWrapper});
+
+    const chatLog = screen.getByRole('log');
+    expect(chatLog).toHaveStyleRule('padding', '2.25rem');
+  });
+
+  it('should set custom element data attribute', () => {
+    render(<ChatLog element="foo_log" />, {wrapper: CustomizationFooWrapper});
+
+    const chatLog = screen.getByRole('log');
+    expect(chatLog.getAttribute('data-paste-element')).toEqual('foo_log');
+  });
+});

--- a/packages/paste-core/components/chat-log/src/ChatLog.tsx
+++ b/packages/paste-core/components/chat-log/src/ChatLog.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BoxElementProps} from '@twilio-paste/box';
+
+export interface ChatLogProps {
+  children?: React.ReactNode;
+  element?: BoxElementProps['element'];
+}
+
+const ChatLog = React.forwardRef<HTMLDivElement, ChatLogProps>(({children, element = 'CHAT_LOG', ...props}, ref) => {
+  return (
+    <Box role="log" padding="space70" element={element} ref={ref} {...safelySpreadBoxProps(props)}>
+      <Box as="ul" margin="space0" padding="space0">
+        {children}
+      </Box>
+    </Box>
+  );
+});
+
+ChatLog.displayName = 'ChatLog';
+
+ChatLog.propTypes = {
+  children: PropTypes.node,
+  element: PropTypes.string,
+};
+
+export {ChatLog};

--- a/packages/paste-core/components/chat-log/src/ChatMessage.tsx
+++ b/packages/paste-core/components/chat-log/src/ChatMessage.tsx
@@ -17,6 +17,7 @@ const ChatMessage = React.forwardRef<HTMLDivElement, ChatMessageProps>(
           ref={ref}
           element={element}
           variant={variant}
+          _last={{marginBottom: 'space0'}}
           {...messageVariantStyles[variant]}
           {...safelySpreadBoxProps(props)}
         >

--- a/packages/paste-core/components/chat-log/src/index.tsx
+++ b/packages/paste-core/components/chat-log/src/index.tsx
@@ -2,4 +2,5 @@ export * from './ChatBubble';
 export * from './ChatMessage';
 export * from './ChatMessageMeta';
 export * from './ChatMessageMetaItem';
+export * from './ChatLog';
 export * from './types';

--- a/packages/paste-core/components/chat-log/stories/index.stories.tsx
+++ b/packages/paste-core/components/chat-log/stories/index.stories.tsx
@@ -5,7 +5,7 @@ import {Box} from '@twilio-paste/box';
 import {HelpText} from '@twilio-paste/help-text';
 import {Button} from '@twilio-paste/button';
 import type {StoryFn} from '@storybook/react';
-import {ChatMessage, ChatBubble, ChatMessageMeta, ChatMessageMetaItem} from '../src';
+import {ChatMessage, ChatBubble, ChatMessageMeta, ChatMessageMetaItem, ChatLog} from '../src';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -62,9 +62,79 @@ export const OutboundMessageWithMeta: StoryFn = () => (
   </>
 );
 
+export const ScrollingChatLog: StoryFn = () => (
+  <Box maxHeight="size40" overflowY="scroll">
+    <ChatLog>
+      <ChatMessage variant="inbound">
+        <ChatBubble>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</ChatBubble>
+        <ChatMessageMeta aria-label="said by Gibby Radki at 4:30pm">
+          <ChatMessageMetaItem>
+            <Avatar name="Gibby Radki" size="sizeIcon20" />
+            Gibby Radki
+          </ChatMessageMetaItem>
+          <ChatMessageMetaItem>4:30 PM</ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+      <ChatMessage variant="outbound">
+        <ChatBubble>Nulla sit amet elit mauris.</ChatBubble>
+        <ChatMessageMeta aria-label="said by you at 4:32pm">
+          <ChatMessageMetaItem>4:32 PM</ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+      <ChatMessage variant="outbound">
+        <ChatBubble>
+          Curabitur enim lorem, cursus et massa non, pretium faucibus lacus. Donec odio neque, consectetur a suscipit
+          sit amet, blandit id erat.
+        </ChatBubble>
+        <ChatMessageMeta aria-label="said by you at 4:48pm">
+          <ChatMessageMetaItem>4:48 PM</ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+      <ChatMessage variant="inbound">
+        <ChatBubble>
+          Quisque ullamcorper ipsum vitae lorem euismod sodales. Donec a nisi eget eros laoreet pellentesque. Donec sed
+          bibendum justo, at ornare mi. Sed eget tempor metus, sed sagittis lacus. Donec commodo nisi in ligula accumsan
+          euismod. Nam ornare lobortis orci, eget rhoncus ligula euismod ut.{' '}
+        </ChatBubble>
+        <ChatBubble>Donec sit amet orci hendrerit, varius diam in, porttitor felis.</ChatBubble>
+        <ChatMessageMeta aria-label="said by Gibby Radki at 5:04pm">
+          <ChatMessageMetaItem>Gibby Radki</ChatMessageMetaItem>
+          <ChatMessageMetaItem>5:04 PM</ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+      <ChatMessage variant="outbound">
+        <ChatBubble>Donec sit amet orci hendrerit, varius diam in, porttitor felis.</ChatBubble>
+        <ChatMessageMeta aria-label="said by you 2 minutes ago">
+          <ChatMessageMetaItem>2 minutes ago</ChatMessageMetaItem>
+        </ChatMessageMeta>
+        <ChatMessageMeta aria-label="(read)">
+          <ChatMessageMetaItem>Read</ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+      <ChatMessage variant="outbound">
+        <ChatBubble>
+          Praesent in lectus commodo orci faucibus ullamcorper. Nulla sit amet sapien consectetur, tempor ante eget,
+          sagittis orci. Curabitur enim lorem, cursus et massa non, pretium faucibus lacus.
+        </ChatBubble>
+        <ChatMessageMeta aria-label="Message failed">
+          <ChatMessageMetaItem>
+            <HelpText variant="error" marginTop="space0">
+              Message failed
+            </HelpText>
+          </ChatMessageMetaItem>
+          <ChatMessageMetaItem>
+            <Button variant="link" onClick={() => {}}>
+              Resend
+            </Button>
+          </ChatMessageMetaItem>
+        </ChatMessageMeta>
+      </ChatMessage>
+    </ChatLog>
+  </Box>
+);
+
 export const KitchenSink: StoryFn = () => (
-  // replace with ChatLog
-  <Box as="ul">
+  <ChatLog>
     <ChatMessage variant="inbound">
       <ChatBubble>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</ChatBubble>
       <ChatMessageMeta aria-label="said by Gibby Radki at 4:30pm">
@@ -129,13 +199,19 @@ export const KitchenSink: StoryFn = () => (
         </ChatMessageMetaItem>
       </ChatMessageMeta>
     </ChatMessage>
-  </Box>
+  </ChatLog>
 );
 
-export const CustomizedMessages: StoryFn = () => (
+export const CustomizedKitchenSink: StoryFn = () => (
   <CustomizationProvider
     baseTheme="default"
     elements={{
+      CHAT_LOG: {
+        padding: 'space100',
+        borderStyle: 'solid',
+        borderColor: 'colorBorder',
+        borderWidth: 'borderWidth10',
+      },
       CHAT_MESSAGE: {
         marginBottom: 'space100',
         variants: {
@@ -159,19 +235,17 @@ export const CustomizedMessages: StoryFn = () => (
       },
       CHAT_MESSAGE_META_ITEM: {
         color: 'colorText',
-        columnGap: 'space0',
+        columnGap: 'space20',
       },
     }}
   >
-    <Box as="ul" width="100%">
+    <ChatLog>
       <ChatMessage variant="inbound">
         <ChatBubble>test</ChatBubble>
         <ChatMessageMeta aria-label="said by Gibby Radki 4 minutes ago">
           <ChatMessageMetaItem>
-            <ChatMessageMetaItem>
-              <Avatar name="Gibby Radki" size="sizeIcon20" />
-              Gibby Radki
-            </ChatMessageMetaItem>
+            <Avatar name="Gibby Radki" size="sizeIcon20" />
+            Gibby Radki
           </ChatMessageMetaItem>
           <ChatMessageMetaItem>4 minutes ago</ChatMessageMetaItem>
         </ChatMessageMeta>
@@ -183,6 +257,6 @@ export const CustomizedMessages: StoryFn = () => (
           <ChatMessageMetaItem>Read</ChatMessageMetaItem>
         </ChatMessageMeta>
       </ChatMessage>
-    </Box>
+    </ChatLog>
   </CustomizationProvider>
 );


### PR DESCRIPTION
The ChatLog package doesn't actually have a ChatLog component !!

## Changes in this PR:
* add a ChatLog component and relevant types
* replace <Box as="ul"> in kitchen sink story and accessibility tests with the chatLog
* add a ScrollingChatLog story that is the same as kitchen sink but with a maxHeight and overflowY='scroll'
* add chatLog tests and customization tests
* update ChatMessage so the last one in the log has no padding on the bottom

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
