### PR TITLE
fix(Spinner docs): reword default icon size and color docs

### DIFF
--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -87,7 +87,7 @@ The spinner is an icon component that can be used in situations where you would 
 
 ### Default
 
-The default Spinner settings are using the default icon size and color, which is designed to match our default text size and color.
+The default Spinner is using the default text color (`color-text`) and default icon size (`icon-size-20`), which is designed to pair with our default text size.
 
 <Callout>
   <CalloutTitle>Accessibility</CalloutTitle>

--- a/packages/paste-website/src/pages/components/spinner/index.mdx
+++ b/packages/paste-website/src/pages/components/spinner/index.mdx
@@ -87,7 +87,7 @@ The spinner is an icon component that can be used in situations where you would 
 
 ### Default
 
-The default Spinner is using the default text color (`color-text`) and default icon size (`icon-size-20`), which is designed to pair with our default text size.
+The default Spinner uses the default text color (`color-text`) and default icon size (`icon-size-20`), which is meant to be paired with our default text size.
 
 <Callout>
   <CalloutTitle>Accessibility</CalloutTitle>


### PR DESCRIPTION
Issue: Spinner is using `color-text` and `icon-size-20`, but the [doc site wording](https://paste.twilio.design/components/spinner#default) makes it sound like it's using `color-text-icon`.

Change from:

> The default Spinner settings are using the default icon size and color, which is designed to match our default text size and color.

to

> The default Spinner uses the default text color (`color-text`) and icon size (`icon-size-20`), which is meant to be paired with our default text size.

Preview: https://deploy-preview-2516--paste-docs.netlify.app/components/spinner#default