### PR TITLE
feat(tokens-page): remove border-radius from square size token examples

### DIFF
--- a/packages/paste-website/src/components/tokens-list/token-card/token-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/token-example/index.tsx
@@ -63,7 +63,11 @@ export const TokenExample: React.FC<TokenExampleProps> = ({category, name, value
         tokenExampleRender = <IconSizeExample size={value as keyof ThemeShape['iconSizes']} />;
       } else if (name.toLowerCase().match('square')) {
         tokenExampleRender = (
-          <BoxExample backgroundColor="colorBackgroundStrong" size={value as keyof ThemeShape['sizes']} />
+          <BoxExample
+            backgroundColor="colorBackgroundStrong"
+            size={value as keyof ThemeShape['sizes']}
+            borderRadius="borderRadius0"
+          />
         );
       }
 


### PR DESCRIPTION
* Cancels default border radius on the square sizing token examples (the small ones looked like circles)

<img width="731" alt="Screen Shot 2022-07-20 at 9 31 02 AM" src="https://user-images.githubusercontent.com/36438/180008348-5a20fdd9-568a-4957-b81f-3eaf637883a6.png">