### PR TITLE
fix: link to tokens list on homepage

### DIFF
--- a/packages/paste-website/src/components/homepage/HomeHero.tsx
+++ b/packages/paste-website/src/components/homepage/HomeHero.tsx
@@ -76,7 +76,7 @@ const HomeHero: React.FC = () => {
                 </Badge>
                 <NewComponentBannerText>We updated our tokens list page!</NewComponentBannerText>
                 <NewComponentBannerLink
-                  to="https://www.figma.com/community/plugin/1040423794729523647/Twilio-Ipsum"
+                  to="/tokens/list"
                   onClick={() =>
                     trackCustomEvent({
                       category: 'Hero',


### PR DESCRIPTION
Update the homepage link to point to the correct page