### PR TITLE
chore: use plugin-react-swc for faster Storybook dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@types/webpack-env": "^1.13.9",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
+    "@vitejs/plugin-react-swc": "^3.0.1",
     "axe-playwright": "^1.1.11",
     "babel-loader": "^9.1.0",
     "babel-plugin-macros": "^3.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     ".danger/**/*",
     "./.jest/@types/index.d.ts",
     "tools/**/*",
-    "cypress.config.ts"
+    "cypress.config.ts",
+    "vite.config.ts"
   ],
   "exclude": [
     "node_modules",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react({jsxImportSource: '@emotion/react'})],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11478,10 +11478,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-darwin-arm64@npm:1.3.24"
+  checksum: 615ab95cd4999d49ca10262a06f9123f5ad305ef11b38c533a9b5efa910b94986e8fc85b0cefb1dfda6fd31a05514b7f2528c96956b91c0485c3ae085cf777f5
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-x64@npm:1.2.160":
   version: 1.2.160
   resolution: "@swc/core-darwin-x64@npm:1.2.160"
   checksum: f5b69ddd0055cf70fb7f56e056c0e6b37ddc7fae261dc572bfa0747edc49498b4f3b82f46bbc791b6988760690fa4588335de8e94817d5fcf64eec29c867c926
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-darwin-x64@npm:1.3.24"
+  checksum: 86d34d8b2847de487993902c8ecae6cb89fd7a4bf291e21b1e6f76773787fc3b910b3d703273b63715f133a5f7f642fc091ba38942c04efd6631e2c9b6d73709
   languageName: node
   linkType: hard
 
@@ -11499,10 +11513,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.24"
+  checksum: fef69d9f618f6abbdac3b541d051bebbb99f5f455df2a40e89d184a0e0e9689a4239fd0ed3c543d9aa0cb3e103e44c9dec3e05296d3dcb27141a58cacde39d03
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-gnu@npm:1.2.160":
   version: 1.2.160
   resolution: "@swc/core-linux-arm64-gnu@npm:1.2.160"
   checksum: 6d259d9dbef61128b661f31c33b073d3262923b240d91feca77b8d3662eee8e80dc55ff0696a1a5b5210fbd221ef885e55db0c0a699d2d37317a5b64392120ad
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.24"
+  checksum: 598bd40b94aa00907519c402224640266ba103d56b26eded9cb668a350c5a4ed484ca1067fdf0890e63481f0647da528ea1bc7d986f7886edff68807784d18f2
   languageName: node
   linkType: hard
 
@@ -11513,10 +11541,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.24"
+  checksum: 4a52b5e63626061ea062618aac3adee997583dc6635dbb8f085fe9d0cfaa6e32b8ca500ee4db1634c5fd6d68ba50a3b90c1b29d0cbe40c732f3c1df38137e579
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-gnu@npm:1.2.160":
   version: 1.2.160
   resolution: "@swc/core-linux-x64-gnu@npm:1.2.160"
   checksum: fe07acd873179399475f8fe3211a326cf81482805f8a79dec7d6c734a0507b5dc0674cd23a9da5365c99ca8bc92f016d81de82e542082e988a0db6f16eed75a3
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.24"
+  checksum: 7695c48ffd75bf946c1510ec40e128b4b47aa182313ac9a18c31ff5822c1f8fa1d38d161c32e944af55fe93f82393300dd360f7dfdce7e737821941ac325d9b9
   languageName: node
   linkType: hard
 
@@ -11527,10 +11569,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.24"
+  checksum: 03741a40d91158b94ae4796f2e98efcaefa361bef118621fd58639398409b37cd5171ef91a663a826335eea08478166cffc84783a71d39d156c35833d6fe053b
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-arm64-msvc@npm:1.2.160":
   version: 1.2.160
   resolution: "@swc/core-win32-arm64-msvc@npm:1.2.160"
   checksum: 79384896ad14ca9080d70efa7178defaaf18e644a4a1c20880aafbc45972609e4f0c10b3a3197f457a0710b0d8e695c6de9029f13f347becd194aa27d7f40bd1
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.24"
+  checksum: 76f083392776518a234ecd46d74afdc80fed222414cf947f98fc29866b8327599f6f808f5bf763a7c1922885ea2d81cca351aa7ae0f53ed1749baf6068fb4802
   languageName: node
   linkType: hard
 
