### PR TITLE
feat(tokens-page): add theme and format controls

### DIFF
--- a/cypress/integration/token-list/index.spec.ts
+++ b/cypress/integration/token-list/index.spec.ts
@@ -7,21 +7,51 @@ describe('Token list filter with no existing search params', function () {
     cy.visit('/tokens/list');
   });
 
-  it('searches for a background color', () => {
-    cy.get('input[name="tokens-filter"]').type('background').should('have.value', 'background');
-    cy.get('#background-colors').should('exist');
-    cy.get('#border-colors').should('not.exist');
-  });
+  // Todo: uncomment search filter tests when filter work is done
 
-  it('shows empty state', () => {
-    cy.get('input[name="tokens-filter"]').type('abc');
-    cy.get('[data-cy="tokens-empty-state"]').should('exist');
-    cy.get('[data-cy="tokens-empty-state"] h3').should('have.text', `Oh no! We couldn't find any matches`);
-  });
+  //   it('searches for a background color', () => {
+  //     cy.get('input[name="tokens-filter"]').type('background').should('have.value', 'background');
+  //     cy.get('#background-colors').should('exist');
+  //     cy.get('#border-colors').should('not.exist');
+  //   });
+
+  //   it('shows empty state', () => {
+  //     cy.get('input[name="tokens-filter"]').type('abc');
+  //     cy.get('[data-cy="tokens-empty-state"]').should('exist');
+  //     cy.get('[data-cy="tokens-empty-state"] h3').should('have.text', `Oh no! We couldn't find any matches`);
+  //   });
 
   describe('Visual regression tests', () => {
     it('Basic VRT', () => {
       cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
     });
+  });
+});
+
+describe('Token list filter format control and theme control', function () {
+  beforeEach(() => {
+    cy.visit('/tokens/list');
+  });
+
+  it('controls format of token name', () => {
+    cy.get('[data-cy="format-control"]').select('javascript').should('have.value', 'javascript');
+    cy.get('[data-cy="tokens-table-container"] li:first dt [data-paste-element="TEXT"]').contains(/^[a-z]/);
+    cy.get('[data-cy="tokens-table-container"] li:first dt [data-paste-element="TEXT"]').contains(/[^$-]/);
+    cy.get('[data-cy="format-control"]').select('css').should('have.value', 'css');
+    cy.get('[data-cy="tokens-table-container"] li:first dt [data-paste-element="TEXT"]').contains(/^[$]/);
+    cy.get('[data-cy="tokens-table-container"] li:first dt [data-paste-element="TEXT"]').contains(/[^A-Z]/);
+  });
+
+  it('controls the theme of filtered tokens', () => {
+    cy.get('[data-cy="theme-control"]').select('dark').should('have.value', 'dark');
+    cy.get('[data-cy="tokens-table-container"] li:first dd [data-paste-element="TEXT"]:first').should(
+      'include.text',
+      'rgb(18, 28, 45)'
+    );
+    cy.get('[data-cy="theme-control"]').select('default').should('have.value', 'default');
+    cy.get('[data-cy="tokens-table-container"] li:first dd [data-paste-element="TEXT"]:first').should(
+      'include.text',
+      'rgb(244, 244, 246)'
+    );
   });
 });

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -2,71 +2,55 @@ import * as React from 'react';
 import {Box} from '@twilio-paste/box';
 import {Label} from '@twilio-paste/label';
 import {Input} from '@twilio-paste/input';
-import Tokens from '@twilio-paste/design-tokens/dist/tokens.generic';
-import DarkModeTokens from '@twilio-paste/design-tokens/dist/themes/dark/tokens.generic';
 import {FilterIcon} from '@twilio-paste/icons/esm/FilterIcon';
 import {Grid, Column} from '@twilio-paste/grid';
 import {Select, Option} from '@twilio-paste/select';
+import {useUID} from '@twilio-paste/uid-library';
 import type {TokensListFilterProps} from './types';
 
 export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
