### PR TITLE
feat(tokens-page): add ScrollToTopLink UI

### DIFF
--- a/packages/paste-website/src/components/tokens-list/ScrollToTopLink.tsx
+++ b/packages/paste-website/src/components/tokens-list/ScrollToTopLink.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {Button} from '@twilio-paste/button';
+import {ArrowUpIcon} from '@twilio-paste/icons/esm/ArrowUpIcon';
+
+export const ScrollToTopLink: React.FC = () => (
+  <Box as="div" position="absolute" top="110vh" bottom="0" right="0">
+    <Box as="span" position="sticky" top="85vh">
+      <Button as="a" href="#paste-docs-content-area" variant="secondary">
+        Scroll to top <ArrowUpIcon decorative />
+      </Button>
+    </Box>
+  </Box>
+);

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -13,6 +13,7 @@ import {TokenCard} from './token-card';
 import {TokensListFilter} from './TokensListFilter';
 import {SimpleStorage} from '../../utils/SimpleStorage';
 import {sectionIntros} from './sectionIntros';
+import {ScrollToTopLink} from './ScrollToTopLink';
 
 const sentenceCase = (catName: string): string => {
   return catName
@@ -24,7 +25,9 @@ const sentenceCase = (catName: string): string => {
 };
 
 const ContentWrapper: React.FC = (props) => <Box as="div" display={['block', 'block', 'flex']} {...props} />;
-const Content: React.FC = (props) => <Box as="div" maxWidth="size70" minWidth="0" width="100%" {...props} />;
+const Content: React.FC = (props) => (
+  <Box as="div" position="relative" maxWidth="size70" minWidth="0" width="100%" {...props} />
+);
 
 const defaultTheme = 'default';
 const defaultFormat = 'css';
@@ -176,6 +179,7 @@ export const TokensList: React.FC = () => {
                     <p>Placeholder...</p>
                   )}
                 </Box>
+                <ScrollToTopLink />
               </React.Fragment>
             );
           })


### PR DESCRIPTION
<!-- Describe your Pull Request -->

[[DSYS-3177]](https://issues.corp.twilio.com/browse/DSYS-3177)

Scroll to top link (styled as overlayed secondary variant button [per the figma spec](https://www.figma.com/file/gHnoNWHbAKjMSjM02T8R3f/Design-Tokens?node-id=274%3A31954))

https://user-images.githubusercontent.com/109178184/186449442-953b4a89-4057-4300-8d23-7343710fb060.mov


