### PR TITLE
build: add no-invalid-module-paths eslint rule

### DIFF
--- a/.changeset/large-apples-reply.md
+++ b/.changeset/large-apples-reply.md
@@ -1,0 +1,7 @@
+---
+'@twilio-paste/callout': patch
+'@twilio-paste/menu': patch
+'@twilio-paste/core': patch
+---
+
+Add eslint escape for type level import using src in path

--- a/.eslint/__tests__/no-invalid-module-paths.test.js
+++ b/.eslint/__tests__/no-invalid-module-paths.test.js
@@ -1,0 +1,73 @@
+import rule from '../rules/no-invalid-module-paths';
+import {RuleTester} from 'eslint';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+const {src} = rule.meta.messages;
+
+ruleTester.run('no-invalid-module-paths', rule, {
+  valid: [
+    // @twilio-paste *value* level module paths that *do not* contain src
+    {code: 'import {ButtonToggleStyles} from "@twilio-paste/button"'},
+    {code: 'import ButtonToggleStyles from "@twilio-paste/button"'},
+    {code: 'export {ButtonToggleStyles} from "@twilio-paste/button"'},
+    {code: 'export * from "@twilio-paste/button"'},
+    {code: 'import("@twilio-paste/button")'},
+    {code: 'const { ButtonToggleStyles } = require("@twilio-paste/button")'},
+
+    // *non* @twilio-paste *value* level module paths that *do* contain src
+    {code: 'import {FooBarStyles} from "@foo/bar/src/styles"'},
+    {code: 'import FooBarStyles from "@foo/bar/src/styles"'},
+    {code: 'export {FooBarStyles} from "@foo/bar/src/styles"'},
+    {code: 'export * from "@foo/bar/src/styles"'},
+    {code: 'import("@foo/bar/src/styles")'},
+    {code: 'const { FooBarStyles } = require("@foo/bar/src/styles")'},
+
+    // @twilio-paste *type* level module paths that *do not* contain src
+    {code: 'import type {ButtonToggleStyleTypes} from "@twilio-paste/button"'},
+    {code: 'export type {ButtonToggleStyleTypes} from "@twilio-paste/button"'},
+
+    // *non* @twilio-paste *type* level module paths that *do* contain src
+    {code: 'import type {FooBarStyles} from "@foo/bar/src/styles"'},
+    {code: 'export type {FooBarStyles} from "@foo/bar/src/styles"'},
+  ],
+
+  invalid: [
+    // @twilio-paste *value* level module paths that *do* contain src
+    {
+      code: 'import {ButtonToggleStyles} from "@twilio-paste/button/src/styles"',
+      errors: [{message: src}],
+    },
+    {
+      code: 'import ButtonToggleStyles from "@twilio-paste/button/src/styles"',
+      errors: [{message: src}],
+    },
+    {
+      code: 'export {ButtonToggleStyles} from "@twilio-paste/button/src/styles"',
+      errors: [{message: src}],
+    },
+    {
+      code: 'export * from "@twilio-paste/button/src/styles"',
+      errors: [{message: src}],
+    },
+    {
+      code: 'import("@twilio-paste/button/src/styles")',
+      errors: [{message: src}],
+    },
+    {
+      code: 'const { ButtonToggleStyles } = require("@twilio-paste/button/src/styles")',
+      errors: [{message: src}],
+    },
+
+    // @twilio-paste *type* level module paths that *do* contain src
+    {
+      code: 'import type {ButtonToggleStyleTypes} from "@twilio-paste/button/src/types"',
+      errors: [{message: src}],
+    },
+    {
+      code: 'export type {ButtonToggleStyleTypes} from "@twilio-paste/button/src/types"',
+      errors: [{message: src}],
+    },
+  ],
+});

