### PR TITLE
fix: add list style type to List component

### DIFF
--- a/.changeset/selfish-trains-attack.md
+++ b/.changeset/selfish-trains-attack.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/list': patch
+'@twilio-paste/core': patch
+---
+
+[List] add list style type to lists

--- a/.changeset/selfish-trains-attack.md
+++ b/.changeset/selfish-trains-attack.md
@@ -3,4 +3,4 @@
 '@twilio-paste/core': patch
 ---
 
-[List] add list style type to lists
+[List] explicitly set the list style type on UnorderedList and OrderedList components.

--- a/packages/paste-core/components/list/src/List.tsx
+++ b/packages/paste-core/components/list/src/List.tsx
@@ -6,7 +6,7 @@ import {isMarginTokenProp} from '@twilio-paste/style-props';
 import type {AsTags, BaseListProps} from './types';
 
 const List = React.forwardRef<HTMLOListElement | HTMLUListElement, BaseListProps>(
-  ({as, children, element = 'LIST', ...props}, ref) => {
+  ({as, children, element = 'LIST', listStyleType = 'disc', ...props}, ref) => {
     return (
       <Text
         {...props}
@@ -17,6 +17,7 @@ const List = React.forwardRef<HTMLOListElement | HTMLUListElement, BaseListProps
         fontWeight="fontWeightNormal"
         lineHeight="lineHeight40"
         marginLeft="space70"
+        listStyleType={listStyleType}
         ref={ref}
       >
         {children}

--- a/packages/paste-core/components/list/src/OrderedList.tsx
+++ b/packages/paste-core/components/list/src/OrderedList.tsx
@@ -15,6 +15,7 @@ const OrderedList = React.forwardRef<HTMLOListElement, OrderedListProps>(
         element={element}
         marginTop={marginTop}
         marginBottom={marginBottom}
+        listStyleType="decimal"
         ref={ref}
       >
         {children}

--- a/packages/paste-core/components/list/src/UnorderedList.tsx
+++ b/packages/paste-core/components/list/src/UnorderedList.tsx
@@ -16,6 +16,7 @@ const UnorderedList = React.forwardRef<HTMLUListElement, UnorderedListProps>(
         marginTop={marginTop}
         marginBottom={marginBottom}
         ref={ref}
+        listStyleType="decimal"
       >
         {children}
       </List>

--- a/packages/paste-core/components/list/src/UnorderedList.tsx
+++ b/packages/paste-core/components/list/src/UnorderedList.tsx
@@ -16,7 +16,7 @@ const UnorderedList = React.forwardRef<HTMLUListElement, UnorderedListProps>(
         marginTop={marginTop}
         marginBottom={marginBottom}
         ref={ref}
-        listStyleType="decimal"
+        listStyleType="disc"
       >
         {children}
       </List>

--- a/packages/paste-core/components/list/src/types.ts
+++ b/packages/paste-core/components/list/src/types.ts
@@ -3,7 +3,9 @@ import type {Space} from '@twilio-paste/style-props';
 
 export type AsTags = 'ol' | 'ul';
 
-export interface BaseListProps extends React.OlHTMLAttributes<HTMLElement>, Pick<TextProps, 'element'> {
+export interface BaseListProps
+  extends React.OlHTMLAttributes<HTMLElement>,
+    Pick<TextProps, 'element' | 'listStyleType'> {
   className?: never;
   style?: never;
   as: AsTags;


### PR DESCRIPTION
Found in this issue: https://github.com/twilio-labs/paste/issues/2954

Explicitly set the list style type on the list component so it doesn't get overriden.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
