### PR TITLE
ci: pin node version for codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "build",
-  "node": "16.13.0",
   "packages": [
     "/packages/paste-icons",
     "/packages/paste-core/core-bundle",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "build",
-  "node": "16",
+  "node": "16.13.0",
   "packages": [
     "/packages/paste-icons",
     "/packages/paste-core/core-bundle",


### PR DESCRIPTION
Pin the node version to match our `nvmrc` as codesandbox builds were failing when using `16.18.0`.