### PR TITLE
fix(theme): add missing Partial around iconSizes bucket

### DIFF
--- a/.changeset/gold-avocados-relax.md
+++ b/.changeset/gold-avocados-relax.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/theme': patch
+'@twilio-paste/core': patch
+---
+
+[Theme] Fix type for the `iconSizes` token bucket under the theme object

--- a/packages/paste-theme/src/types/GenericThemeShape.ts
+++ b/packages/paste-theme/src/types/GenericThemeShape.ts
@@ -77,7 +77,7 @@ export interface GenericThemeShape {
       [key in SizingKeys]: any;
     }
   >;
-  iconSizes: {
+  iconSizes: Partial<{
     sizeIcon05: typeof sizings['sizeIcon05'];
     sizeIcon10: typeof sizings['sizeIcon10'];
     sizeIcon20: typeof sizings['sizeIcon20'];
@@ -90,7 +90,7 @@ export interface GenericThemeShape {
     sizeIcon90: typeof sizings['sizeIcon90'];
     sizeIcon100: typeof sizings['sizeIcon100'];
     sizeIcon110: typeof sizings['sizeIcon110'];
-  };
+  }>;
   lineHeights: Partial<
     {
       [key in LineHeightsKeys]: any;


### PR DESCRIPTION
Add missing `Partial<>` around iconSizes in theme typings