--- a/.eslint/rules/no-invalid-module-paths.js
+++ b/.eslint/rules/no-invalid-module-paths.js
@@ -1,0 +1,53 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid invalid package module paths',
+      category: 'Possible Problems',
+    },
+    fixable: null,
+    schema: [], // no options
+    messages: {
+      src: 'Invalid module path using "src" path. Use a bare module specifier instead.',
+    },
+  },
+
+  create(context) {
+    const checkModulePath = (path, node) => {
+      if (path.startsWith('@twilio-paste') && path.includes('src')) {
+        context.report({messageId: 'src', node});
+      }
+    };
+
+    return createVisitors(checkModulePath);
+  },
+};
+
+const createVisitors = (checkModulePath) => {
+  const checkSource = (source, node) => {
+    if (source?.type !== 'Literal') return;
+    if (typeof source?.value !== 'string') return;
+    checkModulePath(source.value, node);
+  };
+
+  const visitDeclaration = (node) => {
+    checkSource(node.source, node);
+  };
+
+  const visitExpression = (node) => {
+    const isImportCall = node.type === 'ImportExpression';
+    if (isImportCall) return checkSource(node.source, node);
+
+    const isRequireCall =
+      node.type === 'CallExpression' && node.callee.name === 'require' && node.arguments.length === 1;
+    if (isRequireCall) return checkSource(node.arguments[0], node);
+  };
+
+  return {
+    ImportDeclaration: visitDeclaration,
+    ExportNamedDeclaration: visitDeclaration,
+    ExportAllDeclaration: visitDeclaration,
+    CallExpression: visitExpression,
+    ImportExpression: visitExpression,
+  };
+};

--- a/packages/paste-core/components/callout/src/Callout.tsx
+++ b/packages/paste-core/components/callout/src/Callout.tsx
@@ -8,7 +8,7 @@ import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import {SuccessIcon} from '@twilio-paste/icons/esm/SuccessIcon';
 import {WarningIcon} from '@twilio-paste/icons/esm/WarningIcon';
 import type {BoxStyleProps, BoxProps} from '@twilio-paste/box';
-import type {GenericIconProps} from '@twilio-paste/icons/src/types';
+import type {GenericIconProps} from '@twilio-paste/icons/esm/types';
 import {isMarginTokenProp} from '@twilio-paste/style-props';
 
 type CalloutVariants = 'neutral' | 'warning' | 'error' | 'success' | 'new';

--- a/packages/paste-core/components/menu/src/MenuGroup.tsx
+++ b/packages/paste-core/components/menu/src/MenuGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {safelySpreadBoxProps, Box} from '@twilio-paste/box';
-import type {GenericIconProps} from '@twilio-paste/icons/src/types';
+import type {GenericIconProps} from '@twilio-paste/icons/esm/types';
 import {Text} from '@twilio-paste/text';
 
 import {MenuItemVariants} from './constants';

--- a/packages/paste-website/src/components/shortcodes/package-status-legend/index.tsx
+++ b/packages/paste-website/src/components/shortcodes/package-status-legend/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {Box} from '@twilio-paste/box';
 import {Badge} from '@twilio-paste/badge';
-import type {BadgeVariants} from '@twilio-paste/badge/src/types';
+import type {BadgeProps} from '@twilio-paste/badge';
 import {PopoverContainer, PopoverBadgeButton, Popover} from '@twilio-paste/popover';
 import {useUID} from '@twilio-paste/uid-library';
 import {NewIcon} from '@twilio-paste/icons/esm/NewIcon';
@@ -9,6 +9,7 @@ import {ProcessDraftIcon} from '@twilio-paste/icons/esm/ProcessDraftIcon';
 
 import {StatusDescriptions} from '../../../constants';
 
+type BadgeVariants = BadgeProps['variant'];
 interface PackageStatusLegendProps {
   packageStatus?: string | null;
   figmaStatus?: string | null;


### PR DESCRIPTION
This PR introduces a new eslint rule to prevent invalid module paths within import/export/require statements for `@twilio-paste` packages.