### PR TITLE
chore: convert primitive pages except listbox

### DIFF
--- a/packages/paste-core/primitives/box/package.json
+++ b/packages/paste-core/primitives/box/package.json
@@ -3,7 +3,7 @@
   "version": "7.1.2",
   "category": "layout",
   "status": "production",
-  "description": "A primitive component that can be used to create all block level styles in Paste",
+  "description": "The Box component is one of the pillars of our system. It can be any HTML element and can receive many of our token values as props. We use Box to build most of our other components.",
   "author": "Twilio Inc.",
   "license": "MIT",
   "main:dev": "src/index.tsx",

--- a/packages/paste-core/primitives/box/package.json
+++ b/packages/paste-core/primitives/box/package.json
@@ -3,7 +3,7 @@
   "version": "7.1.2",
   "category": "layout",
   "status": "production",
-  "description": "The Box component is one of the pillars of our system. It can be any HTML element and can receive many of our token values as props. We use Box to build most of our other components.",
+  "description": "The Box primitive is one of the pillars of our system. It can be any HTML element and can receive many of our token values as props. We use Box to build most of our other components.",
   "author": "Twilio Inc.",
   "license": "MIT",
   "main:dev": "src/index.tsx",

--- a/packages/paste-core/primitives/disclosure/package.json
+++ b/packages/paste-core/primitives/disclosure/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.10",
   "category": "interaction",
   "status": "production",
-  "description": "An unstyled and accessible basis upon which to build a disclosure.",
+  "description": "An accessible disclosure primitive for controlling the visibility of a content section.",
   "author": "Twilio Inc.",
   "license": "MIT",
   "main:dev": "src/index.tsx",

--- a/packages/paste-core/primitives/text/package.json
+++ b/packages/paste-core/primitives/text/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.2",
   "category": "typography",
   "status": "production",
-  "description": "A primitive component that can be used to create all text styles in Paste",
+  "description": "The Text component is a primitive of the system and can output any supported text style provided by our design tokens. Coupled with Box, it underpins most of our components.",
   "author": "Twilio Inc.",
   "license": "MIT",
   "main:dev": "src/index.tsx",

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -1,67 +1,50 @@
----
-title: Box - Primitives
-description: The Box component is one of the pillars of our system. It can be any HTML element and can receive many of our token values as props. We use Box to build most of our other components.
-slug: /primitives/box/
----
+export const meta = {
+  title: 'Box',
+  package: '@twilio-paste/box',
+  description:
+    'The Box component is one of the pillars of our system. It can be any HTML element and can receive many of our token values as props. We use Box to build most of our other components.',
+  slug: '/primitives/box/',
+};
 
 import {Box} from '@twilio-paste/box';
 import Changelog from '@twilio-paste/box/CHANGELOG.md';
