### PR TITLE
fix(chat log docs): storybook and github links were pointing to combobox

### DIFF
--- a/packages/paste-website/src/pages/components/chat-log/index.mdx
+++ b/packages/paste-website/src/pages/components/chat-log/index.mdx
@@ -85,8 +85,8 @@ export const pageQuery = graphql`
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.COMPONENTS}
-  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/combobox"
-  storybookUrl="/?path=/story/components-combobox--default-combobox"
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/chat-log"
+  storybookUrl="/?path=/story/components-chatlog--kitchen-sink"
   data={props.data}
   description={props.data.mdx.frontmatter.description}
 />


### PR DESCRIPTION
Currently the Storybook and GitHub links on the page header of the Chat Log page are pointing to Combobox links: https://paste.twilio.design/components/chat-log

This PR points them to Chat Log in Storybook and GH: https://deploy-preview-2624--paste-docs.netlify.app/components/chat-log