### PR TITLE
build: add build targets to @twilio-paste/icons

### DIFF
--- a/.changeset/cold-nails-wonder.md
+++ b/.changeset/cold-nails-wonder.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/icons': patch
+---
+
+Remove logical assignment support

--- a/packages/paste-icons/build.js
+++ b/packages/paste-icons/build.js
@@ -8,6 +8,7 @@ const config = {
   entryPoints: [...buildIconList, ...EXTRA_ENTRY_POINTS],
   bundle: false,
   minify: process.env.NODE_ENV === 'production',
+  target: ['chrome66', 'firefox58', 'safari11', 'edge79', 'node12.19.0'],
   define: {
     'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`,
   },


### PR DESCRIPTION
This PR adds build targets for `@twilio-paste/icons` to avoid logical assignment syntax