### PR TITLE
feat(file-picker): add onChange and name props

### DIFF
--- a/.changeset/nice-laws-divide.md
+++ b/.changeset/nice-laws-divide.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/file-picker': minor
+'@twilio-paste/core': minor
+---
+
+[File picker] add `onChange` and `name` props

--- a/packages/paste-core/components/file-picker/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/file-picker/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {Default, Disabled, Required, Customized} from '../stories/index.stories';
 
 describe('FilePicker', () => {
@@ -20,6 +20,20 @@ describe('FilePicker', () => {
     render(<Default data-testid="test-file-picker" />);
     const textId = screen.getByText('No file uploaded').getAttribute('id');
     expect(screen.getByTestId('test-file-picker')).toHaveAttribute('aria-describedby', textId);
+  });
+  it('should run the passed onChange function', () => {
+    const MockOnChange = jest.fn();
+    render(<Default onChange={MockOnChange} data-testid="test-file-picker" />);
+    fireEvent.change(screen.getByTestId('test-file-picker'), {
+      target: {
+        files: [new File([], 'file.png', {type: 'image/png'})],
+      },
+    });
+    expect(MockOnChange).toHaveBeenCalledTimes(1);
+  });
+  it('should correctly pass the name prop', () => {
+    render(<Default name="imAFilePicker" data-testid="test-file-picker" />);
+    expect(screen.getByTestId('test-file-picker').getAttribute('name')).toEqual('imAFilePicker');
   });
 });
 