-  const handleInput = (e: React.FormEvent<HTMLInputElement>): void => {
-    const filter = e.currentTarget.value;
-    props.setFilterString(filter);
-  };
+  const inputId = useUID();
+  const themeControlId = useUID();
+  const formatControlId = useUID();
+
+  console.log('THEME----->', props.theme);
 
   return (
     <>
       <Box marginBottom="space80">
         <Grid gutter="space40">
           <Column span={6}>
-            <Label htmlFor="test" id="test-label">
+            <Label htmlFor={inputId} id="test-label">
               Filter tokens
             </Label>
             <Input
               type="text"
-              id="test"
+              id={inputId}
               aria-labelledby="test-label"
-              onChange={handleInput}
+              onChange={props.handleInput}
               insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
               placeholder="Filter by token name or value"
             />
           </Column>
           <Column span={3}>
-            <Label htmlFor="theme-control" id="theme-control-label">
+            <Label htmlFor={themeControlId} id="theme-control-label">
               Theme
             </Label>
             <Select
-              id="theme-control"
+              id={themeControlId}
+              // props.theme is 'default' for a split second before list renders so 'dark' defaultValue isn't working
               defaultValue={props.theme === 'dark' ? 'dark' : 'default'}
-              onChange={(evt) => {
-                if (evt.target.value === 'dark') {
-                  props.setSelectedTheme('dark');
-                  // @ts-ignore
-                  props.setTokens(DarkModeTokens.tokens);
-                }
-                if (evt.target.value === 'default') {
-                  props.setSelectedTheme('default');
-                  // @ts-ignore
-                  props.setTokens(Tokens.tokens);
-                }
-              }}
+              onChange={props.handleThemeChange}
             >
               <Option value="default">Default</Option>
               <Option value="dark">Dark</Option>
             </Select>
           </Column>
           <Column span={3}>
-            <Label htmlFor="format-control" id="format-control-label">
+            <Label htmlFor={formatControlId} id="format-control-label">
               Format
             </Label>
-            <Select
-              id="format-control"
-              onChange={(evt) => {
-                if (evt.target.value === 'javascript') props.setUseJavascriptNames(true);
-                else props.setUseJavascriptNames(false);
-              }}
-            >
+            <Select id={formatControlId} onChange={props.handleFormatChange}>
               <Option value="css">CSS</Option>
               <Option value="javascript">Javascript</Option>
             </Select>

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -13,8 +13,6 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
   const themeControlId = useUID();
   const formatControlId = useUID();
 
-  console.log('THEME----->', props.theme);
-
   return (
     <>
       <Box marginBottom="space80">
@@ -38,8 +36,7 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
             </Label>
             <Select
               id={themeControlId}
-              // props.theme is 'default' for a split second before list renders so 'dark' defaultValue isn't working
-              defaultValue={props.theme === 'dark' ? 'dark' : 'default'}
+              defaultValue={localStorage.getItem('themeControl') ?? 'default'}
               onChange={props.handleThemeChange}
             >
               <Option value="default">Default</Option>
@@ -50,7 +47,11 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
             <Label htmlFor={formatControlId} id="format-control-label">
               Format
             </Label>
-            <Select id={formatControlId} onChange={props.handleFormatChange}>
+            <Select
+              id={formatControlId}
+              defaultValue={localStorage.getItem('formatControl') ?? 'css'}
+              onChange={props.handleFormatChange}
+            >
               <Option value="css">CSS</Option>
               <Option value="javascript">Javascript</Option>
             </Select>

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {Label} from '@twilio-paste/label';
+import {Input} from '@twilio-paste/input';
+import Tokens from '@twilio-paste/design-tokens/dist/tokens.generic';
+import DarkModeTokens from '@twilio-paste/design-tokens/dist/themes/dark/tokens.generic';
+import {FilterIcon} from '@twilio-paste/icons/esm/FilterIcon';
+import {Grid, Column} from '@twilio-paste/grid';
+import {Select, Option} from '@twilio-paste/select';
+import type {TokensListFilterProps} from './types';
+
+export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
+  const handleInput = (e: React.FormEvent<HTMLInputElement>): void => {
+    const filter = e.currentTarget.value;
+    props.setFilterString(filter);
+  };
+
+  return (
+    <>
+      <Box marginBottom="space80">
+        <Grid gutter="space40">
+          <Column span={6}>
+            <Label htmlFor="test" id="test-label">
+              Filter tokens
+            </Label>
+            <Input
+              type="text"
+              id="test"
+              aria-labelledby="test-label"
+              onChange={handleInput}
+              insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
+              placeholder="Filter by token name or value"
+            />
+          </Column>
+          <Column span={3}>
+            <Label htmlFor="theme-control" id="theme-control-label">
+              Theme
+            </Label>
+            <Select
+              id="theme-control"
+              defaultValue={props.theme === 'dark' ? 'dark' : 'default'}
+              onChange={(evt) => {
+                if (evt.target.value === 'dark') {
+                  props.setSelectedTheme('dark');
+                  // @ts-ignore
+                  props.setTokens(DarkModeTokens.tokens);
+                }
+                if (evt.target.value === 'default') {
+                  props.setSelectedTheme('default');
+                  // @ts-ignore
+                  props.setTokens(Tokens.tokens);
+                }
+              }}
+            >
+              <Option value="default">Default</Option>
+              <Option value="dark">Dark</Option>
+            </Select>
+          </Column>
+          <Column span={3}>
+            <Label htmlFor="format-control" id="format-control-label">
+              Format
+            </Label>
+            <Select
+              id="format-control"
+              onChange={(evt) => {
+                if (evt.target.value === 'javascript') props.setUseJavascriptNames(true);
+                else props.setUseJavascriptNames(false);
+              }}
+            >
+              <Option value="css">CSS</Option>
+              <Option value="javascript">Javascript</Option>
+            </Select>
+          </Column>
+        </Grid>
+      </Box>
+    </>
+  );
+};

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -38,6 +38,7 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
               id={themeControlId}
               defaultValue={localStorage.getItem('themeControl') ?? 'default'}
               onChange={props.handleThemeChange}
+              data-cy="theme-control"
             >
               <Option value="default">Default</Option>
               <Option value="dark">Dark</Option>
@@ -49,8 +50,9 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = (props) => {
             </Label>
             <Select
               id={formatControlId}
-              defaultValue={localStorage.getItem('formatControl') ?? 'css'}
+              defaultValue={localStorage.getItem('format-control') ?? 'css'}
               onChange={props.handleFormatChange}
+              data-cy="format-control"
             >
               <Option value="css">CSS</Option>
               <Option value="javascript">Javascript</Option>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -78,7 +78,9 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                   useCamelCase={useJavascriptNames ? true : false}
                   value={value}
                   comment={comment}
-                  backgroundColor={selectedTheme === 'dark' ? 'rgba(15, 22, 33, 1)' : 'rgb(255, 255, 255)'}
+                  backgroundColor={
+                    tokens['background-colors'].find((token) => token.name === 'color-background-body')?.value
+                  }
                 />
               ))}
             </Box>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
