### PR TITLE
fix(ButtonGroup): customization tests 

### DIFF
--- a/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
+import type {RenderOptions} from '@testing-library/react';
+import {Theme} from '@twilio-paste/theme';
 
 import {AlertDialogWithTwoActions, DestructiveAlertDialog} from '../stories/index.stories';
+
+const ThemeWrapper: RenderOptions['wrapper'] = ({children}) => (
+  <Theme.Provider theme="default">{children}</Theme.Provider>
+);
 
 describe('Alert Dialog', () => {
   it('Should render an alert dialog box', () => {
@@ -18,8 +24,9 @@ describe('Alert Dialog', () => {
   });
 
   it('Should have a destructive button style when the destructive prop is included', () => {
-    render(<DestructiveAlertDialog />);
-    expect(screen.getByText('Delete')).toHaveStyle('background-color: color-background-destructive');
+    render(<DestructiveAlertDialog />, {wrapper: ThemeWrapper});
+    const button = screen.getByRole('button', {name: 'Delete'});
+    expect(button).toHaveStyleRule('background-color', 'rgb(214, 31, 31)');
   });
 
   it('Should have a heading the same as the heading prop', () => {

--- a/packages/paste-core/components/button-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/button-group/__tests__/index.spec.tsx
@@ -4,7 +4,7 @@ import {Button} from '@twilio-paste/button';
 import {CustomizationProvider} from '@twilio-paste/customization';
 
 import {ButtonGroup} from '../src';
-import {Attached, Unattached} from '../stories/index.stories';
+import {Unattached} from '../stories/index.stories';
 
 describe('ButtonGroup', () => {
   it('should render a group visibly into document', () => {
@@ -20,18 +20,6 @@ describe('ButtonGroup', () => {
     for (const btn of btns) {
       expect(btn).toBeVisible();
     }
-  });
-
-  it('should accept attached prop and apply styles', () => {
-    render(<Attached />);
-    const middleBtn = screen.getAllByRole('button')[1];
-    expect(middleBtn).toHaveStyle({borderRadius: 0});
-  });
-
-  it('should default to unattached and apply styles', () => {
-    render(<Unattached />);
-    const middleBtn = screen.getAllByRole('button')[1];
-    expect(middleBtn).not.toHaveStyle({borderRadius: 0});
   });
 
   it('should forward safe box props to root group role node', () => {

--- a/packages/paste-core/components/button-group/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/button-group/__tests__/index.spec.tsx
@@ -72,7 +72,7 @@ describe('ButtonGroup customization', () => {
     );
 
     const btnGroup = screen.getByRole('group');
-    expect(btnGroup).toHaveStyle({backgroundColor: 'rgb(20, 176, 83'});
+    expect(btnGroup).toHaveStyleRule('background-color', 'rgb(20, 176, 83)');
   });
 
   it('should add custom styling to a custom element for ButtonGroup', () => {
@@ -88,6 +88,6 @@ describe('ButtonGroup customization', () => {
     );
 
     const btnGroup = screen.getByRole('group');
-    expect(btnGroup).toHaveStyle({backgroundColor: 'rgb(20, 176, 83'});
+    expect(btnGroup).toHaveStyleRule('background-color', 'rgb(20, 176, 83)');
   });
 });

--- a/packages/paste-core/components/combobox/__tests__/GrowingInput.spec.tsx
+++ b/packages/paste-core/components/combobox/__tests__/GrowingInput.spec.tsx
@@ -16,7 +16,7 @@ describe('GrowingInput component', () => {
     );
     const input = screen.getByRole('textbox');
 
-    expect(input).toHaveStyle('width: 100%');
+    expect(input).toHaveStyleRule('width', '100%');
     expect(input.getAttribute('id')).toEqual(TEST_ID);
   });
 });

--- a/packages/paste-core/components/file-picker/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/file-picker/__tests__/index.spec.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
+import type {RenderOptions} from '@testing-library/react';
+import {Theme} from '@twilio-paste/theme';
 
 import {Default, Disabled, Required, Customized} from '../stories/index.stories';
+
+const ThemeWrapper: RenderOptions['wrapper'] = ({children}) => (
+  <Theme.Provider theme="default">{children}</Theme.Provider>
+);
 
 describe('FilePicker', () => {
   it('should render', () => {
@@ -52,27 +58,33 @@ describe('FilePicker customization', () => {
     expect(container.querySelector('[data-paste-element="MY_FILEPICKER_TEXT"]')).toBeInTheDocument();
   });
   it('should add custom styling to File Picker', () => {
-    const {container} = render(<Customized />);
-    expect(container.querySelector('[data-paste-element="FILEPICKER"]')).toHaveStyle(
-      "font-family: 'Fira Mono',Courier,monospace"
+    const {container} = render(<Customized />, {wrapper: ThemeWrapper});
+    expect(container.querySelector('[data-paste-element="FILEPICKER"]')).toHaveStyleRule(
+      'font-family',
+      "'Fira Mono',Courier,monospace"
     );
-    expect(container.querySelector('[data-paste-element="FILEPICKER_BUTTON"]')).toHaveStyle(
-      'background-color: rgba(242, 47, 70, 0.1)'
+    expect(container.querySelector('[data-paste-element="FILEPICKER_BUTTON"]')).toHaveStyleRule(
+      'background-color',
+      'rgba(242, 47, 70, 0.1)'
     );
-    expect(container.querySelector('[data-paste-element="FILEPICKER_TEXT"]')).toHaveStyle(
-      'margin: 0px 0.75rem 0px 0.125rem'
+    expect(container.querySelector('[data-paste-element="FILEPICKER_TEXT"]')).toHaveStyleRule(
+      'margin-left',
+      '0.125rem'
     );
   });
   it('should add custom styling to a custom named File Picker', () => {
     const {container} = render(<Customized element="MY_FILEPICKER" />);
-    expect(container.querySelector('[data-paste-element="MY_FILEPICKER"]')).toHaveStyle(
-      "font-family: 'Fira Mono',Courier,monospace"
+    expect(container.querySelector('[data-paste-element="MY_FILEPICKER"]')).toHaveStyleRule(
+      'font-family',
+      "'Fira Mono',Courier,monospace"
     );
-    expect(container.querySelector('[data-paste-element="MY_FILEPICKER_BUTTON"]')).toHaveStyle(
-      'background-color: rgba(242, 47, 70, 0.1)'
+    expect(container.querySelector('[data-paste-element="MY_FILEPICKER_BUTTON"]')).toHaveStyleRule(
+      'background-color',
+      'rgba(242, 47, 70, 0.1)'
     );
-    expect(container.querySelector('[data-paste-element="MY_FILEPICKER_TEXT"]')).toHaveStyle(
-      'margin: 0px 0.75rem 0px 0.125rem'
+    expect(container.querySelector('[data-paste-element="MY_FILEPICKER_TEXT"]')).toHaveStyleRule(
+      'margin-left',
+      '0.125rem'
     );
   });
 });

--- a/packages/paste-website/src/__tests__/tokenCard.test.tsx
+++ b/packages/paste-website/src/__tests__/tokenCard.test.tsx
@@ -108,7 +108,7 @@ describe('TokenCard', () => {
     );
 
     const previewDiv = screen.getByTestId('alertInverse').querySelector('[data-paste-element=TOKEN_EXAMPLE]');
-    expect(previewDiv).toHaveStyle(`background-color: ${testExampleBackgroundInverse}`);
+    expect(previewDiv).toHaveStyleRule('background-color', testExampleBackgroundInverse);
   });
 
   it('should render inverse text color for the color accessibility description on an inverse text color', () => {
@@ -128,7 +128,7 @@ describe('TokenCard', () => {
       </Theme.Provider>
     );
 
-    expect(screen.getByText('AAA')).toHaveStyle(`color: ${testExampleTextColorInverse}`);
+    expect(screen.getByText('AAA')).toHaveStyleRule('color', testExampleTextColorInverse);
   });
 
   it('should render the proper highlight color for a token example (line height)', () => {
@@ -151,6 +151,6 @@ describe('TokenCard', () => {
     );
 
     const testElement = screen.getByTestId('highlightToken').querySelector('[data-paste-element=TOKEN_EXAMPLE] > div');
-    expect(testElement).toHaveStyle(`background-color: ${testExampleHighlightColor}`);
+    expect(testElement).toHaveStyleRule('background-color', testExampleHighlightColor);
   });
 });

--- a/packages/paste-website/src/__tests__/tokenCard.test.tsx
+++ b/packages/paste-website/src/__tests__/tokenCard.test.tsx
@@ -108,6 +108,7 @@ describe('TokenCard', () => {
     );
 
     const previewDiv = screen.getByTestId('alertInverse').querySelector('[data-paste-element=TOKEN_EXAMPLE]');
+    // @ts-expect-error toHaveStyleRule definitely exists
     expect(previewDiv).toHaveStyleRule('background-color', testExampleBackgroundInverse);
   });
 
@@ -127,7 +128,7 @@ describe('TokenCard', () => {
         />
       </Theme.Provider>
     );
-
+    // @ts-expect-error toHaveStyleRule definitely exists
     expect(screen.getByText('AAA')).toHaveStyleRule('color', testExampleTextColorInverse);
   });
 
@@ -151,6 +152,7 @@ describe('TokenCard', () => {
     );
 
     const testElement = screen.getByTestId('highlightToken').querySelector('[data-paste-element=TOKEN_EXAMPLE] > div');
+    // @ts-expect-error toHaveStyleRule definitely exists
     expect(testElement).toHaveStyleRule('background-color', testExampleHighlightColor);
   });
 });


### PR DESCRIPTION
Currently, the customization tests use `toHaveStyle` instead of `toHaveStyleRule`. If you change the value, `toHaveStyle` always passes - only `toHaveStyleRule` actually works for our components. For example, there was currently a typo in the `toHaveStyle` rule and the test still passed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
