### PR TITLE
chore(internal docs): adding more prerequisites to the developing locally doc

### DIFF
--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -34,7 +34,8 @@ Before you begin there are some things that you will need to have installed, and
    1. Install via NPM instructions on the Yarn website [https://classic.yarnpkg.com/en/](https://classic.yarnpkg.com/en/)
    2. Paste currently uses v3.
 7. **[Visual Studio Code](https://code.visualstudio.com/)** (optional) - Lightweight IDE that’s really good working with Typescript codebases.
-   1. Check out the recommended extensions in the extensions tab. 9. We supply some handy React code snippets in the Paste repo too
+   1. Check out the recommended extensions in the extensions tab.
+   2. We supply some handy React code snippets in the Paste repo too
 8. **Chrome, Edge, Firefox and Safari browsers** - Browsers we support.
 9. **[iTerm2](https://iterm2.com/)** - (optional) Handy terminal with many features.
    1. We’re fans of zShell coupled with [Oh My Zsh!](https://ohmyz.sh/)

--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -21,26 +21,26 @@
 Before you begin there are some things that you will need to have installed, and some things that we recommend, but are not essential:
 
 1. **[Git](https://git-scm.com/)** - distributed version control. This should be preinstalled on a Mac.
-   1. `git config --global user.name “first last”`
-   2. `git config --global user.email johndoe@example.com`
+    1. `git config --global user.name “first last”`
+    2. `git config --global user.email johndoe@example.com`
 2. **[Xcode Command Line Tools](https://developer.apple.com/xcode/)** - Used to build some Apple software and node packages.
 3. **[Homebrew](https://brew.sh/)** (optional)- A package manager for Mac software
-   1. Follow the installation instructions on the [Homebrew website](https://brew.sh/)
+    1. Follow the installation instructions on the [Homebrew website](https://brew.sh/)
 4. **NodeJS v16.13.x**- A JavaScript runtime for running JavaScript applications
-   1. Node is preinstalled on Macs but you might need to manage the version that is installed.
+    1. Node is preinstalled on Macs but you might need to manage the version that is installed.
 5. **[NVM](https://github.com/nvm-sh/nvm)** (optional) - A Node version manager that can help installing and managing Node versions on your machine
-   1. Follow the [installation instructions on NVM](https://github.com/nvm-sh/nvm#installing-and-updating).
+    1. Follow the [installation instructions on NVM](https://github.com/nvm-sh/nvm#installing-and-updating).
 6. **[Yarn](https://classic.yarnpkg.com/en/)** - A package manager for node packages.
-   1. Install via NPM instructions on the Yarn website [https://classic.yarnpkg.com/en/](https://classic.yarnpkg.com/en/)
-   2. Paste currently uses v3.
+    1. Install via NPM instructions on the Yarn website [https://classic.yarnpkg.com/en/](https://classic.yarnpkg.com/en/)
+    2. Paste currently uses v3.
 7. **[Visual Studio Code](https://code.visualstudio.com/)** (optional) - Lightweight IDE that’s really good working with Typescript codebases.
-   1. Check out the recommended extensions in the extensions tab.
-   2. We supply some handy React code snippets in the Paste repo too
+    1. Check out the recommended extensions in the extensions tab.
+    2. We supply some handy React code snippets in the Paste repo too
 8. **Chrome, Edge, Firefox and Safari browsers** - Browsers we support.
 9. **[iTerm2](https://iterm2.com/)** - (optional) Handy terminal with many features.
-   1. We’re fans of zShell coupled with [Oh My Zsh!](https://ohmyz.sh/)
+    1. We’re fans of zShell coupled with [Oh My Zsh!](https://ohmyz.sh/)
 10. **[Connect to Github with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)** - You'll need this to connect your local machine to Github and clone the Paste repo.
-   1. Follow the [Github instructions to check if you have an existing SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys). If not, continue through the instructions to generate and add a new one.
+    1. Follow the [Github instructions to check if you have an existing SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys). If not, continue through the instructions to generate and add a new one.
 
 ## First time working on Paste
 

--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -28,7 +28,8 @@ Before you begin there are some things that you will need to have installed, and
    1. Follow the installation instructions on the Homebrew website [https://brew.sh/](https://brew.sh/)
 4. **NodeJS v16.13.x**- A JavaScript runtime for running JavaScript applications
    1. Node is preinstalled on Macs but you might need to manage the version that is installed.
-5. **[NVM](https://github.com/nvm-sh/nvm)** (optional) - A Node version manager that can help installing and managing Node versions on your machine 5. Install via Homebrew
+5. **[NVM](https://github.com/nvm-sh/nvm)** (optional) - A Node version manager that can help installing and managing Node versions on your machine
+   1. Install via Homebrew
 6. **[Yarn](https://classic.yarnpkg.com/en/)** - A package manager for node packages.
    1. Install via NPM instructions on the Yarn website [https://classic.yarnpkg.com/en/](https://classic.yarnpkg.com/en/)
    2. Paste currently uses v3.

--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -29,7 +29,7 @@ Before you begin there are some things that you will need to have installed, and
 4. **NodeJS v16.13.x**- A JavaScript runtime for running JavaScript applications
    1. Node is preinstalled on Macs but you might need to manage the version that is installed.
 5. **[NVM](https://github.com/nvm-sh/nvm)** (optional) - A Node version manager that can help installing and managing Node versions on your machine
-   1. Install via Homebrew
+   1. Follow the [installation instructions on NVM](https://github.com/nvm-sh/nvm#installing-and-updating).
 6. **[Yarn](https://classic.yarnpkg.com/en/)** - A package manager for node packages.
    1. Install via NPM instructions on the Yarn website [https://classic.yarnpkg.com/en/](https://classic.yarnpkg.com/en/)
    2. Paste currently uses v3.

--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -20,12 +20,12 @@
 
 Before you begin there are some things that you will need to have installed, and some things that we recommend, but are not essential:
 
-1. **[Git](https://git-scm.com/)** - distributed version control. This should be preinstalled on a Mac
+1. **[Git](https://git-scm.com/)** - distributed version control. This should be preinstalled on a Mac.
    1. `git config --global user.name “first last”`
    2. `git config --global user.email johndoe@example.com`
-2. **[Xcode Command Line Tools](https://developer.apple.com/xcode/)** - Used to build some Apple software and node packages
+2. **[Xcode Command Line Tools](https://developer.apple.com/xcode/)** - Used to build some Apple software and node packages.
 3. **[Homebrew](https://brew.sh/)** (optional)- A package manager for Mac software
-   1. Follow the installation instructions on the Homebrew website [https://brew.sh/](https://brew.sh/)
+   1. Follow the installation instructions on the [Homebrew website](https://brew.sh/)
 4. **NodeJS v16.13.x**- A JavaScript runtime for running JavaScript applications
    1. Node is preinstalled on Macs but you might need to manage the version that is installed.
 5. **[NVM](https://github.com/nvm-sh/nvm)** (optional) - A Node version manager that can help installing and managing Node versions on your machine
@@ -38,6 +38,8 @@ Before you begin there are some things that you will need to have installed, and
 8. **Chrome, Edge, Firefox and Safari browsers** - Browsers we support.
 9. **[iTerm2](https://iterm2.com/)** - (optional) Handy terminal with many features.
    1. We’re fans of zShell coupled with [Oh My Zsh!](https://ohmyz.sh/)
+10. **[Connect to Github with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)** - You'll need this to connect your local machine to Github and clone the Paste repo.
+   1. Follow the [Github instructions to check if you have an existing SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys). If not, continue through the instructions to generate and add a new one.
 
 ## First time working on Paste
 


### PR DESCRIPTION
Changes:

1. The nested list items needed 4 spaces because the last nested item wouldn't nest with only 3 spaces.
2. Swapped NVM installation instructions to link to https://github.com/nvm-sh/nvm#installing-and-updating
3. Added "Connecting to Github with SSH" as a prerequesite: https://docs.github.com/en/authentication/connecting-to-github-with-ssh
4. Minor punctuation and text formatting.