-import {Label} from '@twilio-paste/label';
-import {Input} from '@twilio-paste/input';
 import Tokens from '@twilio-paste/design-tokens/dist/tokens.generic';
 import DarkModeTokens from '@twilio-paste/design-tokens/dist/themes/dark/tokens.generic';
 import {AnchoredHeading} from '../Heading';
@@ -11,9 +9,7 @@ import type {Token, TokenCategory, TokensListProps} from './types';
 import {PageAside} from '../shortcodes/PageAside';
 import {NoTokensFound} from './NoTokensFound';
 import {TokenCard} from './token-card';
-import {FilterIcon} from '@twilio-paste/icons/esm/FilterIcon';
-import {Grid, Column} from '@twilio-paste/grid';
-import {Select, Option} from '@twilio-paste/select';
+import {TokensListFilter} from './TokensListFilter';
 
 const sentenceCase = (catName: string): string => {
   return catName
@@ -41,11 +37,6 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
     trackTokenFilterString(filterString);
   }, [filterString, props, theme]);
 
-  const handleInput = (e: React.FormEvent<HTMLInputElement>): void => {
-    const filter = e.currentTarget.value;
-    setFilterString(filter);
-  };
-
   if (tokens === null) {
     return <NoTokensFound onClearSearch={() => setFilterString('')} />;
   }
