### PR TITLE
Update GitHub Usage

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/site-footer/SiteFooterNav.tsx
+++ b/packages/paste-website/src/components/site-wrapper/site-footer/SiteFooterNav.tsx
@@ -90,7 +90,7 @@ const SiteFooterNav: React.FC = () => {
                 })
               }
             >
-              Github
+              GitHub
             </Anchor>
             <Anchor
               href={FIGMA_PROFILE_URL}


### PR DESCRIPTION
- Updated `Github` in the site footer to `GitHub`. The `h` in GitHub should be capitalized.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
