### PR TITLE
chore(website): add breakpoints, maxWidth

### DIFF
--- a/cypress/integration/token-list/index.spec.ts
+++ b/cypress/integration/token-list/index.spec.ts
@@ -7,20 +7,6 @@ describe('Token list filter with no existing search params', function () {
     cy.visit('/tokens/list');
   });
 
-  // Todo: uncomment search filter tests when filter work is done
-
-  //   it('searches for a background color', () => {
-  //     cy.get('input[name="tokens-filter"]').type('background').should('have.value', 'background');
-  //     cy.get('#background-colors').should('exist');
-  //     cy.get('#border-colors').should('not.exist');
-  //   });
-
-  //   it('shows empty state', () => {
-  //     cy.get('input[name="tokens-filter"]').type('abc');
-  //     cy.get('[data-cy="tokens-empty-state"]').should('exist');
-  //     cy.get('[data-cy="tokens-empty-state"] h3').should('have.text', `Oh no! We couldn't find any matches`);
-  //   });
-
   describe('Visual regression tests', () => {
     it('Basic VRT', () => {
       cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
@@ -74,5 +60,19 @@ describe('Token list filter format control and theme control', function () {
     cy.get('[data-cy="input-column"]').should('have.css', 'min-width', '0px');
     cy.viewport('iphone-x');
     cy.get('[data-cy="input-column"]').should('have.css', 'min-width', '100%');
+  });
+});
+
+describe('Token Card', function () {
+  beforeEach(() => {
+    cy.visit('/tokens/list');
+  });
+
+  it('has a responsive layout', () => {
+    cy.get('[data-paste-element=TOKEN_CARD] dd').should('have.css', 'display', 'flex');
+    cy.get('[data-paste-element=TOKEN_CARD] dd ul').should('have.css', 'maxWidth', '192px');
+    cy.viewport('iphone-x');
+    cy.get('[data-paste-element=TOKEN_CARD] dd').should('have.css', 'display', 'block');
+    cy.get('[data-paste-element=TOKEN_CARD] dd ul').should('have.css', 'maxWidth', 'none');
   });
 });

--- a/cypress/integration/token-list/index.spec.ts
+++ b/cypress/integration/token-list/index.spec.ts
@@ -11,6 +11,10 @@ describe('Token list filter with no existing search params', function () {
     it('Basic VRT', () => {
       cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
     });
+    it('Small viewport VRT', () => {
+      cy.viewport('iphone-x');
+      cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
+    });
   });
 });
 

--- a/cypress/integration/token-list/index.spec.ts
+++ b/cypress/integration/token-list/index.spec.ts
@@ -11,10 +11,6 @@ describe('Token list filter with no existing search params', function () {
     it('Basic VRT', () => {
       cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
     });
-    it('Small viewport VRT', () => {
-      cy.viewport('iphone-x');
-      cy.visualRegressionTestUrl({url: '/tokens/list', testName: `${testSuiteName}-basic-page-check`});
-    });
   });
 });
 

--- a/packages/paste-website/src/components/tokens-list/token-card/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/index.tsx
@@ -178,7 +178,7 @@ export const TokenCard: React.FC<{
               paddingLeft="space0"
               flexShrink={0}
               listStyleType="none"
-              maxWidth="size20"
+              maxWidth={['none', 'size20', 'none', 'size20']}
             >
               <Text
                 as="li"

--- a/packages/paste-website/src/components/tokens-list/token-card/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/index.tsx
@@ -18,8 +18,8 @@ const TokenCardContent = styled.dl(
     gridTemplateColumns: '1fr',
     gridTemplateRows: '1fr',
     margin: 'space0',
-    paddingX: ['space50', 'space70'],
-    paddingY: ['space50', 'space60'],
+    paddingX: ['space50', 'space70', 'space50', 'space70'],
+    paddingY: ['space50', 'space60', 'space50', 'space60'],
   })
 );
 
