### PR TITLE
fix: react 18 - fix reakit ssr issues with portals

### DIFF
--- a/packages/paste-libraries/reakit/src/Portal/Portal.tsx
+++ b/packages/paste-libraries/reakit/src/Portal/Portal.tsx
@@ -1,6 +1,6 @@
 /*
- * Pulled this code from https://github.com/ariakit/ariakit/pull/802/files#diff-b87c59df480f1e77ba8a0bcdb6dbb55b0fc6f4028d2a773e8278b28af3c785bc
- * Taken from a draft PR that addresses portal issues in NextJS
+ * Taken from a draft PR that addresses portal issues in NextJS - https://github.com/ariakit/ariakit/pull/802
+ * The main difference when comparing this file with the latest reakit version is the useEffect hook found here https://github.com/ariakit/ariakit/pull/802/files#diff-b87c59df480f1e77ba8a0bcdb6dbb55b0fc6f4028d2a773e8278b28af3c785bc
  * Unfortunaely this never got merged in as focus shifted towards to Ariakit
  */
 import * as React from 'react';

--- a/packages/paste-libraries/reakit/src/Portal/Portal.tsx
+++ b/packages/paste-libraries/reakit/src/Portal/Portal.tsx
@@ -1,0 +1,51 @@
+/*
+ * Pulled this code from https://github.com/ariakit/ariakit/pull/802/files#diff-b87c59df480f1e77ba8a0bcdb6dbb55b0fc6f4028d2a773e8278b28af3c785bc
+ * Taken from a draft PR that addresses portal issues in NextJS
+ * Unfortunaely this never got merged in as focus shifted towards to Ariakit
+ */
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {canUseDOM} from 'reakit-utils/canUseDOM';
+
+export type PortalProps = {
+  /**
+   * Portal's children.
+   */
+  children: React.ReactNode;
+};
+
+function getBodyElement(): HTMLElement | null {
+  return canUseDOM ? document.body : null;
+}
+
+export const PortalContext = React.createContext<HTMLElement | null>(getBodyElement());
+
+export function Portal({children}: PortalProps): React.ReactPortal | null {
+  const context = React.useContext(PortalContext) || getBodyElement();
+  const [hostNode, setHostNode] = React.useState<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!context) return undefined;
+    const element = document.createElement('div');
+    element.className = Portal.__className;
+    setHostNode(element);
+    // eslint-disable-next-line unicorn/prefer-dom-node-append
+    context.appendChild(element);
+    return () => {
+      // eslint-disable-next-line unicorn/prefer-dom-node-remove
+      context.removeChild(element);
+    };
+  }, [context]);
+
+  if (hostNode) {
+    return ReactDOM.createPortal(
+      <PortalContext.Provider value={hostNode}>{children}</PortalContext.Provider>,
+      hostNode
+    );
+  }
+  // ssr
+  return null;
+}
+
+Portal.__className = '__reakit-portal';
+Portal.__selector = `.${Portal.__className}`;

--- a/packages/paste-libraries/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/paste-libraries/reakit/src/Tooltip/Tooltip.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import {createComponent} from 'reakit-system/createComponent';
+import {createHook} from 'reakit-system/createHook';
+import {useForkRef} from 'reakit-utils/useForkRef';
+import {getDocument} from 'reakit-utils/getDocument';
+
+import {useDisclosureContent} from '..';
+import type {TooltipStateReturn, DisclosureContentHTMLProps, DisclosureContentOptions} from '..';
+import {Portal} from '../Portal/Portal';
+import {TOOLTIP_KEYS} from './__keys';
+import globalState from './__globalState';
+
+export type TooltipOptions = DisclosureContentOptions &
+  Pick<Partial<TooltipStateReturn>, 'unstable_popoverRef' | 'unstable_popoverStyles'> & {
+    /**
+     * Whether or not the tooltip should be rendered within `Portal`.
+     */
+    unstable_portal?: boolean;
+  };
+
+export type TooltipHTMLProps = DisclosureContentHTMLProps;
+
+export type TooltipProps = TooltipOptions & TooltipHTMLProps;
+
+function globallyHideTooltipOnEscape(event: KeyboardEvent): void {
+  if (event.defaultPrevented) return;
+  if (event.key === 'Escape') {
+    globalState.show(null);
+  }
+}
+
+export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
+  name: 'Tooltip',
+  compose: useDisclosureContent,
+  keys: TOOLTIP_KEYS,
+
+  useOptions({unstable_portal = true, ...options}) {
+    return {unstable_portal, ...options};
+  },
+
+  useProps(options, {ref: htmlRef, style: htmlStyle, wrapElement: htmlWrapElement, ...htmlProps}) {
+    React.useEffect(() => {
+      const document = getDocument(options.unstable_popoverRef?.current);
+      document.addEventListener('keydown', globallyHideTooltipOnEscape);
+    }, []);
+
+    const wrapElement = React.useCallback(
+      (element: React.ReactNode) => {
+        if (options.unstable_portal) {
+          element = <Portal>{element}</Portal>;
+        }
+        if (htmlWrapElement) {
+          return htmlWrapElement(element);
+        }
+        return element;
+      },
+      [options.unstable_portal, htmlWrapElement]
+    );
+
+    return {
+      ref: useForkRef(options.unstable_popoverRef, htmlRef),
+      role: 'tooltip',
+      style: {
+        ...options.unstable_popoverStyles,
+        pointerEvents: 'none',
+        ...htmlStyle,
+      },
+      wrapElement,
+      ...htmlProps,
+    };
+  },
+});
+
+export const Tooltip = createComponent({
+  as: 'div',
+  memo: true,
+  useHook: useTooltip,
+});

