### PR TITLE
chore: remove name

### DIFF
--- a/packages/paste-website/src/pages/foundations/content/content-checklist/index.mdx
+++ b/packages/paste-website/src/pages/foundations/content/content-checklist/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Content checklist
-description: Self-service tips and how to access UX Writer support from Caroline (London, GMT).
+description: Self-service tips and how to access UX Writer support.
 slug: /foundations/content/content-checklist/
 ---
 

--- a/packages/paste-website/src/pages/foundations/content/index.mdx
+++ b/packages/paste-website/src/pages/foundations/content/index.mdx
@@ -44,7 +44,7 @@ export const pageQuery = graphql`
   <CalloutHeading as="h2">Early Access! Early Access! Early Access!</CalloutHeading>
   <CalloutText>
     These guidelines are still in development and are not yet complete. If you can't see what you need here, you've
-    found an edge-case or exception, or you have other comments, reach out to Caroline Tecks on Slack.
+    found an edge-case or exception, or you have other comments, reach out on Slack.
   </CalloutText>
 </Callout>
 


### PR DESCRIPTION
Removed a hard-coded name. Responsibilities shift, and specifying a person directly isn't a good long term solution.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
