### PR TITLE
docs: add website docs for ButtonGroup

### DIFF
--- a/cypress/integration/sitemap-vrt/constants.ts
+++ b/cypress/integration/sitemap-vrt/constants.ts
@@ -24,6 +24,7 @@ export const SITEMAP = [
   '/components/display-pill-group/',
   '/components/disclosure/',
   '/components/button/',
+  '/components/button-group/',
   '/components/flex/',
   '/components/combobox/',
   '/components/date-picker/',

--- a/packages/paste-website/src/component-examples/ButtonGroupExamples.ts
+++ b/packages/paste-website/src/component-examples/ButtonGroupExamples.ts
@@ -1,0 +1,147 @@
+export const BasicExample = `const BasicButtonGroup = () => {
+  return (
+    <ButtonGroup attached>
+      <Button variant="secondary">
+        <PlusIcon decorative />
+        Add
+      </Button>
+      <Button variant="secondary">
+        <EditIcon decorative />
+        Edit
+      </Button>
+      <Button variant="secondary">
+        <ExportIcon decorative />
+        Export
+      </Button>
+      <Button variant="destructive_secondary">
+        <DeleteIcon decorative />
+        Delete
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+render(<BasicButtonGroup />);`.trim();
+
+export const UnattachedExample = `const BasicButtonGroup = () => {
+  return (
+    <ButtonGroup>
+      <Button variant="secondary">
+        <PlusIcon decorative />
+        Add
+      </Button>
+      <Button variant="secondary">
+        <EditIcon decorative />
+        Edit
+      </Button>
+      <Button variant="secondary">
+        <ExportIcon decorative />
+        Export
+      </Button>
+      <Button variant="destructive_secondary">
+        <DeleteIcon decorative />
+        Delete
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+render(<BasicButtonGroup />);`.trim();
+
+export const DisabledExample = `const DisabledButtonGroup = () => {
+  return (
+    <ButtonGroup attached>
+      <Button variant="secondary" disabled>
+        <PlusIcon decorative />
+        Add
+      </Button>
+      <Button variant="secondary" disabled>
+        <EditIcon decorative />
+        Edit
+      </Button>
+      <Button variant="secondary" disabled>
+        <ExportIcon decorative />
+        Export
+      </Button>
+      <Button variant="destructive_secondary" disabled>
+        <DeleteIcon decorative />
+        Delete
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+render(<DisabledButtonGroup />);`.trim();
+
+export const IconExample = `const IconButtonGroup = () => {
+  const [boldPressed, setBoldPressed] = React.useState(false);
+  const [italicPressed, setItalicPressed] = React.useState(false);
+  const [underlinePressed, setUnderlinePressed] = React.useState(false);
+
+  return (
+    <ButtonGroup attached>
+      <Tooltip text="Bold">
+        <Button
+          variant="secondary_icon"
+          size="icon"
+          pressed={boldPressed}
+          onClick={() => setBoldPressed(!boldPressed)}
+        >
+          <BoldIcon decorative={false} title="Bold" />
+        </Button>
+      </Tooltip>
+      <Tooltip text="Italic">
+      <Button
+          variant="secondary_icon"
+          size="icon"
+          pressed={italicPressed}
+          onClick={() => setItalicPressed(!italicPressed)}
+        >
+          <ItalicIcon decorative={false} title="Italic" />
+        </Button>
+      </Tooltip>
+      <Tooltip text="Underline">
+        <Button
+          variant="secondary_icon"
+          size="icon"
+          pressed={underlinePressed}
+          onClick={() => setUnderlinePressed(!underlinePressed)}
+        >
+          <UnderlineIcon decorative={false} title="Underline" />
+        </Button>
+      </Tooltip>
+    </ButtonGroup>
+  );
+};
+
+render(<IconButtonGroup />);`.trim();
+
+export const MenuExample = `const MenuButtonGroup = () => {
+  const menu = useMenuState();
+  return (
+    <ButtonGroup attached>
+      <Button variant="secondary">
+        <PlusIcon decorative />
+        Add
+      </Button>
+      <Button variant="secondary">
+        <EditIcon decorative />
+        Edit
+      </Button>
+      <Button variant="destructive_secondary">
+        <DeleteIcon decorative />
+        Delete
+      </Button>
+      <MenuButton {...menu} variant="secondary">
+        <ChevronDownIcon decorative={false} title='Additional actions' />
+      </MenuButton>
+      <Menu {...menu} aria-label="Additional actions">
+        <MenuItem {...menu}>Export</MenuItem>
+        <MenuItem {...menu}>Share</MenuItem>
+        <MenuItem {...menu}>Duplicate</MenuItem>
+      </Menu>
+    </ButtonGroup>
+  );
+};
+
+render(<MenuButtonGroup />);`.trim();

--- a/packages/paste-website/src/pages/components/button-group/index.mdx
+++ b/packages/paste-website/src/pages/components/button-group/index.mdx
@@ -1,0 +1,263 @@
+---
+title: Button Group
+package: '@twilio-paste/button-group'
+description: A Button Group displays a set of related actions.
+slug: /components/button-group/
+---
+
+import {graphql} from 'gatsby';
+import {Button} from '@twilio-paste/button';
+import {ButtonGroup} from '@twilio-paste/button-group';
+import {Tooltip} from '@twilio-paste/tooltip';
+import {Menu, useMenuState, MenuButton, MenuItem} from '@twilio-paste/menu';
+import {DeleteIcon} from '@twilio-paste/icons/esm/DeleteIcon';
+import {EditIcon} from '@twilio-paste/icons/esm/EditIcon';
+import {ExportIcon} from '@twilio-paste/icons/esm/ExportIcon';
+import {BoldIcon} from '@twilio-paste/icons/esm/BoldIcon';
+import {CheckboxCheckIcon} from '@twilio-paste/icons/esm/CheckboxCheckIcon';
+import {ItalicIcon} from '@twilio-paste/icons/esm/ItalicIcon';
+import {PlusIcon} from '@twilio-paste/icons/esm/PlusIcon';
+import {UnderlineIcon} from '@twilio-paste/icons/esm/UnderlineIcon';
+import {ChevronDownIcon} from '@twilio-paste/icons/esm/ChevronDownIcon';
+
+import {SidebarCategoryRoutes} from '../../../constants';
+import {
+  BasicExample,
+  UnattachedExample,
+  DisabledExample,
+  IconExample,
+  MenuExample,
+} from '../../../component-examples/ButtonGroupExamples';
+
+export const pageQuery = graphql`
+  {
+    allPasteComponent(filter: {name: {eq: "@twilio-paste/button-group"}}) {
+      edges {
+        node {
+          name
+          description
+          status
+          version
+        }
+      }
+    }
+    mdx(frontmatter: {slug: {eq: "/components/button-group/"}}) {
+      fileAbsolutePath
+      frontmatter {
+        slug
+        title
+      }
+      headings {
+        depth
+        value
+      }
+    }
+    allAirtable(filter: {data: {Feature: {eq: "Button Group"}}}) {
+      edges {
+        node {
+          data {
+            Documentation
+            Figma
+            Design_committee_review
+            Engineer_committee_review
+            Code
+            status
+          }
+        }
+      }
+    }
+  }
+`;
+
+<NormalizedComponentHeader
+  categoryRoute={SidebarCategoryRoutes.COMPONENTS}
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/button-group"
+  storybookUrl="/?path=/story/components-button-group--attached"
+  data={props.data}
+  description={props.pageContext.frontmatter.description}
+/>
+
+---
+
+<contentwrapper>
+
+<PageAside data={props.data.mdx} />
+
+<content>
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    PlusIcon,
+    ExportIcon,
+    DeleteIcon,
+    EditIcon,
+  }}
+  language="jsx"
+>
+  {BasicExample}
+</LivePreview>
+
+## Guidelines
+
+A Button Group is a way to bring a set of 2-6 buttons together, often visually, that have related actions. The buttons should be independent from each other, i.e. clicking one button does not change the state of another button.
+
+Any Paste components that use [Button](/components/button), including [Popover](/components/popover), [Modal](/components/modal), and [Minimizable Dialog](/components/minimizable-dialog) can be put into a ButtonGroup.
+
+### Button Group vs Radio Button Group
+
+Button groups should be used to help bring together a group of related actions, rather than selecting from a set of options. Use a Radio Button Group to allow the user to select a single option from a group of mutually exclusive choices. Radio Buttons cannot be used within a Button Group.
+
+## Examples
+
+### Default
+
+By default, the Buttons in a Button Group are displayed horizontally with a margin between them.
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    PlusIcon,
+    ExportIcon,
+    DeleteIcon,
+    EditIcon,
+  }}
+  language="jsx"
+>
+  {UnattachedExample}
+</LivePreview>
+
+### Attached
+
+Use the `attached` prop to make the buttons visually connected.
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    PlusIcon,
+    ExportIcon,
+    DeleteIcon,
+    EditIcon,
+  }}
+  language="jsx"
+>
+  {BasicExample}
+</LivePreview>
+
+### Icon
+
+Use the icon variant when space is limited and the icons being used are easily recognizable (e.g., icons representing graph types). It is highly recommended to pair this variant with the [Tooltip](/components/tooltip) component to help ensure understandability.
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    UnderlineIcon,
+    BoldIcon,
+    ItalicIcon,
+    Tooltip,
+  }}
+  language="jsx"
+>
+  {IconExample}
+</LivePreview>
+
+### With Menu
+
+Use a [Menu](/components/menu) to include more actions in the ButtonGroup, such as when there is limited space or there are more than 6 actions.
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    PlusIcon,
+    DeleteIcon,
+    EditIcon,
+    Menu,
+    useMenuState,
+    MenuButton,
+    ChevronDownIcon,
+    MenuItem,
+  }}
+  language="jsx"
+>
+  {MenuExample}
+</LivePreview>
+
+## States
+
+### Disabled
+
+<LivePreview
+  noInline
+  scope={{
+    ButtonGroup,
+    Button,
+    PlusIcon,
+    ExportIcon,
+    DeleteIcon,
+    EditIcon,
+  }}
+  language="jsx"
+>
+  {DisabledExample}
+</LivePreview>
+
+## Composition notes
+
+Button Groups:
+
+- Should have between 2–6 options
+- Are comprised of independent buttons
+- Labels should use sentence case
+
+## Implementation Guide
+
+### API
+
+#### Installation
+
+```bash
+yarn add @twilio-paste/button-group - or - yarn add @twilio-paste/core
+```
+
+#### Usage
+
+```jsx
+import {ButtonGroup} from '@twilio-paste/core/button-group';
+import {Button} from '@twilio-paste/core/button';
+
+const Component = () => (
+  <ButtonGroup attached>
+    <Button variant="primary">First button</Button>
+    <Button variant="secondary">Second button</Button>
+    <Button variant="destructive">Destructive button</Button>
+  </ButtonGroup>
+);
+```
+
+#### Props
+
+All the valid HTML attributes for `div` are supported including the following props:
+
+| Prop      | Type                   | Description                                                                               | Default        |
+| --------- | ---------------------- | ----------------------------------------------------------------------------------------- | -------------- |
+| children  | `React.ReactElement[]` | The Buttons rendered in the ButtonGroup                                                   |                |
+| attached? | `boolean`              | If the group of buttons are visually attached                                             | `false`        |
+| element?  | `string`               | Overrides the default element name to apply unique styles with the Customization Provider | 'BUTTON_GROUP' |
+
+<ChangelogRevealer>
+  <Changelog />
+</ChangelogRevealer>
+
+</content>
+
+</contentwrapper>


### PR DESCRIPTION
Adds a documentation page for the ButtonGroup component.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
