### PR TITLE
chore: make tokens filter responsive

### DIFF
--- a/cypress/integration/token-list/index.spec.ts
+++ b/cypress/integration/token-list/index.spec.ts
@@ -54,4 +54,10 @@ describe('Token list filter format control and theme control', function () {
       'rgb(244, 244, 246)'
     );
   });
+
+  it('has a responsive layout', () => {
+    cy.get('[data-cy="input-column"]').should('have.attr', 'min-width', '0px');
+    cy.viewport('iphone-x');
+    cy.get('[data-cy="input-column"]').should('have.attr', 'min-width', '100%');
+  });
 });

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -24,8 +24,8 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = ({
   return (
     <>
       <Box marginBottom="space80">
-        <Grid gutter="space40">
-          <Column span={6}>
+        <Grid gutter="space40" vertical={[true, true, false]}>
+          <Column span={[12, 6, 6]} data-cy="input-column">
             <Label htmlFor={inputId} id="test-label">
               Filter tokens
             </Label>
@@ -34,27 +34,36 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = ({
               id={inputId}
               aria-labelledby="test-label"
               onChange={handleInput}
-              insertBefore={<FilterIcon decorative={false} title="Description of icon" />}
+              insertBefore={<FilterIcon decorative={false} title="Description of icon" color="colorTextIcon" />}
               placeholder="Filter by token name or value"
             />
           </Column>
-          <Column span={3}>
-            <Label htmlFor={themeControlId} id={themeControlLabelId}>
-              Theme
-            </Label>
-            <Select id={themeControlId} value={selectedTheme} onChange={handleThemeChange} data-cy="theme-control">
-              <Option value="default">Default</Option>
-              <Option value="dark">Dark</Option>
-            </Select>
-          </Column>
-          <Column span={3}>
-            <Label htmlFor={formatControlId} id={formatControlLabelId}>
-              Format
-            </Label>
-            <Select id={formatControlId} value={selectedFormat} onChange={handleFormatChange} data-cy="format-control">
-              <Option value="css">CSS</Option>
-              <Option value="javascript">Javascript</Option>
-            </Select>
+          <Column span={[12, 6, 6]}>
+            <Grid gutter="space40">
+              <Column span={6}>
+                <Label htmlFor={themeControlId} id={themeControlLabelId}>
+                  Theme
+                </Label>
+                <Select id={themeControlId} value={selectedTheme} onChange={handleThemeChange} data-cy="theme-control">
+                  <Option value="default">Default</Option>
+                  <Option value="dark">Dark</Option>
+                </Select>
+              </Column>
+              <Column span={6}>
+                <Label htmlFor={formatControlId} id={formatControlLabelId}>
+                  Format
+                </Label>
+                <Select
+                  id={formatControlId}
+                  value={selectedFormat}
+                  onChange={handleFormatChange}
+                  data-cy="format-control"
+                >
+                  <Option value="css">CSS</Option>
+                  <Option value="javascript">Javascript</Option>
+                </Select>
+              </Column>
+            </Grid>
           </Column>
         </Grid>
       </Box>


### PR DESCRIPTION
## In this PR

[Jira ticket](https://issues.corp.twilio.com/browse/DSYS-3175)

The purpose of the ticket was to add a modal for the filtering UI at smaller screen sizes, but [based on this slack thread](https://twilio.slack.com/archives/C02LKSS1H41/p1657905916067179), we decided to display all of the filtering controls at all sizes, but stack them at the smallest breakpoint.

This PR adds breakpoints and an additional grid to the `TokensListFilter` component to implement that behavior. Screen recording shows the proposed solution.

### Open questions
- I added a cypress test but I'm having trouble actually getting cypress to run. I'll dig into it more on Monday, but here's the error I get when I try to run a test using the gui



https://user-images.githubusercontent.com/75342690/179315855-85dc8ef3-51c2-4f95-a59f-171a86341277.mov

