### PR TITLE
chore: "upgrade" react and react-router-dom in cra template

### DIFF
--- a/packages/paste-cra-template/template.json
+++ b/packages/paste-cra-template/template.json
@@ -8,17 +8,17 @@
       "@twilio-paste/icons": "latest",
       "history": "5.0.0",
       "prop-types": "15.7.2",
-      "react": "16.13.1",
-      "react-dom": "16.13.1",
-      "react-router-dom": "6.0.0-beta.0",
+      "react": "18.0.0",
+      "react-dom": "18.0.0",
+      "react-router-dom": "6.2.1",
       "typescript": "4.1.3",
       "web-vitals": "1.0.1"
     },
     "devDependencies": {
       "@types/jest": "26.0.19",
       "@types/node": "14.14.16",
-      "@types/react": "16.14.2",
-      "@types/react-dom": "16.9.10",
+      "@types/react": "18.0.0",
+      "@types/react-dom": "18.0.0",
       "react-router-dom": "6.2.1"
     },
     "jest": {


### PR DESCRIPTION
Using react 18 and react-router-dom @ 6.2.1 in the CRA template

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