--- a/packages/paste-libraries/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/paste-libraries/reakit/src/Tooltip/Tooltip.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
+import {useDisclosureContent} from 'reakit';
+import type {TooltipStateReturn, DisclosureContentHTMLProps, DisclosureContentOptions} from 'reakit';
 import {createComponent} from 'reakit-system/createComponent';
 import {createHook} from 'reakit-system/createHook';
 import {useForkRef} from 'reakit-utils/useForkRef';
 import {getDocument} from 'reakit-utils/getDocument';
 
-import {useDisclosureContent} from '..';
-import type {TooltipStateReturn, DisclosureContentHTMLProps, DisclosureContentOptions} from '..';
 import {Portal} from '../Portal/Portal';
 import {TOOLTIP_KEYS} from './__keys';
 import globalState from './__globalState';

--- a/packages/paste-libraries/reakit/src/Tooltip/__globalState.tsx
+++ b/packages/paste-libraries/reakit/src/Tooltip/__globalState.tsx
@@ -1,0 +1,22 @@
+type Listener = (id: string | null) => void;
+
+export default {
+  currentTooltipId: null as string | null,
+  listeners: new Set<Listener>(),
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  },
+  show(id: string | null): void {
+    this.currentTooltipId = id;
+    this.listeners.forEach((listener) => listener(id));
+  },
+  hide(id: string): void {
+    if (this.currentTooltipId === id) {
+      this.currentTooltipId = null;
+      this.listeners.forEach((listener) => listener(null));
+    }
+  },
+};

--- a/packages/paste-libraries/reakit/src/index.tsx
+++ b/packages/paste-libraries/reakit/src/index.tsx
@@ -11,7 +11,6 @@ export {
   CompositeGroup,
   CompositeItem,
   // https://reakit.io/docs/disclosure/
-  useDisclosureContent,
   useDisclosureState,
   Disclosure,
   DisclosureContent,
@@ -49,8 +48,6 @@ export type {
   CompositeGroupProps,
   DisclosureProps,
   DisclosureContentProps,
-  DisclosureContentOptions,
-  DisclosureContentHTMLProps,
   DisclosureState,
   DisclosureInitialState,
   DisclosureStateReturn,

--- a/packages/paste-libraries/reakit/src/index.tsx
+++ b/packages/paste-libraries/reakit/src/index.tsx
@@ -2,6 +2,7 @@ import {PopoverArrow} from './Popover/PopoverArrow';
 import type {PopoverArrowProps} from './Popover/PopoverArrow';
 import {TooltipArrow} from './Tooltip/TooltipArrow';
 import type {TooltipArrowProps} from './Tooltip/TooltipArrow';
+import {Tooltip} from './Tooltip/Tooltip';
 
 export {
   // https://reakit.io/docs/composite/
@@ -10,6 +11,7 @@ export {
   CompositeGroup,
   CompositeItem,
   // https://reakit.io/docs/disclosure/
+  useDisclosureContent,
   useDisclosureState,
   Disclosure,
   DisclosureContent,
@@ -35,7 +37,6 @@ export {
   TabPanel,
   // https://reakit.io/docs/tooltip/
   useTooltipState,
-  Tooltip,
   TooltipReference,
 } from 'reakit';
 
@@ -48,6 +49,8 @@ export type {
   CompositeGroupProps,
   DisclosureProps,
   DisclosureContentProps,
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
   DisclosureState,
   DisclosureInitialState,
   DisclosureStateReturn,
@@ -82,3 +85,5 @@ export type {PopoverArrowProps};
 
 export {TooltipArrow};
 export type {TooltipArrowProps};
+
+export {Tooltip};


### PR DESCRIPTION
# Reakit SSR Fix

We realised that Tooltip component was failing when using Nextjs 13 (React 18).

We found these two GitHub issue:

- [https://github.com/ariakit/ariakit/issues/656](https://github.com/ariakit/ariakit/issues/656)
- [https://github.com/ariakit/ariakit/issues/844](https://github.com/ariakit/ariakit/issues/844) 

There's a linked PR to the first one but it is still a draft: [https://github.com/ariakit/ariakit/pull/802](https://github.com/ariakit/ariakit/pull/802)

We managed to reproduce that PR fix on [codesandbox](https://codesandbox.io/p/sandbox/heuristic-knuth-lk4m55) changing the dependency in the package.json to that commit:

```json
"reakit": "https://pkg.csb.dev/reakit/reakit/commit/b6285795/reakit"
```

This PR aims to integrate those changes into @twilio-paste/reakit-library, using the fix above wouldn't work well as the base of the branch of the `b6285795` commit is some releases older.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
