### PR TITLE
chore: code owners improvement, auto assignee

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @twilio-labs/design-system-eng
+* @twilio-labs/design-systems-eng
 
 # Paste core - round robin someone from leads for review
 /packages/paste-core @twilio-labs/design-system-eng-leads
@@ -12,8 +12,14 @@
 # Paste theme - round robin someone from leads for review
 /packages/paste-theme @twilio-labs/design-system-eng-leads
 
+# Design tokens - round robin someone from leads for review
+/packages/paste-design-tokens @twilio-labs/design-system-eng-leads
+
 # Design tokens - ensure someone from design reviews to keep in sync with Figma
-/packages/paste-design-tokens @twilio-labs/design-systems-pd @twilio-labs/design-system-eng-leads
+/packages/paste-design-tokens/tokens @twilio-labs/design-systems-pd
 
 # Icons - ensure changes to icons are reviewed by a designer
 /packages/paste-icons/svg @twilio-labs/design-systems-pd
+
+# Website - ensure changes to website page copy is reviewed by a designer
+/packages/paste-website/src/pages @twilio-labs/design-systems-pd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,33 @@
-* @twilio-labs/design-systems-eng
+- @twilio-labs/design-systems-eng
 
 # Paste core - round robin someone from leads for review
-/packages/paste-core @twilio-labs/design-system-eng-leads
+
+/packages/paste-core @twilio-labs/design-systems-eng-leads
 
 # Paste customization - round robin someone from leads for review
-/packages/paste-customization @twilio-labs/design-system-eng-leads
+
+/packages/paste-customization @twilio-labs/design-systems-eng-leads
 
 # Paste style props - round robin someone from leads for review
-/packages/paste-style-props @twilio-labs/design-system-eng-leads
+
+/packages/paste-style-props @twilio-labs/design-systems-eng-leads
 
 # Paste theme - round robin someone from leads for review
-/packages/paste-theme @twilio-labs/design-system-eng-leads
+
+/packages/paste-theme @twilio-labs/design-systems-eng-leads
 
 # Design tokens - round robin someone from leads for review
-/packages/paste-design-tokens @twilio-labs/design-system-eng-leads
+
+/packages/paste-design-tokens @twilio-labs/design-systems-eng-leads
 
 # Design tokens - ensure someone from design reviews to keep in sync with Figma
+
 /packages/paste-design-tokens/tokens @twilio-labs/design-systems-pd
 
 # Icons - ensure changes to icons are reviewed by a designer
+
 /packages/paste-icons/svg @twilio-labs/design-systems-pd
 
 # Website - ensure changes to website page copy is reviewed by a designer
+
 /packages/paste-website/src/pages @twilio-labs/design-systems-pd

--- a/.github/workflows/on_pull_request_open.yml
+++ b/.github/workflows/on_pull_request_open.yml
@@ -8,7 +8,10 @@ jobs:
   pr-triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3
+      - name: Auto labeller
+        uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/opened-pr-labeler.yml
+      - name: Assign Author
+        uses: technote-space/assign-author@v1.3.1


### PR DESCRIPTION
This PR does the following things:

- Ensures the group @twilio-labs/design-systems-pd is assigned as a reviewer on any content changes.
- Ensures the group @twilio-labs/design-systems-pd is only assigned as a review when the design token values are changed in the yaml file, not everything in the design token directory which include engineering tasks.
- Corrects the base review assignee as the engineering group, based on a typo.
- Auto assigns the author as the assignee when a PR is created.