### PR TITLE
fix: syntax highlighting colors in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -75,7 +75,7 @@ module.exports = {
     config.resolve.alias = config.resolve.alias == null ? customAlias : {...config.resolve.alias, ...customAlias};
 
     // FIX: Tell Storybook to look at dev files if available
-    config.resolve.mainFields = ['main:dev', 'browser', 'module', 'main'];
+    config.resolve.mainFields = ['browser', 'main:dev', 'main', 'module'];
 
     return config;
   },

--- a/packages/paste-nextjs-template/sandbox.config.json
+++ b/packages/paste-nextjs-template/sandbox.config.json
@@ -1,0 +1,8 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "container": {
+    "node": "12"
+  }
+}


### PR DESCRIPTION
Since paste packages don't have a `browser` field in their `package.json` files, but some of our dependencies do, I moved `main:dev` to after the `browser` resolution and things magically worked. Kinda got lucky here, but I'll take it.