+import packageJson from '@twilio-paste/box/package.json';
 import {Callout, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/box"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/box/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Box"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Box');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/box"
   storybookUrl="/?path=/story/primitives-box--default"
   data={props.data}
+  description={meta.description}
 />
 
 ---
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/box/index.mdx
+++ b/packages/paste-website/src/pages/primitives/box/index.mdx
@@ -37,7 +37,6 @@ export const getStaticProps = async () => {
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/box"
   storybookUrl="/?path=/story/primitives-box--default"
   data={props.data}
-  description={meta.description}
 />
 
 ---

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -48,7 +48,6 @@ export const getStaticProps = async () => {
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/combobox"
   storybookUrl="/?path=/story/primitives-combobox--dropdown-combobox"
   data={props.data}
-  description={meta.description}
 />
 
 ---

--- a/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/combobox-primitive/index.mdx
@@ -1,11 +1,14 @@
----
-title: Combobox Primitive
-description: An unstyled and accessible basis upon which to build a combobox.
-slug: /primitives/combobox-primitive/
----
+export const meta = {
+  title: 'Combobox Primitive',
+  package: '@twilio-paste/combobox-primitive',
+  description: 'An unstyled and accessible basis upon which to build a combobox.',
+  slug: '/primitives/combobox-primitive/',
+};
 
 import {useUID, useUIDSeed} from '@twilio-paste/uid-library';
 import {useComboboxPrimitive, useMultiSelectPrimitive} from '@twilio-paste/combobox-primitive';
+import Changelog from '@twilio-paste/combobox-primitive/CHANGELOG.md';
+import packageJson from '@twilio-paste/combobox-primitive/package.json';
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
 import {Label} from '@twilio-paste/label';
@@ -21,60 +24,38 @@ import {
   defaultExample,
   multiSelectExample,
 } from '../../../component-examples/ComboboxPrimitiveExamples';
-import Changelog from '@twilio-paste/combobox-primitive/CHANGELOG.md';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/combobox-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/combobox-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Combobox Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Combobox Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/combobox"
   storybookUrl="/?path=/story/primitives-combobox--dropdown-combobox"
   data={props.data}
+  description={meta.description}
 />
 
 ---
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 
@@ -98,7 +79,7 @@ a functional and accessible experience to your customers.
 This primitive should be used to compose all custom Comboboxes to ensure accessibility and upgrade paths.
 
 <Callout variant="warning" marginY="space70">
-  <CalloutHeading>Warning</CalloutHeading>
+  <CalloutHeading as="h4">Warning</CalloutHeading>
   <CalloutText>
     We strongly suggest that all components built on top of this primitive get reviewed by the Design Systems team and
     goes through the UX Review process to ensure an excellent experience for our customers.

--- a/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
@@ -1,8 +1,9 @@
----
-title: Disclosure Primitive
-description: An accessible disclosure primitive for controlling the visibility of a content section.
-slug: /primitives/disclosure-primitive/
----
+export const meta = {
+  title: 'Disclosure Primitive',
+  package: '@twilio-paste/disclosure-primitive',
+  description: 'An accessible disclosure primitive for controlling the visibility of a content section.',
+  slug: '/primitives/disclosure-primitive/',
+};
 
 import {
   useDisclosurePrimitiveState,
@@ -10,9 +11,11 @@ import {
   DisclosurePrimitiveContent,
 } from '@twilio-paste/disclosure-primitive';
 import Changelog from '@twilio-paste/disclosure-primitive/CHANGELOG.md';
+import packageJson from '@twilio-paste/disclosure-primitive/package.json';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {
@@ -20,59 +23,38 @@ import {
   ConditionallyRenderingExample,
   MultipleExample,
 } from '../../../component-examples/DisclosurePrimitiveExamples';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/disclosure-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/disclosure-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Disclosure Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Disclosure Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/disclosure"
   storybookUrl="/?path=/story/primitives-disclosure"
   data={props.data}
+  description={meta.description}
 />
 
 ---
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/disclosure-primitive/index.mdx
@@ -47,7 +47,6 @@ export const getStaticProps = async () => {
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/disclosure"
   storybookUrl="/?path=/story/primitives-disclosure"
   data={props.data}
-  description={meta.description}
 />
 
 ---

--- a/packages/paste-website/src/pages/primitives/index.mdx
+++ b/packages/paste-website/src/pages/primitives/index.mdx
@@ -1,6 +1,5 @@
 export const meta = {
   title: 'Primitives overview',
-  description: 'Our primitives are rad',
   slug: '/primitives/',
 };
 
@@ -48,12 +47,8 @@ export const getStaticProps = async () => {
     </CalloutListItem>
     <CalloutListItem>
       Secondly, we recommend{' '}
-      <Anchor href="https://github.com/twilio-labs/paste/issues">creating an issue on GitHub</Anchor> with your
-      component, primitive, or proposal.
-    </CalloutListItem>
-    <CalloutListItem>
-      While not all requests are accepted for the design system, we may be able to suggest suitable alternatives - for
-      this, drop us a note on #help-design-system or join our Weekly Office hours.
+      <Anchor href="https://github.com/twilio-labs/paste/discussions">creating an discussion on GitHub</Anchor> with
+      your component, primitive, or proposal.
     </CalloutListItem>
     <CalloutListItem>
       We've also written a guide for{' '}

--- a/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
@@ -1,8 +1,9 @@
----
-title: Menu - Primitives
-description: An unstyled and accessible basis upon which to build Menus.
-slug: /primitives/menu-primitive/
----
+export const meta = {
+  title: 'Menu Primitive',
+  package: '@twilio-paste/menu-primitive',
+  description: 'An unstyled and accessible basis upon which to build Menus.',
+  slug: '/primitives/menu-primitive/',
+};
 
 import Image from 'next/image';
 import {Box} from '@twilio-paste/box';
@@ -10,6 +11,7 @@ import {Text} from '@twilio-paste/text';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {Button} from '@twilio-paste/button';
 import Changelog from '@twilio-paste/menu-primitive/CHANGELOG.md';
+import packageJson from '@twilio-paste/menu-primitive/package.json';
 import {
   useMenuPrimitiveState,
   MenuPrimitive,
@@ -18,62 +20,42 @@ import {
   MenuPrimitiveSeparator,
 } from '@twilio-paste/menu-primitive';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {defaultExample, subMenuExample, customExample} from '../../../component-examples/MenuPrimitiveExamples';
 import MenuBar from '../../../assets/images/menu-primitive-images/menubar.png';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/menu-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/menu-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Menu Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Menu Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/menu"
   storybookUrl="/?path=/story/primitives-menu--simple-menu"
   data={props.data}
+  description={meta.description}
 />
 
 ---
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 
@@ -187,7 +169,7 @@ This package is a wrapper around the [Reakit Menu](https://reakit.io/docs/menu/)
     desktop software menubar you see at the top of your screen. These have limited use cases on the web unless you're
     building a desktop replacement like Figma or Google Docs. We may reconsider this in the future if we see a good use
     for this.
-    <Image src={MenuBar} layout="fill" />
+    <Image src={MenuBar} placeholder="blur" />
   </CalloutText>
 </Callout>
 

--- a/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/menu-primitive/index.mdx
@@ -48,7 +48,6 @@ export const getStaticProps = async () => {
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/menu"
   storybookUrl="/?path=/story/primitives-menu--simple-menu"
   data={props.data}
-  description={meta.description}
 />
 
 ---

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -1,10 +1,12 @@
----
-title: Modal Dialog - Primitives
-description: An accessible modal dialog window
-slug: /primitives/modal-dialog-primitive/
----
+export const meta = {
+  title: 'Modal Dialog Primitive',
+  package: '@twilio-paste/modal-dialog-primitive',
+  description: 'An accessible modal dialog window.',
+  slug: '/primitives/modal-dialog-primitive/',
+};
 
 import {ModalDialogPrimitiveContent, ModalDialogPrimitiveOverlay} from '@twilio-paste/modal-dialog-primitive';
+import packageJson from '@twilio-paste/modal-dialog-primitive/package.json';
 import Changelog from '@twilio-paste/modal-dialog-primitive/CHANGELOG.md';
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
@@ -12,46 +14,24 @@ import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {ModalDialogPrimitiveExample} from '../../../component-examples/ModalDialogPrimitiveExample.tsx';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/modal-dialog-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/modal-dialog-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Modal Dialog Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Modal Dialog Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
@@ -64,7 +44,7 @@ export const pageQuery = `
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/modal-dialog-primitive/index.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Modal Dialog Primitive',
   package: '@twilio-paste/modal-dialog-primitive',
-  description: 'An accessible modal dialog window.',
+  description: 'An unstyled and accessible basis upon which to build Modal Dialogs.',
   slug: '/primitives/modal-dialog-primitive/',
 };
 

--- a/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/non-modal-dialog-primitive/index.mdx
@@ -1,8 +1,9 @@
----
-title: Non-Modal Dialog - Primitives
-description: An unstyled and accessible base upon which to build a non-modal dialog.
-slug: /primitives/non-modal-dialog-primitive/
----
+export const meta = {
+  title: 'Non-Modal Primitive',
+  package: '@twilio-paste/non-modal-dialog-primitive',
+  description: 'An unstyled and accessible base upon which to build a non-modal dialog.',
+  slug: '/primitives/non-modal-dialog-primitive/',
+};
 
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
@@ -15,7 +16,9 @@ import {
   NonModalDialogDisclosurePrimitive,
   NonModalDialogArrowPrimitive,
 } from '@twilio-paste/non-modal-dialog-primitive';
+import packageJson from '@twilio-paste/non-modal-dialog-primitive/package.json';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {
   defaultExample,
@@ -23,46 +26,24 @@ import {
   gutterExample,
   styledExample,
 } from '../../../component-examples/NonModalDialogPrimitiveExamples';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/non-modal-dialog-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/non-modal-dialog-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Non-modal Dialog Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Non-Modal Dialog Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
@@ -75,7 +56,7 @@ export const pageQuery = `
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/tabs-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tabs-primitive/index.mdx
@@ -1,8 +1,9 @@
----
-title: Tabs - Primitives
-description: An unstyled and accessible basis upon which to style a tabset.
-slug: /primitives/tabs-primitive/
----
+export const meta = {
+  title: 'Tabs Primitive',
+  package: '@twilio-paste/tabs-primitive',
+  description: 'An unstyled and accessible basis upon which to style a tabset.',
+  slug: '/primitives/tabs-primitive/',
+};
 
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
@@ -10,50 +11,30 @@ import {StyledBase} from '@twilio-paste/theme';
 import {Text} from '@twilio-paste/text';
 import {Stack} from '@twilio-paste/stack';
 import Changelog from '@twilio-paste/tabs-primitive/CHANGELOG.md';
+import packageJson from '@twilio-paste/tabs-primitive/package.json';
 import {useTabPrimitiveState, TabPrimitive, TabPrimitiveList, TabPrimitivePanel} from '@twilio-paste/tabs-primitive';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {horizontalExample, verticalExample, styledExample} from '../../../component-examples/TabsPrimitiveExamples';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/tabs-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/tabs-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Tabs Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Tabs Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
@@ -66,7 +47,7 @@ export const pageQuery = `
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/text/index.mdx
+++ b/packages/paste-website/src/pages/primitives/text/index.mdx
@@ -1,70 +1,53 @@
----
-title: Text - Primitives
-description: The Text component is a primitive of the system and can output any supported text style provided by our design tokens. Coupled with Box, it underpins most of our components.
-slug: /primitives/text/
----
+export const meta = {
+  title: 'Text Primitive',
+  package: '@twilio-paste/text',
+  description:
+    'The Text component is a primitive of the system and can output any supported text style provided by our design tokens. Coupled with Box, it underpins most of our components.',
+  slug: '/primitives/text/',
+};
 
 import {Box} from '@twilio-paste/box';
 import {Text} from '@twilio-paste/text';
+import packageJson from '@twilio-paste/text/package.json';
 import {Paragraph} from '@twilio-paste/paragraph';
 import Changelog from '@twilio-paste/text/CHANGELOG.md';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+
 import {SidebarCategoryRoutes} from '../../../constants';
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import {InlineCode} from '../../../components/Typography';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/text"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/text/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Text"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Text');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/text"
   storybookUrl="/?path=/story/primitives-text--default"
   data={props.data}
+  description={meta.description}
 />
 
 ---
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 
@@ -81,8 +64,6 @@ export const pageQuery = `
     here, come to the Design System Office Hours.
   </CalloutText>
 </Callout>
-
-<Paragraph>{props.pageContext.frontmatter.description}</Paragraph>
 
 ### About Text
 

--- a/packages/paste-website/src/pages/primitives/text/index.mdx
+++ b/packages/paste-website/src/pages/primitives/text/index.mdx
@@ -40,7 +40,6 @@ export const getStaticProps = async () => {
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/primitives/text"
   storybookUrl="/?path=/story/primitives-text--default"
   data={props.data}
-  description={meta.description}
 />
 
 ---

--- a/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
@@ -1,14 +1,16 @@
----
-title: Tooltip - Primitives
-description: An unstyled and accessible base upon which to build a tooltip.
-slug: /primitives/tooltip-primitive/
----
+export const meta = {
+  title: 'Tooltip Primitive',
+  package: '@twilio-paste/tooltip-primitive',
+  description: 'An unstyled and accessible base upon which to build a tooltip.',
+  slug: '/primitives/toolti[-primitive/',
+};
 
 import {Box} from '@twilio-paste/box';
 import {Button} from '@twilio-paste/button';
 import {StyledBase} from '@twilio-paste/theme';
 import {Text} from '@twilio-paste/text';
 import Changelog from '@twilio-paste/tooltip-primitive/CHANGELOG.md';
+import packageJson from '@twilio-paste/tooltip-primitive/package.json';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
 import {
   useTooltipPrimitiveState,
@@ -18,46 +20,24 @@ import {
 } from '@twilio-paste/tooltip-primitive';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {defaultExample, rightExample, styledExample} from '../../../component-examples/TooltipPrimitiveExamples';
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getFeature, getNavigationData} from '../../../utils/api';
 
-export const pageQuery = `
-  {
-    allPastePrimitive(filter: {name: {eq: "@twilio-paste/tooltip-primitive"}}) {
-      edges {
-        node {
-          name
-          description
-          status
-          version
-        }
-      }
-    }
-    mdx(frontmatter: {slug: {eq: "/primitives/tooltip-primitive/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-    allAirtable(filter: {data: {Feature: {eq: "Tooltip Primitive"}}}) {
-      edges {
-        node {
-          data {
-            Documentation
-            Figma
-            Design_committee_review
-            Engineer_committee_review
-            Code
-            status
-          }
-        }
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Tooltip Primitive');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
 
 <NormalizedComponentHeader
   categoryRoute={SidebarCategoryRoutes.PRIMITIVES}
@@ -70,7 +50,7 @@ export const pageQuery = `
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 

--- a/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
+++ b/packages/paste-website/src/pages/primitives/tooltip-primitive/index.mdx
@@ -2,7 +2,7 @@ export const meta = {
   title: 'Tooltip Primitive',
   package: '@twilio-paste/tooltip-primitive',
   description: 'An unstyled and accessible base upon which to build a tooltip.',
-  slug: '/primitives/toolti[-primitive/',
+  slug: '/primitives/tooltip-primitive/',
 };
 
 import {Box} from '@twilio-paste/box';


### PR DESCRIPTION
converts all primitive pages except the listbox page, see this thread for context: https://twilio.slack.com/archives/C04L4C4E51D/p1674761782898869

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