@@ -33,14 +33,14 @@ const TokenCardName = styled.dt(
 
 const TokenCardValue = styled.dd(
   css({
-    gridRow: [3, '1/3'],
-    gridColumn: [1, '2/2'],
-    display: ['block', 'flex'],
+    gridRow: [3, '1/3', 3, '1/3'],
+    gridColumn: [1, '2/2', 1, '2/2'],
+    display: ['block', 'flex', 'block', 'flex'],
     margin: 'space0',
-    marginTop: ['space40', 'space0'],
-    marginLeft: ['space0', 'space110'],
+    marginTop: ['space40', 'space0', 'space40', 'space0'],
+    marginLeft: ['space0', 'space110', 'space0', 'space110'],
     verticalAlign: 'center',
-    textAlign: ['left', 'right'],
+    textAlign: ['left', 'right', 'left', 'right'],
   })
 );
 
@@ -173,17 +173,25 @@ export const TokenCard: React.FC<{
               display="flex"
               flexDirection="column"
               justifyContent="center"
-              marginTop={['space30', 'space0']}
+              marginTop={['space30', 'space0', 'space30', 'space0']}
               marginBottom="space0"
               paddingLeft="space0"
               flexShrink={0}
               listStyleType="none"
-              maxWidth="190px"
+              maxWidth="size20"
             >
-              <Text as="li" fontSize={['fontSize20', 'fontSize30']} lineHeight={['lineHeight20', 'lineHeight30']}>
+              <Text
+                as="li"
+                fontSize={['fontSize20', 'fontSize30', 'fontSize20', 'fontSize30']}
+                lineHeight={['lineHeight20', 'lineHeight30', 'lineHeight20', 'lineHeight30']}
+              >
                 {value}
               </Text>
-              <Text as="li" fontSize={['fontSize20', 'fontSize30']} lineHeight={['lineHeight20', 'lineHeight30']}>
+              <Text
+                as="li"
+                fontSize={['fontSize20', 'fontSize30', 'fontSize20', 'fontSize30']}
+                lineHeight={['lineHeight20', 'lineHeight30', 'lineHeight20', 'lineHeight30']}
+              >
                 {altValue}
               </Text>
             </Box>

--- a/packages/paste-website/src/components/tokens-list/token-card/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/token-card/index.tsx
@@ -173,7 +173,6 @@ export const TokenCard: React.FC<{
               display="flex"
               flexDirection="column"
               justifyContent="center"
-              marginTop={['space30', 'space0', 'space30', 'space0']}
               marginBottom="space0"
               paddingLeft="space0"
               flexShrink={0}

--- a/packages/paste-website/stories/TokenCard.stories.tsx
+++ b/packages/paste-website/stories/TokenCard.stories.tsx
@@ -145,7 +145,7 @@ BoxShadowToken.args = {
 export const FontFamilyToken = Template.bind({});
 FontFamilyToken.args = {
   category: 'fonts',
-  name: 'font-family-code',
+  name: 'font-family-text',
 };
 
 export const FontSizeToken = Template.bind({});


### PR DESCRIPTION
## Changes in this PR
[[DSYS-3447](https://issues.corp.twilio.com/browse/DSYS-3447)] This PR affects the layout within the Token Card in the Tokens List page. Changes include:
- Set up two more break points for `TokenCardValue` component. This change allows for the right hand side nav to be used in more window sizes. You can see the new behavior from this change [in this video](https://www.loom.com/share/8edca1b57ca7421d9dc3e2eb28e7b452).
- Added a `maxWidth` to the Box surrounding the token values. Without a maxWidth value, some token's values that were extremely long (mainly font-family tokens) pushed the token name text to be much too small. 

### Open question
The `maxWidth` value is currently set to `size20`. Originally I chose `size30`, but certain screen widths still made font-family token names too squished. Now at `size20`, they look better. The trade-off is that there are now other token values, namely the shadow-focus ones, that wrap to two lines. This seemed fine by me but wanted to call it out in case there was someone with a strong case against it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
