### PR TITLE
chore(avatar): remove underline on avatars in anchors

### DIFF
--- a/.changeset/six-frogs-destroy.md
+++ b/.changeset/six-frogs-destroy.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/avatar': patch
+'@twilio-paste/core': patch
+---
+
+[Avatar] Prevent underlines from being added to Avatar initials inside of anchors or display pills

--- a/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Avatar intials should render responsive css 1`] = `
   line-height: lineHeight10;
   display: inline-block;
   font-weight: fontWeightBold;
-  text-align: center;
+  vertical-align: text-top;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Avatar intials should render responsive css 1`] = `
   line-height: lineHeight10;
   display: inline-block;
   font-weight: fontWeightBold;
-  vertical-align: text-top;
+  vertical-align: top;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/paste-core/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Avatar image should render responsive css with an image 1`] = `
   .emotion-0 {
   box-sizing: border-box;
   overflow: hidden;
+  text-align: center;
   width: sizeIcon30;
   height: sizeIcon30;
   background-color: colorBackgroundUser;
@@ -67,6 +68,7 @@ exports[`Avatar intials should render responsive css 1`] = `
   .emotion-0 {
   box-sizing: border-box;
   overflow: hidden;
+  text-align: center;
   width: sizeIcon10;
   height: sizeIcon10;
   background-color: colorBackgroundUser;
@@ -94,7 +96,7 @@ exports[`Avatar intials should render responsive css 1`] = `
   color: inherit;
   font-size: fontSize10;
   line-height: lineHeight10;
-  display: block;
+  display: inline-block;
   font-weight: fontWeightBold;
   text-align: center;
   -webkit-text-decoration: none;

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -32,7 +32,6 @@ const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE
       fontSize={computedTokenNames.fontSize}
       fontWeight="fontWeightBold"
       lineHeight={computedTokenNames.lineHeight}
-      textAlign="center"
       verticalAlign="text-top"
       textDecoration="none"
       title={name}
@@ -90,7 +89,6 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         as="div"
         element={element}
         overflow="hidden"
-        // textDecoration="none"
         textAlign="center"
         ref={ref}
         size={size}

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -33,6 +33,7 @@ const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE
       fontWeight="fontWeightBold"
       lineHeight={computedTokenNames.lineHeight}
       textAlign="center"
+      verticalAlign="text-top"
       textDecoration="none"
       title={name}
       color="inherit"
@@ -89,6 +90,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         as="div"
         element={element}
         overflow="hidden"
+        // textDecoration="none"
         textAlign="center"
         ref={ref}
         size={size}

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -32,7 +32,7 @@ const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE
       fontSize={computedTokenNames.fontSize}
       fontWeight="fontWeightBold"
       lineHeight={computedTokenNames.lineHeight}
-      verticalAlign="text-top"
+      verticalAlign="top"
       textDecoration="none"
       title={name}
       color="inherit"

--- a/packages/paste-core/components/avatar/src/index.tsx
+++ b/packages/paste-core/components/avatar/src/index.tsx
@@ -28,7 +28,7 @@ const AvatarContents: React.FC<AvatarContentProps> = ({name, size = DEFAULT_SIZE
   return (
     <Text
       as="abbr"
-      display="block"
+      display="inline-block"
       fontSize={computedTokenNames.fontSize}
       fontWeight="fontWeightBold"
       lineHeight={computedTokenNames.lineHeight}
@@ -89,6 +89,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         as="div"
         element={element}
         overflow="hidden"
+        textAlign="center"
         ref={ref}
         size={size}
         {...colorVariants[color]}

--- a/packages/paste-core/components/display-pill-group/stories/index.stories.tsx
+++ b/packages/paste-core/components/display-pill-group/stories/index.stories.tsx
@@ -26,6 +26,10 @@ export const Basic: React.FC = () => {
         <Avatar size="sizeIcon10" name="avatar example" src="./avatars/avatar4.png" />
         Baseball
       </DisplayPill>
+      <DisplayPill href="/">
+        <Avatar size="sizeIcon10" name="Avatar Anchor Example" />
+        Bowling
+      </DisplayPill>
       <DisplayPill>Basketball</DisplayPill>
       <DisplayPill>Soccer</DisplayPill>
     </DisplayPillGroup>


### PR DESCRIPTION
Jira ticket: [DSYS-3449](https://issues.corp.twilio.com/browse/DSYS-3449)

This PR removes the extra underline from Avatars inside of Anchors or linked Display Pills.

Old:
![Screen Shot 2022-09-22 at 3 32 46 PM](https://user-images.githubusercontent.com/75342690/191835148-df32f124-a0d5-44e3-9533-004bc806411b.png)

Now:
![Screen Shot 2022-09-22 at 3 35 28 PM](https://user-images.githubusercontent.com/75342690/191835590-fdc5e346-febc-4b62-97ea-d2b3bf9fd8e2.png)