--- a/packages/paste-core/components/file-picker/src/FilePicker.tsx
+++ b/packages/paste-core/components/file-picker/src/FilePicker.tsx
@@ -12,6 +12,8 @@ export interface FilePickerProps extends React.HTMLAttributes<HTMLInputElement>,
   disabled?: boolean;
   i18nNoSelectionText?: string;
   required?: boolean;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  name?: string;
 }
 
 const FilePicker = React.forwardRef<HTMLInputElement, FilePickerProps>(
@@ -24,6 +26,7 @@ const FilePicker = React.forwardRef<HTMLInputElement, FilePickerProps>(
       disabled = false,
       i18nNoSelectionText = 'No file uploaded',
       required = false,
+      onChange,
       ...props
     },
     ref
@@ -33,8 +36,13 @@ const FilePicker = React.forwardRef<HTMLInputElement, FilePickerProps>(
     const textId = useUID();
 
     const handleChange = (evt: any): void => {
-      const file = evt.target.files[0].name;
-      setFileDescription(file);
+      if (onChange) onChange(evt);
+      if (evt.currentTarget.files && evt.currentTarget.files.length > 0) {
+        const file = evt.currentTarget.files[0].name;
+        setFileDescription(file);
+      } else {
+        setFileDescription(i18nNoSelectionText);
+      }
     };
 
     return (
@@ -105,6 +113,8 @@ FilePicker.propTypes = {
   disabled: PropTypes.bool,
   i18nNoSelectionText: PropTypes.string,
   required: PropTypes.bool,
+  onChange: PropTypes.func,
+  name: PropTypes.string,
 };
 
 export {FilePicker};

--- a/packages/paste-core/components/file-picker/stories/index.stories.tsx
+++ b/packages/paste-core/components/file-picker/stories/index.stories.tsx
@@ -68,15 +68,34 @@ export const I18n: Story = () => {
   );
 };
 
-export const containedWidth: Story = () => {
+export const ContainedWidth: Story = () => {
   const id = useUID();
   return (
     <Box width="size40">
       <Label htmlFor={id}>Profile picture</Label>
       <FilePicker id={id}>
-        <FilePickerButton variant="secondary">Upload a file</FilePickerButton>
+        <FilePickerButton variant="secondary">Upload a file with a long name</FilePickerButton>
       </FilePicker>
     </Box>
+  );
+};
+
+export const OnChange: Story = () => {
+  const id = useUID();
+  const [uploadedFileName, setUploadedFileName] = React.useState('upload a file to see the onChange run');
+  return (
+    <>
+      <Label htmlFor={id}>Profile picture</Label>
+      <FilePicker
+        id={id}
+        onChange={(evt) => {
+          if (evt.currentTarget.files) setUploadedFileName(evt.currentTarget.files[0].name);
+        }}
+      >
+        <FilePickerButton variant="secondary">Upload a file</FilePickerButton>
+      </FilePicker>
+      {uploadedFileName}
+    </>
   );
 };
 

--- a/packages/paste-website/src/component-examples/FilePickerExamples.ts
+++ b/packages/paste-website/src/component-examples/FilePickerExamples.ts
@@ -2,10 +2,11 @@ export const defaultFilePicker = `
 const FilePickerExample = () => {
   const id = useUID();
   const helpText = useUID();
+  const [files, setFiles] = React.useState([])
   return (
     <>
     <Label htmlFor={id}>Profile picture</Label>
-    <FilePicker id={id} accept="image/*" aria-describedby={helpText}>
+    <FilePicker id={id} accept="image/*" aria-describedby={helpText} onChange={(evt)=>{setFiles(evt.currentTarget.files)}}>
       <FilePickerButton variant="secondary">Upload a file</FilePickerButton>
     </FilePicker>
     <HelpText id={helpText}>Please upload an image</HelpText>
@@ -21,10 +22,11 @@ render(
 export const disabledFilePicker = `
 const FilePickerExample = () => {
   const id = useUID();
+  const [files, setFiles] = React.useState([])
   return (
     <>
     <Label disabled htmlFor={id}>Receipt to expense</Label>
-    <FilePicker id={id} accept=".pdf" disabled>
+    <FilePicker id={id} accept=".pdf" disabled onChange={(evt)=>{setFiles(evt.currentTarget.files)}}>
       <FilePickerButton variant="secondary">Upload a file</FilePickerButton>
     </FilePicker>
   </>
@@ -40,10 +42,11 @@ export const requiredFilePicker = `
 const FilePickerExample = () => {
   const id = useUID();
   const helpText = useUID();
+  const [files, setFiles] = React.useState([])
   return (
     <>
     <Label htmlFor={id} required>Proof of employment</Label>
-    <FilePicker id={id} aria-describedby={helpText} required>
+    <FilePicker id={id} aria-describedby={helpText} required onChange={(evt)=>{setFiles(evt.currentTarget.files)}}>
       <FilePickerButton variant="secondary">Upload a file</FilePickerButton>
     </FilePicker>
     <HelpText id={helpText}>Acceptable formats include W2, I9, or latest pay stub.</HelpText>

--- a/packages/paste-website/src/pages/components/file-picker/index.mdx
+++ b/packages/paste-website/src/pages/components/file-picker/index.mdx
@@ -21,6 +21,7 @@ import {
   disabledFilePicker,
   requiredFilePicker,
   i18nFilePicker,
+  onChangeFilePicker,
 } from '../../../component-examples/FilePickerExamples.ts';
 import Changelog from '@twilio-paste/file-picker/CHANGELOG.md';
 
@@ -249,6 +250,8 @@ All the valid attributes for `Button` are supported including the following prop
 | required?            | <inlineCode>boolean</inlineCode>            | Sets the File Picker as required.                                                                                                                                                                                                                                         | false              |
 | i18nNoSelectionText? | <inlineCode>string</inlineCode>             | The text string displayed when no files are selected.                                                                                                                                                                                                                     | 'No file uploaded' |
 | element?             | <inlineCode>string</inlineCode>             | Overrides the default element name to apply unique styles with the Customization Provider.                                                                                                                                                                                | 'FILEPICKER'       |
+| onChange?            | `(event: React.MouseEvent<HTMLElement>)`    | Function will run when the uploaded file changes                                                                                                                                                                                                                          | null               |
+| name?                | <inlineCode>string</inlineCode>             |                                                                                                                                                                                                                                                                           | null               |
 
 <ChangelogRevealer>
   <Changelog />


### PR DESCRIPTION
Fixes a couple bugs in the File Picker package. It was missing the `name` prop (which is important for form elements and someone asked about it for using the file picker with react-forms) and the `onChange` prop wasn't being passed down to the input element.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
