### PR TITLE
fix: combobox types

### DIFF
--- a/.changeset/stale-tools-admire.md
+++ b/.changeset/stale-tools-admire.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/combobox': patch
+'@twilio-paste/core': patch
+---
+
+[Combobox] remove inherited HTML `autoComplete` prop because it conflicts with the autocomplete prop and remove state prop from Multiselect Combobox because we don't support using it with the useComboboxState hook.

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -39,7 +39,9 @@ export type HighlightedIndexChanges = {
   inputValue: string;
 };
 
-export interface ComboboxProps extends Omit<InputProps, 'id' | 'type' | 'value'>, Pick<BoxProps, 'element'> {
+export interface ComboboxProps
+  extends Omit<InputProps, 'id' | 'type' | 'value' | 'autoComplete'>,
+    Pick<BoxProps, 'element'> {
   autocomplete?: boolean;
   helpText?: string | React.ReactNode;
   labelText: string | NonNullable<React.ReactNode>;
@@ -89,6 +91,7 @@ export interface MultiselectComboboxProps
     | 'onSelectedItemChange'
     | 'getA11yStatusMessage'
     | 'getA11ySelectionMessage'
+    | 'state'
   > {
   initialSelectedItems?: any[];
   onSelectedItemsChange?: (newSelectedItems: any[]) => void;


### PR DESCRIPTION
This is a quick fix for type issues found in github discussions:
* https://github.com/twilio-labs/paste/discussions/2781
* https://github.com/twilio-labs/paste/discussions/2768

## Changes in this PR:
**Combobox**
Omits the default HMTL `autoComplete` prop from the types because it conflicts with the `autocomplete` prop that actually changes how the Combobox behaves.

**Multiselect Combobox**
Omits the `state` prop because we don't support using the `useComboboxState` hook with the multiselect combobox

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
