### PR TITLE
fix: text color of deafult variant when selected + hover

### DIFF
--- a/.changeset/sour-buckets-care.md
+++ b/.changeset/sour-buckets-care.md
@@ -3,4 +3,4 @@
 '@twilio-paste/core': minor
 ---
 
-[Form Pill Group] add error variant, disabled pills, and update styles
+[Form Pill Group] add error variant, update styles, and support disabled pills

--- a/packages/paste-core/components/form-pill-group/src/FormPill.styles.ts
+++ b/packages/paste-core/components/form-pill-group/src/FormPill.styles.ts
@@ -114,6 +114,7 @@ export const hoverPillStyles: VariantStyles = {
     _selected_hover: {
       backgroundColor: 'colorBackgroundErrorStrongest',
       borderColor: 'transparent',
+      color: 'inherit',
     },
     _focus_hover: {
       borderColor: 'transparent',


### PR DESCRIPTION
One liner fix for this issue: https://www.loom.com/share/3eb7d0c6b68c4846a4407fc1e3aa52e7

-____-

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
