### PR TITLE
chore: name cypress vrt job uniquely so it can be a required check

### DIFF
--- a/.github/workflows/on_pull_request_cypress.yml
+++ b/.github/workflows/on_pull_request_cypress.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           record: true
           parallel: true
-          group: "Paste Actions Parallel"
+          group: "Paste Actions with VRT Parallel"
           config: baseUrl=${{ steps.waitForDeployment.outputs.url }}
         env:
           USE_CYPRESS_EYES: true


### PR DESCRIPTION
To be able to create a branch protection rule ensuring cypress VRT is run before merge, give it a unique name so it can be targetted.

## Changes

- Makes sure the cypress group name is different from the non-vrt group name `Paste Actions with VRT Parallel`