@@ -60,60 +51,18 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
         }}
       />
       <Content>
-        <Box marginBottom="space80">
-          <Grid gutter="space40">
-            <Column span={6}>
-              <Label htmlFor="test" id="test-label">
-                Filter tokens
-              </Label>
-              <Input
-                type="text"
-                id="test"
-                aria-labelledby="test-label"
-                onChange={handleInput}
-                insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
-                placeholder="Filter by token name or value"
-              />
-            </Column>
-            <Column span={3}>
-              <Label htmlFor="theme-control" id="theme-control-label">
-                Theme
-              </Label>
-              <Select
-                id="theme-control"
-                defaultValue={theme === 'dark' ? 'dark' : 'default'}
-                onChange={(evt) => {
-                  if (evt.target.value === 'dark') {
-                    setSelectedTheme('dark');
-                    setTokens(DarkModeTokens.tokens);
-                  }
-                  if (evt.target.value === 'default') {
-                    setSelectedTheme('default');
-                    setTokens(Tokens.tokens);
-                  }
-                }}
-              >
-                <Option value="default">Default</Option>
-                <Option value="dark">Dark</Option>
-              </Select>
-            </Column>
-            <Column span={3}>
-              <Label htmlFor="format-control" id="format-control-label">
-                Format
-              </Label>
-              <Select
-                id="format-control"
-                onChange={(evt) => {
-                  if (evt.target.value === 'javascript') setUseJavascriptNames(true);
-                  else setUseJavascriptNames(false);
-                }}
-              >
-                <Option value="css">CSS</Option>
-                <Option value="javascript">Javascript</Option>
-              </Select>
-            </Column>
-          </Grid>
-        </Box>
+        <TokensListFilter
+          // @ts-ignore
+          defaultTokens={Tokens.tokens}
+          // @ts-ignore
+          darkTokens={DarkModeTokens.tokens}
+          theme={theme}
+          // @ts-ignore
+          setTokens={setTokens}
+          setUseJavascriptNames={setUseJavascriptNames}
+          setSelectedTheme={setSelectedTheme}
+          setFilterString={setFilterString}
+        />
         {tokenCategories.map((tokenCategory) => (
           <React.Fragment key={`catname-${tokenCategory}`}>
             <AnchoredHeading as="h2" variant="heading20">

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -29,13 +29,27 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
   const [tokens, setTokens] = React.useState(Tokens.tokens);
   const [tokenCategories, setTokenCategories] = React.useState(Object.keys(tokens) as unknown as [keyof typeof tokens]);
   const [useJavascriptNames, setUseJavascriptNames] = React.useState(false);
-  const [selectedTheme, setSelectedTheme] = React.useState(theme === 'dark' ? 'dark' : 'default');
 
   // The rendered tokens should update every time the filterString, props, or theme changes
   React.useEffect(() => {
     // setTokens(filterTokenList(filterString, props, theme));
     trackTokenFilterString(filterString);
   }, [filterString, props, theme]);
+
+  const handleInput = (e: React.FormEvent<HTMLInputElement>): void => {
+    const filter = e.currentTarget.value;
+    setFilterString(filter);
+  };
+
+  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    if (e.currentTarget.value === 'dark') setTokens(DarkModeTokens.tokens);
+    else if (e.currentTarget.value === 'default') setTokens(Tokens.tokens);
+  };
+
+  const handleFormatChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    if (e.currentTarget.value === 'javascript') setUseJavascriptNames(true);
+    else if (e.currentTarget.value === 'css') setUseJavascriptNames(false);
+  };
 
   if (tokens === null) {
     return <NoTokensFound onClearSearch={() => setFilterString('')} />;
@@ -52,16 +66,10 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
       />
       <Content>
         <TokensListFilter
-          // @ts-ignore
-          defaultTokens={Tokens.tokens}
-          // @ts-ignore
-          darkTokens={DarkModeTokens.tokens}
           theme={theme}
-          // @ts-ignore
-          setTokens={setTokens}
-          setUseJavascriptNames={setUseJavascriptNames}
-          setSelectedTheme={setSelectedTheme}
-          setFilterString={setFilterString}
+          handleThemeChange={handleThemeChange}
+          handleFormatChange={handleFormatChange}
+          handleInput={handleInput}
         />
         {tokenCategories.map((tokenCategory) => (
           <React.Fragment key={`catname-${tokenCategory}`}>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -4,6 +4,7 @@ import {Label} from '@twilio-paste/label';
 import {Input} from '@twilio-paste/input';
 import Tokens from '@twilio-paste/design-tokens/dist/tokens.generic';
 import DarkModeTokens from '@twilio-paste/design-tokens/dist/themes/dark/tokens.generic';
+import camelCase from 'lodash/camelCase';
 import {AnchoredHeading} from '../Heading';
 import {useDarkModeContext} from '../../context/DarkModeContext';
 import {trackTokenFilterString, filterTokenList, getTokensByTheme} from './helpers';
@@ -12,6 +13,8 @@ import {PageAside} from '../shortcodes/PageAside';
 import {NoTokensFound} from './NoTokensFound';
 import {TokenCard} from './token-card';
 import {FilterIcon} from '@twilio-paste/icons/esm/FilterIcon';
+import {Grid, Column} from '@twilio-paste/grid';
+import {Select, Option} from '@twilio-paste/select';
 
 const sentenceCase = (catName: string): string => {
   return catName
@@ -30,6 +33,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
   const [filterString, setFilterString] = React.useState('');
   const [tokens, setTokens] = React.useState(Tokens.tokens);
   const [tokenCategories, setTokenCategories] = React.useState(Object.keys(tokens) as unknown as [keyof typeof tokens]);
+  const [useJavascriptNames, setUseJavascriptNames] = React.useState(false);
 
   // The rendered tokens should update every time the filterString, props, or theme changes
   React.useEffect(() => {
@@ -56,19 +60,54 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
         }}
       />
       <Content>
-        <Box paddingBottom="space80">
-          <Label htmlFor="test" id="test-label">
-            Filter tokens
-          </Label>
-          <Input
-            type="text"
-            id="test"
-            aria-labelledby="test-label"
-            onChange={handleInput}
-            insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
-          />
+        <Box marginBottom="space80">
+          <Grid gutter="space40">
+            <Column span={6}>
+              <Label htmlFor="test" id="test-label">
+                Filter tokens
+              </Label>
+              <Input
+                type="text"
+                id="test"
+                aria-labelledby="test-label"
+                onChange={handleInput}
+                insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
+                placeholder="Filter by token name or value"
+              />
+            </Column>
+            <Column span={3}>
+              <Label htmlFor="theme-control" id="theme-control-label">
+                Theme
+              </Label>
+              <Select
+                id="theme-control"
+                defaultValue={theme === 'dark' ? 'dark' : 'default'}
+                onChange={(evt) => {
+                  if (evt.target.value === 'dark') setTokens(DarkModeTokens.tokens);
+                  if (evt.target.value === 'default') setTokens(Tokens.tokens);
+                }}
+              >
+                <Option value="default">Default</Option>
+                <Option value="dark">Dark</Option>
+              </Select>
+            </Column>
+            <Column span={3}>
+              <Label htmlFor="format-control" id="format-control-label">
+                Format
+              </Label>
+              <Select
+                id="format-control"
+                onChange={(evt) => {
+                  if (evt.target.value === 'javascript') setUseJavascriptNames(true);
+                  else setUseJavascriptNames(false);
+                }}
+              >
+                <Option value="css">CSS</Option>
+                <Option value="javascript">Javascript</Option>
+              </Select>
+            </Column>
+          </Grid>
         </Box>
-
         {tokenCategories.map((tokenCategory) => (
           <React.Fragment key={`catname-${tokenCategory}`}>
             <AnchoredHeading as="h2" variant="heading20">
@@ -80,7 +119,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                 <TokenCard
                   key={`token${name}`}
                   category={tokenCategory}
-                  name={name}
+                  name={useJavascriptNames ? camelCase(name) : name}
                   value={value}
                   comment={comment}
                   backgroundColor="rgb(255, 255, 255)"

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -34,6 +34,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
   const [tokens, setTokens] = React.useState(Tokens.tokens);
   const [tokenCategories, setTokenCategories] = React.useState(Object.keys(tokens) as unknown as [keyof typeof tokens]);
   const [useJavascriptNames, setUseJavascriptNames] = React.useState(false);
+  const [selectedTheme, setSelectedTheme] = React.useState(theme === 'dark' ? 'dark' : 'default');
 
   // The rendered tokens should update every time the filterString, props, or theme changes
   React.useEffect(() => {
@@ -83,8 +84,14 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                 id="theme-control"
                 defaultValue={theme === 'dark' ? 'dark' : 'default'}
                 onChange={(evt) => {
-                  if (evt.target.value === 'dark') setTokens(DarkModeTokens.tokens);
-                  if (evt.target.value === 'default') setTokens(Tokens.tokens);
+                  if (evt.target.value === 'dark') {
+                    setSelectedTheme('dark');
+                    setTokens(DarkModeTokens.tokens);
+                  }
+                  if (evt.target.value === 'default') {
+                    setSelectedTheme('default');
+                    setTokens(Tokens.tokens);
+                  }
                 }}
               >
                 <Option value="default">Default</Option>
@@ -122,7 +129,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                   name={useJavascriptNames ? camelCase(name) : name}
                   value={value}
                   comment={comment}
-                  backgroundColor="rgb(255, 255, 255)"
+                  backgroundColor={selectedTheme === 'dark' ? 'rgba(15, 22, 33, 1)' : 'rgb(255, 255, 255)'}
                 />
               ))}
             </Box>

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -42,13 +42,16 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
   };
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    // @ts-ignore todo: figure out ts error with DarkModeTokens
     if (e.currentTarget.value === 'dark') setTokens(DarkModeTokens.tokens);
     else if (e.currentTarget.value === 'default') setTokens(Tokens.tokens);
+    localStorage.setItem('themeControl', e.currentTarget.value);
   };
 
   const handleFormatChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     if (e.currentTarget.value === 'javascript') setUseJavascriptNames(true);
     else if (e.currentTarget.value === 'css') setUseJavascriptNames(false);
+    localStorage.setItem('formatControl', e.currentTarget.value);
   };
 
   if (tokens === null) {
@@ -66,7 +69,6 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
       />
       <Content>
         <TokensListFilter
-          theme={theme}
           handleThemeChange={handleThemeChange}
           handleFormatChange={handleFormatChange}
           handleInput={handleInput}

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -4,7 +4,6 @@ import {Label} from '@twilio-paste/label';
 import {Input} from '@twilio-paste/input';
 import Tokens from '@twilio-paste/design-tokens/dist/tokens.generic';
 import DarkModeTokens from '@twilio-paste/design-tokens/dist/themes/dark/tokens.generic';
-import camelCase from 'lodash/camelCase';
 import {AnchoredHeading} from '../Heading';
 import {useDarkModeContext} from '../../context/DarkModeContext';
 import {trackTokenFilterString, filterTokenList, getTokensByTheme} from './helpers';
@@ -126,7 +125,8 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                 <TokenCard
                   key={`token${name}`}
                   category={tokenCategory}
-                  name={useJavascriptNames ? camelCase(name) : name}
+                  name={name}
+                  useCamelCase={useJavascriptNames ? true : false}
                   value={value}
                   comment={comment}
                   backgroundColor={selectedTheme === 'dark' ? 'rgba(15, 22, 33, 1)' : 'rgb(255, 255, 255)'}

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -85,7 +85,7 @@ export const TokensList: React.FC<TokensListProps> = (props) => {
                   key={`token${name}`}
                   category={tokenCategory}
                   name={name}
-                  useCamelCase={useJavascriptNames ? true : false}
+                  useCamelCase={useJavascriptNames}
                   value={value}
                   comment={comment}
                   backgroundColor={

--- a/packages/paste-website/src/components/tokens-list/types.ts
+++ b/packages/paste-website/src/components/tokens-list/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export interface Token {
   name: string;
   value: string | number;
@@ -23,4 +25,12 @@ export interface TokensListProps {
   children?: React.ReactElement;
   defaultTokens: TokensShape[];
   darkTokens: TokensShape[];
+}
+
+export interface TokensListFilterProps extends Pick<TokensListProps, 'defaultTokens' | 'darkTokens'> {
+  theme: string;
+  setTokens: React.Dispatch<React.SetStateAction<TokensShape>>;
+  setFilterString: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedTheme: React.Dispatch<React.SetStateAction<string>>;
+  setUseJavascriptNames: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/packages/paste-website/src/components/tokens-list/types.ts
+++ b/packages/paste-website/src/components/tokens-list/types.ts
@@ -28,7 +28,6 @@ export interface TokensListProps {
 }
 
 export interface TokensListFilterProps {
-  theme: string;
   handleThemeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   handleInput: (e: React.FormEvent<HTMLInputElement>) => void;
   handleFormatChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;

--- a/packages/paste-website/src/components/tokens-list/types.ts
+++ b/packages/paste-website/src/components/tokens-list/types.ts
@@ -27,10 +27,9 @@ export interface TokensListProps {
   darkTokens: TokensShape[];
 }
 
-export interface TokensListFilterProps extends Pick<TokensListProps, 'defaultTokens' | 'darkTokens'> {
+export interface TokensListFilterProps {
   theme: string;
-  setTokens: React.Dispatch<React.SetStateAction<TokensShape>>;
-  setFilterString: React.Dispatch<React.SetStateAction<string>>;
-  setSelectedTheme: React.Dispatch<React.SetStateAction<string>>;
-  setUseJavascriptNames: React.Dispatch<React.SetStateAction<boolean>>;
+  handleThemeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleInput: (e: React.FormEvent<HTMLInputElement>) => void;
+  handleFormatChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 }

--- a/packages/paste-website/stories/TokensListFilter.stories.tsx
+++ b/packages/paste-website/stories/TokensListFilter.stories.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {TokensListFilter} from '../src/components/tokens-list/TokensListFilter';
+
+const testTokens = {
+  tokens: {
+    'background-colors': [
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(18, 28, 45)',
+        comment: 'Default background color for any container',
+        originalValue: '{!palette-gray-100}',
+        name: 'color-background',
+      },
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(20, 176, 83)',
+        comment: 'Color used to represent an entity or person as "available".',
+        originalValue: '{!palette-green-60}',
+        name: 'color-background-available',
+      },
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(13, 19, 28)',
+        comment: 'Background color of the main page body',
+        originalValue: '{!palette-gray-110}',
+        name: 'color-background-body',
+      },
+    ],
+  },
+};
+
+const testDarkTokens = {
+  tokens: {
+    'background-colors': [
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(18, 28, 45)',
+        comment: 'Default background color for any container',
+        originalValue: '{!palette-gray-100}',
+        name: 'color-background',
+      },
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(20, 176, 83)',
+        comment: 'Color used to represent an entity or person as "available".',
+        originalValue: '{!palette-green-60}',
+        name: 'color-background-available',
+      },
+      {
+        type: 'color',
+        category: 'background-color',
+        value: 'rgb(13, 19, 28)',
+        comment: 'Background color of the main page body',
+        originalValue: '{!palette-gray-110}',
+        name: 'color-background-body',
+      },
+    ],
+  },
+};
+
+export const TokensListFilterExample = (): React.ReactNode => (
+  // @ts-ignore
+  <TokensListFilter defaultTokens={testTokens} darkTokens={testDarkTokens} theme="default" />
+);
+
+export default {
+  title: 'Website/TokensListFilter',
+  component: TokensListFilter,
+};

--- a/packages/paste-website/stories/TokensListFilter.stories.tsx
+++ b/packages/paste-website/stories/TokensListFilter.stories.tsx
@@ -1,71 +1,9 @@
 import * as React from 'react';
 import {TokensListFilter} from '../src/components/tokens-list/TokensListFilter';
 
-const testTokens = {
-  tokens: {
-    'background-colors': [
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(18, 28, 45)',
-        comment: 'Default background color for any container',
-        originalValue: '{!palette-gray-100}',
-        name: 'color-background',
-      },
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(20, 176, 83)',
-        comment: 'Color used to represent an entity or person as "available".',
-        originalValue: '{!palette-green-60}',
-        name: 'color-background-available',
-      },
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(13, 19, 28)',
-        comment: 'Background color of the main page body',
-        originalValue: '{!palette-gray-110}',
-        name: 'color-background-body',
-      },
-    ],
-  },
-};
-
-const testDarkTokens = {
-  tokens: {
-    'background-colors': [
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(18, 28, 45)',
-        comment: 'Default background color for any container',
-        originalValue: '{!palette-gray-100}',
-        name: 'color-background',
-      },
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(20, 176, 83)',
-        comment: 'Color used to represent an entity or person as "available".',
-        originalValue: '{!palette-green-60}',
-        name: 'color-background-available',
-      },
-      {
-        type: 'color',
-        category: 'background-color',
-        value: 'rgb(13, 19, 28)',
-        comment: 'Background color of the main page body',
-        originalValue: '{!palette-gray-110}',
-        name: 'color-background-body',
-      },
-    ],
-  },
-};
-
 export const TokensListFilterExample = (): React.ReactNode => (
-  // @ts-ignore
-  <TokensListFilter defaultTokens={testTokens} darkTokens={testDarkTokens} theme="default" />
+  // @ts-expect-error not passing in props
+  <TokensListFilter />
 );
 
 export default {


### PR DESCRIPTION
## Theme and format controls for filtering tokens

[Jira Ticket](https://issues.corp.twilio.com/browse/DSYS-3169)

### In this PR
This PR adds 2 select fields to the filtering section of the new Token List page. 

One is for controlling the theme of the displayed tokens. It should operate independently from the website theme switcher.

The other is for controlling the format of the token name. If the user selects "javascript", the token names are displayed in camelCase.

The `TokensList` component is refactored because I pulled out `TokensListFilter` into its own component. I did this so that we could do VRT on the `TokensListFilter` section of the page.

When a new theme or format is selected, it's added to local storage so that the selection persists next time someone revisits the page.

Cypress tests for the new controls.

### To do
- There's a ts error that is currently being ignored on line 46 of `tokens-list/index.tsx`, it's stumping me

### Notes
- The performance is very slow, but it's out of the scope of this ticket to fix performance issues. That will be addressed when we revisit the filtering of the page.
- The token values I'm using to test that the theme switcher works are hardcoded values. I tried pulling in the dist file to check against that, but it was undefined in cypress. Let me know if you have any thoughts on how to better test that the theme switcher is working.

--------------------------------------------------------------------------------

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
