### PR TITLE
fix: escape jsx in a changeset

### DIFF
--- a/.changeset/tall-falcons-occur.md
+++ b/.changeset/tall-falcons-occur.md
@@ -3,4 +3,4 @@
 '@twilio-paste/core': patch
 ---
 
-[Button] support <Button as='a' variant='inverse'> and add the `target` prop
+[Button] support `<Button as='a' variant='inverse'>` and add the `target` prop


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
