### PR TITLE
fix: storybook hot reloading on paste imports

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,8 +1,7 @@
-const DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin');
 const path = require('path');
 
 module.exports = {
-  stories: ['../packages/**/*.stories.mdx', '../packages/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../packages/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
@@ -63,13 +62,6 @@ module.exports = {
   },
 
   webpackFinal: async (config) => {
-    const customPlugins = [
-      new DirectoryNamedWebpackPlugin({honorPackage: ['main:dev', 'main'], exclude: /node_modules/}),
-    ];
-
-    config.resolve.plugins =
-      config.resolve.plugins == null ? customPlugins : [...config.resolve.plugins, ...customPlugins];
-
     // Need to custom alias react-dom and scheduler for component profiling in production
     // mode. Without doing so, no React profiling data can be extracted from stories
     // When they are deployed.
@@ -81,6 +73,9 @@ module.exports = {
       'emotion-theming': path.resolve(__dirname, '../node_modules/@emotion/react'),
     };
     config.resolve.alias = config.resolve.alias == null ? customAlias : {...config.resolve.alias, ...customAlias};
+
+    // FIX: Tell Storybook to look at dev files if available
+    config.resolve.mainFields = ['main:dev', 'browser', 'module', 'main'];
 
     return config;
   },

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "cypress": "10.8.0",
     "danger": "^10.6.6",
     "del": "^5.1.0",
-    "directory-named-webpack-plugin": "^4.0.1",
     "dotenv": "^16.0.0",
     "esbuild": "^0.14.43",
     "eslint": "^7.32.0",

--- a/packages/paste-core/components/menu/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/menu/__tests__/customization.spec.tsx
@@ -121,7 +121,7 @@ describe('Menu Customization', () => {
 
         expect(nodeCalledMenu).toHaveStyleRule('box-shadow', '0 16px 24px 0 rgba(18, 28, 45, 0.2)');
         expect(nodeCalledMenu).toHaveStyleRule('border-radius', '0');
-        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(244, 124, 34)');
+        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(235, 244, 255)');
         expect(nodeCalledMenuItem).toHaveStyleRule('font-weight', '500');
         expect(nodeCalledMenuItem).toHaveStyleRule('border-left-width', '4px', {target: ':hover'});
         expect(nodeCalledMenuItem).toHaveStyleRule('border-left-style', 'solid', {target: ':hover'});
@@ -159,7 +159,7 @@ describe('Menu Customization', () => {
 
         expect(nodeCalledMenu).toHaveStyleRule('box-shadow', '0 16px 24px 0 rgba(18, 28, 45, 0.2)');
         expect(nodeCalledMenu).toHaveStyleRule('border-radius', '0');
-        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(49, 12, 12)');
+        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(235, 244, 255)');
 
         expect(nodeCalledMenuItem).toHaveStyleRule('font-weight', '500');
         expect(nodeCalledMenuItem).toHaveStyleRule('border-left-width', '4px', {target: ':hover'});
@@ -279,7 +279,7 @@ describe('Menu Customization', () => {
 
         expect(nodeCalledMenu).toHaveStyleRule('box-shadow', '0 16px 24px 0 rgba(18, 28, 45, 0.2)');
         expect(nodeCalledMenu).toHaveStyleRule('border-radius', '0');
-        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(244, 124, 34)');
+        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(235, 244, 255)');
 
         expect(nodeCalledMenuItem).toHaveStyleRule('font-weight', '500');
         expect(nodeCalledMenuItem).toHaveStyleRule('border-left-width', '4px', {target: ':hover'});
@@ -318,7 +318,7 @@ describe('Menu Customization', () => {
 
         expect(nodeCalledMenu).toHaveStyleRule('box-shadow', '0 16px 24px 0 rgba(18, 28, 45, 0.2)');
         expect(nodeCalledMenu).toHaveStyleRule('border-radius', '0');
-        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(49, 12, 12)');
+        expect(nodeCalledMenuButton).toHaveStyleRule('background-color', 'rgb(235, 244, 255)');
 
         expect(nodeCalledMenuItem).toHaveStyleRule('font-weight', '500');
         expect(nodeCalledMenuItem).toHaveStyleRule('border-left-width', '4px', {target: ':hover'});

--- a/packages/paste-core/components/menu/stories/customization.stories.tsx
+++ b/packages/paste-core/components/menu/stories/customization.stories.tsx
@@ -24,8 +24,8 @@ export const initStyles = (element: string): ElementOverrides => ({
   },
   [`${element}_BUTTON`]: {
     variants: {
-      secondary: {backgroundColor: 'colorBackgroundBusy'},
-      destructive: {backgroundColor: 'colorBackgroundDestructiveStrongest'},
+      secondary: {color: 'colorText', backgroundColor: 'colorBackgroundNeutralWeakest'},
+      destructive: {color: 'colorText', backgroundColor: 'colorBackgroundNeutralWeakest'},
       destructive_secondary: {backgroundColor: 'colorBackgroundNeutralWeakest', color: 'colorTextWarningStrong'},
       link: {padding: 'space40', borderRadius: 'borderRadiusCircle', backgroundColor: 'colorBackgroundNeutralWeakest'},
       destructive_link: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20627,18 +20627,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"directory-named-webpack-plugin@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "directory-named-webpack-plugin@npm:4.0.1"
-  dependencies:
-    enhanced-resolve: ^4.0.0
-    object-assign: ^4.1.0
-  peerDependencies:
-    webpack: ">=4.0.0"
-  checksum: 0132d1475fd2ec14003843cb201a7cbfadfdf45258f1bf6a0ce996cd5257d92301c6415958e286a3bf0354aacab1ea4e7a80f081fc480cdbea3556fe1ec08d9e
-  languageName: node
-  linkType: hard
-
 "dlv@npm:^1.1.3":
   version: 1.1.3
   resolution: "dlv@npm:1.1.3"
@@ -21322,7 +21310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^4.0.0, enhanced-resolve@npm:^4.5.0":
+"enhanced-resolve@npm:^4.5.0":
   version: 4.5.0
   resolution: "enhanced-resolve@npm:4.5.0"
   dependencies:
@@ -35176,7 +35164,6 @@ fsevents@^1.2.7:
     cypress: 10.8.0
     danger: ^10.6.6
     del: ^5.1.0
-    directory-named-webpack-plugin: ^4.0.1
     dotenv: ^16.0.0
     esbuild: ^0.14.43
     eslint: ^7.32.0


### PR DESCRIPTION
Fixes Storybook hot reloading of Paste imports.  Hot reloading worked when importing relative source files (i.e.: `import {Button} from '../src';` but failed when importing named packages (i.e.: `import {Button} from '@twilio-paste/button'`).  This made it tedious to iterate quickly.

Loom video of my debugging process: 
https://www.loom.com/share/9fcfbf7d5526457a926a5890fe02df2d