### PR TITLE
chore: remove deprecated VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "styled-components.vscode-styled-components",
     "eamodio.gitlens",
     "patbenatar.advanced-new-file",
-    "coenraads.bracket-pair-colorizer",
     "wmaurer.change-case",
     "bierner.docs-view",
     "editorconfig.editorconfig",


### PR DESCRIPTION
* Removes deprecated "Bracket Pair Colorizer" extension from VS Code extensions list.
* Stops VS Code from giving the deprecated warning when opening Paste.
* Per [their repo](https://github.com/CoenraadS/BracketPair#readme), this functionality is now native to VSCode.