### PR TITLE
Ensure header stays on top of tooltips

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderDesktop.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-header/SiteHeaderDesktop.tsx
@@ -20,6 +20,7 @@ const SiteHeaderDesktop: React.FC = () => {
       borderBottomWidth="borderWidth10"
       borderBottomStyle="solid"
       flex="1 0 auto"
+      zIndex="99"
     >
       <SiteHeaderLogo title="Paste" subtitle="UX Platform" />
       <Box


### PR DESCRIPTION
<!-- Describe your Pull Request -->

On the tooltip page, tooltips with controlled state can show on top of the header:
https://paste.twilio.design/components/tooltip/#using-state-hooks

<img width="646" alt="Screen Shot 2022-07-28 at 5 35 26 PM" src="https://user-images.githubusercontent.com/305339/181641937-6027f26d-5873-4315-bf73-2272685cb3f0.png">

Wasn't sure if all props were strings, but this might need to be a number :)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
