### PR TITLE
chore: ignore tsx check on react import

### DIFF
--- a/packages/paste-website/src/__tests__/genericHeader.test.tsx
+++ b/packages/paste-website/src/__tests__/genericHeader.test.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore react import is flagged as unused by tsx but required when running the tests
 import * as React from 'react';
 import {Theme} from '@twilio-paste/theme';
 import {render, screen} from '@testing-library/react';

--- a/packages/paste-website/src/__tests__/packageStatusLegend.test.tsx
+++ b/packages/paste-website/src/__tests__/packageStatusLegend.test.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore react import is flagged as unused by tsx but required when running the tests
 import * as React from 'react';
 import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';


### PR DESCRIPTION
`yarn type-check` marks those react imports as unused but when running the tests they fail if no react import is there.

Decided today to ignore the tsx check on those imports.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
