### PR TITLE
feat(sticky-token-filters): add support for sticky filters

### DIFF
--- a/packages/paste-website/src/components/shortcodes/PageAside.tsx
+++ b/packages/paste-website/src/components/shortcodes/PageAside.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
+import type {BoxProps} from '@twilio-paste/box';
 import {TableOfContents} from './table-of-contents';
 import {FeedbackPopover} from './feedback-popover';
 
@@ -17,9 +18,11 @@ interface PageAsideProps {
     headings?: ToCHeading[];
   };
   hideFeedback?: boolean;
+  stickyTop?: BoxProps['top'];
+  topPadding?: BoxProps['padding'];
 }
 
-const PageAside: React.FC<PageAsideProps> = ({data, hideFeedback}) => {
+const PageAside: React.FC<PageAsideProps> = ({data, hideFeedback, stickyTop = 'space130', topPadding = 'space0'}) => {
   return (
     <Box
       order={2}
@@ -30,7 +33,7 @@ const PageAside: React.FC<PageAsideProps> = ({data, hideFeedback}) => {
       display={['none', 'none', 'block']}
       data-cy="page-aside"
     >
-      <Box position="sticky" top="space130">
+      <Box position="sticky" top={stickyTop} paddingTop={topPadding}>
         {hideFeedback ? null : <FeedbackPopover />}
         <TableOfContents headings={data.headings} />
       </Box>

--- a/packages/paste-website/src/components/shortcodes/table-of-contents/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/table-of-contents/index.tsx
@@ -5,6 +5,9 @@ import {TableOfContentsList} from './TableOfContentsList';
 import {TableOfContentsListItem} from './TableOfContentsListItem';
 import {TableOfContentsAnchor} from './TableOfContentsAnchor';
 import {slugify} from '../../../utils/RouteUtils';
+import {useLocationPathname} from '../../../utils/RouteUtils';
+import {useWindowSize} from '../../../hooks/useWindowSize';
+import {TOKEN_STICKY_FILTER_HEIGHT, TOKEN_LIST_PAGE_REGEX} from '../../../constants';
 
 // Table of contents should only include h2, h3, h4 headings
 const shouldIncludeInToC = ({depth}: {depth: number}): boolean => depth > 1 && depth < 4;
@@ -20,11 +23,33 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({headings}) => {
     return headingAnchor;
   });
 
+  /**
+   * The Tokens List page has a sticky filter when scrolled, which means that we need to
+   * set a negative offset to adjust whew ScrollSpy transitions from one section to the next.
+   *
+   * We have a global array, 'TOKEN_STICKY_FILTER_HEIGHT' that returns a value for the height
+   * of the filter for the current breakpoint (different breakpoints have different heights),
+   * and we use that, combined with router awareness of our current location, to determine the
+   * value to set for ScrollSpy's offset prop. We also adjust by 42px, which is the value of
+   * the margin between token category sections.
+   */
+  const {breakpointIndex} = useWindowSize();
+  let scrollOffset = 0;
+
+  if (breakpointIndex !== undefined && TOKEN_LIST_PAGE_REGEX.test(useLocationPathname())) {
+    scrollOffset = -TOKEN_STICKY_FILTER_HEIGHT[breakpointIndex] + 32;
+  }
+
   // TODO: Add changelog to headingsList Array because changelogs aren't imported.
   // but only for pages with changelogs
   return (
     <Box as="nav" aria-label="document outline" data-cy="table-of-contents">
-      <TableOfContentsList items={headingsList} currentClassName="is-current" rootEl="#styled-site-body">
+      <TableOfContentsList
+        items={headingsList}
+        currentClassName="is-current"
+        rootEl="#styled-site-body"
+        offset={scrollOffset}
+      >
         {
           // Get heading anchors and convert to #anchor format. Excluding h1 elements.
           headings.filter(shouldIncludeInToC).map(({value, depth}) => {

--- a/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteBody.tsx
@@ -6,7 +6,12 @@ import {useWindowSize} from '@twilio-paste/utils';
 import {Sidebar} from './sidebar';
 import {SiteHeader} from './site-header';
 import {SiteFooter} from './site-footer';
-import {PASTE_DOCS_CONTENT_AREA, SITE_BREAKPOINTS} from '../../constants';
+import {
+  PASTE_DOCS_CONTENT_AREA,
+  SITE_BREAKPOINTS,
+  TOKEN_STICKY_FILTER_HEIGHT,
+  TOKEN_LIST_PAGE_REGEX,
+} from '../../constants';
 import {docSearchStyles, docSearchVariable} from '../../styles/docSearch';
 
 /* Wraps the main region and footer on the doc site page */
@@ -32,15 +37,34 @@ const StyledSiteBody = styled.div`
   }
 `;
 
-export const SiteBody: React.FC = ({children}) => {
+export const SiteBody: React.FC<{pathname: string}> = ({children, pathname}) => {
   const {breakpointIndex} = useWindowSize();
   const themeObject = useTheme();
+
+  /**
+   * The Tokens List page has a sticky filter when scrolled, which means that we need to set a
+   * CSS property called 'scrollPaddingTop' to adjust where the page scrolls to on jump links,
+   * so the content doesn't appear underneath the sticky filter.
+   *
+   * We have a global array, 'TOKEN_STICKY_FILTER_HEIGHT' that returns a value for the height
+   * of the filter (different breakpoints have different heights), and we use that, combined
+   * with router awareness of our current location, to determine the value to set for scrollPaddingTop.
+   *
+   * We also have a default value set to optimize the scroll jump so there's some space above the content.
+   */
+
+  const defaultScrollOffset = 16;
+  let scrollOffset = defaultScrollOffset;
+
+  if (breakpointIndex !== undefined && TOKEN_LIST_PAGE_REGEX.test(pathname)) {
+    scrollOffset = TOKEN_STICKY_FILTER_HEIGHT[breakpointIndex] + defaultScrollOffset;
+  }
 
   return (
     <Box display="flex" flexDirection="column" height="100vh">
       <StylingGlobals styles={{...docSearchStyles({theme: themeObject}), ...docSearchVariable(themeObject)}} />
       <SiteHeader />
-      <StyledSiteBody id="styled-site-body">
+      <StyledSiteBody id="styled-site-body" css={{scrollPaddingTop: `${scrollOffset}px`}}>
         {breakpointIndex === undefined || breakpointIndex > 1 ? <Sidebar /> : null}
         <Box flex="1" minWidth="size0">
           <main id={PASTE_DOCS_CONTENT_AREA}>{children}</main>

--- a/packages/paste-website/src/components/site-wrapper/index.tsx
+++ b/packages/paste-website/src/components/site-wrapper/index.tsx
@@ -88,7 +88,7 @@ const SiteWrapper: React.FC<SiteWrapperProps> = ({pathname, children}) => {
               <Anchor href={`#${PASTE_DOCS_SEARCH_INPUT}`}>Skip to search</Anchor>
             </Stack>
           </SkipLinkContainer>
-          <SiteBody>{children}</SiteBody>
+          <SiteBody pathname={pathname}>{children}</SiteBody>
         </DarkModeContext.Provider>
       </NavigationContext.Provider>
     </Theme.Provider>

--- a/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
+++ b/packages/paste-website/src/components/tokens-list/TokensListFilter.tsx
@@ -17,6 +17,7 @@ export interface TokensListFilterProps {
   handleClearSearch: () => void;
   selectedFormat: string;
   selectedTheme: string;
+  shadowOpacity: number;
 }
 
 export const TokensListFilter: React.FC<TokensListFilterProps> = ({
@@ -27,6 +28,7 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = ({
   handleClearSearch,
   selectedFormat,
   selectedTheme,
+  shadowOpacity = 0,
 }) => {
   const inputId = useUID();
   const themeControlId = useUID();
@@ -34,9 +36,30 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = ({
   const formatControlId = useUID();
   const formatControlLabelId = useUID();
 
+  // Note: We use pseudo content for creating the shadow, in order for it to be
+  // visually cropped and not bleed onto the sides of the filter container.
   return (
-    <>
-      <Box marginBottom="space80">
+    <Box
+      marginBottom="space80"
+      position="sticky"
+      top="0"
+      zIndex="zIndex10"
+      marginX="spaceNegative40"
+      css={{
+        '::before': {
+          content: '""',
+          position: 'absolute',
+          bottom: '0',
+          right: '8px',
+          left: '8px',
+          height: '1px',
+          backgroundColor: '#fff',
+          boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.8)',
+          opacity: shadowOpacity,
+        },
+      }}
+    >
+      <Box backgroundColor="colorBackgroundBody" padding="space40" position="relative">
         <Grid gutter="space40" vertical={[true, false, true, false]}>
           <Column span={[12, 6, 12, 6]} data-cy="input-column">
             <Label htmlFor={inputId}>Filter tokens</Label>
@@ -85,6 +108,6 @@ export const TokensListFilter: React.FC<TokensListFilterProps> = ({
           </Column>
         </Grid>
       </Box>
-    </>
+    </Box>
   );
 };

--- a/packages/paste-website/src/components/tokens-list/index.tsx
+++ b/packages/paste-website/src/components/tokens-list/index.tsx
@@ -137,6 +137,9 @@ export const TokensList: React.FC = () => {
     if (tokensFilter) {
       intObserver.observe(tokensFilter);
     }
+    return () => {
+      intObserver.disconnect();
+    };
   }, []);
 
   // Render code

--- a/packages/paste-website/src/constants.ts
+++ b/packages/paste-website/src/constants.ts
@@ -23,6 +23,12 @@ export const PASTE_DOCS_CONTENT_AREA = 'paste-docs-content-area';
 export const PASTE_DOCS_SEARCH_INPUT = 'paste-docs-search-input';
 export const PASTE_DOCS_SEARCH_INPUT_MOBILE = 'paste-docs-search-input-mobile';
 
+// Used to adjust scrolling elements to account for sticky filter on tokens/list page
+export const TOKEN_STICKY_FILTER_HEIGHT = [192, 108, 192, 108];
+
+// Regex that looks for match on `/tokens/list/` route, specifically
+export const TOKEN_LIST_PAGE_REGEX = /^\/tokens\/list\/$/;
+
 // env variables
 export const DATADOG_APPLICATION_ID = process.env.GATSBY_DATADOG_APPLICATION_ID || 'no env variable';
 export const DATADOG_CLIENT_TOKEN = process.env.GATSBY_DATADOG_CLIENT_TOKEN || 'no env variable';

--- a/packages/paste-website/src/pages/tokens/list/index.mdx
+++ b/packages/paste-website/src/pages/tokens/list/index.mdx
@@ -18,6 +18,13 @@ import {SidebarCategoryRoutes} from '../../../constants';
   description="All tokens that are available in the Paste token system."
 />
 
----
+<Box
+  as="hr"
+  borderWidth="borderWidth0"
+  borderColor="colorBorderWeak"
+  borderStyle="solid"
+  borderBottomWidth="borderWidth10"
+  marginTop="space100"
+/>
 
 <TokensList />


### PR DESCRIPTION
**This is a replacement PR for #2602 because the checks were failing**

## Update summary
* Updates Tokens Page filters to be sticky on the page.
* Uses IntersectionObserver to apply shadow on filters.
* Resolves issue with ToC nav on Tokens Page losing its position once the header is off screen.
* Adds support for route & breakpoint based scroll offset values.

### Additional notes
* Using a placeholder element ("filter-canary") to interact w/ IntersectionObserver since sticky position never triggers the events we need. 
* Setting a height on the IntersectionObserver canary allows us to fade in opacity of the shadow as the user scrolls down.
* Shadow is built using a pseudo element since applying a box-shadow to the whole element will bleed over to the sides. 
* Using negative margins and z-indicies to cover up the top and sides of the shadow pesudo.