@@ -11541,10 +11597,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.24"
+  checksum: 7e08d70e74d72aa79193a300521c7cc7eb61fee6eb0d1826a3afda7fcea9c3f5b3556cba1aea94f3e82fab70b055fdb619193053f33078035b69faf0ed6ea153
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-x64-msvc@npm:1.2.160":
   version: 1.2.160
   resolution: "@swc/core-win32-x64-msvc@npm:1.2.160"
   checksum: 7ff9dc988a0af6d0448729633edaf74b0eabb9e8a38c55834ac50c8f33817b7abf8ac98f30049c9f31a958d7ea874318caf3e99f8f0f3130cb5d76ddf038f86c
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.3.24":
+  version: 1.3.24
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.24"
+  checksum: c624dc3ad2eaddd22ffad8db9404aa937d7c81c0f2a9a00b84b398a3dfc57042d8006d6a9c391a75a04394c17b88e11d64c52a4dce9b21518be5d2119d7cdc8a
   languageName: node
   linkType: hard
 
@@ -11595,6 +11665,47 @@ __metadata:
   bin:
     swcx: run_swcx.js
   checksum: 2926a1b6a2f059a682331f318edf1086a47684a09f77bd75516d7df7dd419a882872946aa5ae26437afcae5b69bc65b1cc1cc398fc1d04410a723812898d76de
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.3.22":
+  version: 1.3.24
+  resolution: "@swc/core@npm:1.3.24"
+  dependencies:
+    "@swc/core-darwin-arm64": 1.3.24
+    "@swc/core-darwin-x64": 1.3.24
+    "@swc/core-linux-arm-gnueabihf": 1.3.24
+    "@swc/core-linux-arm64-gnu": 1.3.24
+    "@swc/core-linux-arm64-musl": 1.3.24
+    "@swc/core-linux-x64-gnu": 1.3.24
+    "@swc/core-linux-x64-musl": 1.3.24
+    "@swc/core-win32-arm64-msvc": 1.3.24
+    "@swc/core-win32-ia32-msvc": 1.3.24
+    "@swc/core-win32-x64-msvc": 1.3.24
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  bin:
+    swcx: run_swcx.js
+  checksum: a27b842be129b83c116f804e63deaa51dbd5d9b77d6260888d549f6408df1dd05aeef20046ceacc9fd7458e6afda6723545249bd77f77086b98bd9bf84738c19
   languageName: node
   linkType: hard
 
@@ -16589,6 +16700,17 @@ __metadata:
   version: 1.7.0
   resolution: "@vercel/webpack-asset-relocator-loader@npm:1.7.0"
   checksum: 05f220859aa93303c75cf4f695de67ef36c9470849c0e4fba820bd35fff0899c02a72031747586335931228a327cde3c9a52b3f4fc994e669aed97d8d3f01e7d
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-react-swc@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@vitejs/plugin-react-swc@npm:3.0.1"
+  dependencies:
+    "@swc/core": ^1.3.22
+  peerDependencies:
+    vite: ^4
+  checksum: 4023b8a582d8f30d0969dd485b2de1ffed8b5110ee732e8129c427cb9ce6c4238343afe4c5bf451cfebf2822df67ff989915231f93e0c94ac74a1aca42fb2f00
   languageName: node
   linkType: hard
 
@@ -40022,6 +40144,7 @@ fsevents@^1.2.7:
     "@types/webpack-env": ^1.13.9
     "@typescript-eslint/eslint-plugin": ^5.46.0
     "@typescript-eslint/parser": ^5.46.0
+    "@vitejs/plugin-react-swc": ^3.0.1
     axe-playwright: ^1.1.11
     babel-loader: ^9.1.0
     babel-plugin-macros: ^3.1.0


### PR DESCRIPTION
Use [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) for faster Storybook startup and Fast Refresh. Currently our Storybook takes 12s to start on cold and hot cache.

**Cold cache plugin-react-swc**

<img width="389" alt="Screenshot 2023-01-03 at 1 54 36 PM" src="https://user-images.githubusercontent.com/2147624/210634275-78b1a3a8-be78-4f94-82f5-54dd7afc3a8e.png">

**Hot cache plugin-react-swc**

<img width="389" alt="Screenshot 2023-01-03 at 1 56 24 PM" src="https://user-images.githubusercontent.com/2147624/210634316-25505284-96d5-46db-8075-aabce6b68778.png">
