### PR TITLE
feat(tokens-page): make pill radius example more pill like

### DIFF
--- a/packages/paste-website/src/components/tokens-list/token-card/token-example/BoxExample.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/token-example/BoxExample.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import {Box} from '@twilio-paste/box';
 import type {BoxProps} from '@twilio-paste/box';
 
-type BoxExampleProps = Pick<BoxProps, 'backgroundColor' | 'borderColor' | 'boxShadow' | 'borderRadius' | 'size'>;
+type BoxExampleProps = Pick<
+  BoxProps,
+  'backgroundColor' | 'borderColor' | 'boxShadow' | 'borderRadius' | 'size' | 'height'
+>;
 
 export const BoxExample: React.FC<BoxExampleProps> = ({
   backgroundColor,
@@ -10,6 +13,7 @@ export const BoxExample: React.FC<BoxExampleProps> = ({
   boxShadow,
   borderRadius = 'borderRadius20',
   size = 'sizeSquare110',
+  height,
 }) => {
   return (
     <Box
@@ -18,7 +22,8 @@ export const BoxExample: React.FC<BoxExampleProps> = ({
       borderColor={borderColor}
       borderWidth={borderColor ? 'borderWidth20' : null}
       borderStyle={borderColor ? 'solid' : null}
-      size={size}
+      height={height || size}
+      width={size}
       borderRadius={borderRadius}
       boxShadow={boxShadow}
     />

--- a/packages/paste-website/src/components/tokens-list/token-card/token-example/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/token-example/index.tsx
@@ -47,8 +47,14 @@ export const TokenExample: React.FC<TokenExampleProps> = ({category, name, value
       tokenExampleRender = <LineHeightExample tokenName={name} lineHeight={value as keyof ThemeShape['lineHeights']} />;
       break;
     case 'radii':
+      const height = name.toLowerCase().match('pill') ? 'sizeSquare70' : null;
+
       tokenExampleRender = (
-        <BoxExample borderRadius={value as keyof ThemeShape['radii']} backgroundColor="colorBackgroundStrong" />
+        <BoxExample
+          borderRadius={value as keyof ThemeShape['radii']}
+          backgroundColor="colorBackgroundStrong"
+          height={height}
+        />
       );
       break;
     case 'box-shadows':


### PR DESCRIPTION
* Introduces ability to set a height prop on the Token BoxExample
* Sets shorter height for pill radius token to make it look more pill-like

<img width="738" alt="Screen Shot 2022-07-20 at 9 16 05 AM" src="https://user-images.githubusercontent.com/36438/180004936-ea89a54d-40ce-404f-8883-6094d9c7423b.png">