### PR TITLE
fix(ChatComposer): fix Lexical global styles

### DIFF
--- a/.changeset/chilly-lizards-dress.md
+++ b/.changeset/chilly-lizards-dress.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/core': patch
+'@twilio-paste/chat-composer': patch
+---
+
+[ChatComposer]: fix Lexical global styles

--- a/packages/paste-core/components/chat-composer/src/ChatComposer.tsx
+++ b/packages/paste-core/components/chat-composer/src/ChatComposer.tsx
@@ -28,9 +28,10 @@ import {
    */
   HistoryPlugin,
 } from '@twilio-paste/lexical-library';
+import {StylingGlobals} from '@twilio-paste/styling-library';
 import type {LexicalComposerProps, OnChangeFunction, ContentEditableProps} from '@twilio-paste/lexical-library';
 
-import './styles.css';
+import {chatComposerLexicalStyles} from './styles';
 import {AutoLinkPlugin} from './AutoLinkPlugin';
 import {PlaceholderWrapper} from './PlaceholderWrapper';
 import {baseConfig, renderInitialText} from './helpers';
@@ -97,6 +98,7 @@ export const ChatComposer = React.forwardRef<HTMLDivElement, ChatComposerProps>(
         overflowY="scroll"
         maxHeight={maxHeight}
       >
+        <StylingGlobals styles={chatComposerLexicalStyles} />
         <LexicalComposer initialConfig={merge(baseConfigWithEditorState, config)}>
           <>
             <RichTextPlugin

--- a/packages/paste-core/components/chat-composer/src/styles.ts
+++ b/packages/paste-core/components/chat-composer/src/styles.ts
@@ -1,3 +1,6 @@
+import {EmotionCSS} from '@twilio-paste/styling-library';
+
+export const chatComposerLexicalStyles = EmotionCSS`
 .paste-chat-composer-paragraph {
   margin: 0;
   position: relative;
@@ -6,3 +9,4 @@
 .paste-chat-composer-content-editable:focus {
   outline: none;
 }
+`;


### PR DESCRIPTION
This PR fixes the global styles required by Lexical for our `ChatComposer` component. See this [PR comment for a demonstration of the issue](https://github.com/twilio-labs/paste/pull/2852#discussion_r1036270046)

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
