### PR TITLE
Migrate core pages to Nextjs

### DIFF
--- a/packages/paste-website/src/pages/core/changelog.mdx
+++ b/packages/paste-website/src/pages/core/changelog.mdx
@@ -1,28 +1,25 @@
----
-title: Core Package Changelog
-slug: /core/changelog
----
+export const meta = {
+  title: 'Core Package Changelog',
+  slug: '/core/changelog',
+};
 
 import Changelog from '@twilio-paste/core/CHANGELOG.md';
 import {SidebarCategoryRoutes} from '../../constants';
+import {getNavigationData} from '../../utils/api';
+import DefaultLayout from '../../layouts/DefaultLayout';
 
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/changelog/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+export default DefaultLayout;
 
-<GenericHeader name={props.pageContext.frontmatter.title} categoryRoute={SidebarCategoryRoutes.CORE} />
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      navigationData,
+    },
+  };
+};
+
+<GenericHeader name={meta.title} categoryRoute={SidebarCategoryRoutes.CORE} />
 
 ---
 

--- a/packages/paste-website/src/pages/core/libraries/codemods/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/codemods/index.mdx
@@ -1,41 +1,42 @@
----
-title: Codemods
-description: A collection of jscodeshift codemods to help update projects built with Paste.
-slug: /core/libraries/codemods/
----
+export const meta = {
+  title: 'Codemods',
+  package: '@twilio-paste/codemods',
+  description: 'A collection of codemods for maintaining projects built with Paste.',
+  slug: '/core/libraries/codemods/',
+};
 
-import PackageJSON from '@twilio-paste/codemods/package.json';
 import {SidebarCategoryRoutes} from '../../../../constants';
+import {getNavigationData} from '../../../../utils/api';
+import packageJson from '@twilio-paste/codemods/package.json';
+import DefaultLayout from '../../../../layouts/DefaultLayout';
 
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/libraries/codemods/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      data: {
+        ...packageJson,
+      },
+      navigationData,
+    },
+  };
+};
 
 <GenericHeader
-  name="Codemods"
+  name={meta.title}
   categoryRoute={SidebarCategoryRoutes.LIBRARIES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-codemods"
-  packageName={PackageJSON.name}
-  version={PackageJSON.version}
-  description={PackageJSON.description}
+  packageName={props.data.name}
+  version={props.data.version}
+  description={props.data.description}
 />
 
 ---
 
 <contentwrapper>
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 <content>
 
 ## About

--- a/packages/paste-website/src/pages/core/libraries/data-visualization/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/data-visualization/index.mdx
@@ -1,47 +1,47 @@
----
-title: Data visualization library
-description: A library that helps theme data visualizations with Paste tokens.
-slug: /core/libraries/data-visualization/
----
+export const meta = {
+  title: 'Data visualization library',
+  package: '@twilio-paste/data-visualization-library',
+  description: 'A library that helps theme data visualizations with Paste tokens.',
+  slug: '/core/libraries/data-visualization/',
+};
 
-import PackageJSON from '@twilio-paste/data-visualization-library/package.json';
+import DefaultLayout from '../../../../layouts/DefaultLayout';
+import packageJson from '@twilio-paste/data-visualization-library/package.json';
 import Changelog from '@twilio-paste/data-visualization-library/CHANGELOG.md';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import {usePasteHighchartsTheme} from '@twilio-paste/data-visualization-library';
-
 import {SidebarCategoryRoutes} from '../../../../constants';
+import {getNavigationData} from '../../../../utils/api';
 
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/libraries/data-visualization/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      data: {
+        ...packageJson,
+      },
+      navigationData,
+    },
+  };
+};
 
 <GenericHeader
-  name="Data visualization library"
+  name={meta.title}
   categoryRoute={SidebarCategoryRoutes.LIBRARIES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-libraries/data-visualization"
   storybookUrl="/?path=/story/libraries-data-visualization"
-  packageName={PackageJSON.name}
-  version={PackageJSON.version}
-  description={PackageJSON.description}
+  packageName={props.data.name}
+  version={props.data.version}
+  description={props.data.description}
 />
 
 ---
 
 <contentwrapper>
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 <content>
 
 ## Usage Guide

--- a/packages/paste-website/src/pages/core/libraries/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/index.mdx
@@ -1,34 +1,32 @@
----
-title: Libraries
-description: Standalone tools and plugins built and supported by the Paste team.
-slug: /core/libraries/
----
+export const meta = {
+  title: 'Libraries',
+  description: 'Standalone tools and plugins built and supported by the Paste team.',
+  slug: '/core/libraries/',
+};
 
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/libraries/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {getNavigationData} from '../../../utils/api';
+
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      navigationData,
+    },
+  };
+};
 
 <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 
-<h1>{props.pageContext.frontmatter.title}</h1>
+<h1>{meta.title}</h1>
 
-<p>{props.pageContext.frontmatter.description}</p>
+<p>{meta.description}</p>
 
 ---
 

--- a/packages/paste-website/src/pages/core/libraries/uid-library/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/uid-library/index.mdx
@@ -1,44 +1,45 @@
----
-title: UID Library
-description: Generates unique identifiers for HTML and JS
-slug: /core/libraries/uid-library/
----
+export const meta = {
+  title: 'UID Library',
+  package: '@twilio-paste/uid-library',
+  description: 'Generates unique identifiers for HTML and JS',
+  slug: '/core/libraries/uid-library/',
+};
 
 import {Box} from '@twilio-paste/box';
-import PackageJSON from '@twilio-paste/uid-library/package.json';
+import packageJson from '@twilio-paste/uid-library/package.json';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
 import {SidebarCategoryRoutes} from '../../../../constants';
+import {getNavigationData} from '../../../../utils/api';
+import DefaultLayout from '../../../../layouts/DefaultLayout';
 
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/libraries/uid-library/"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      data: {
+        ...packageJson,
+      },
+      navigationData,
+    },
+  };
+};
 
 <GenericHeader
-  name="UID Library"
+  name={meta.title}
   categoryRoute={SidebarCategoryRoutes.LIBRARIES}
   githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-libraries/uid"
   storybookUrl="/?path=/story/libraries-uid"
-  packageName={PackageJSON.name}
-  version={PackageJSON.version}
-  description={PackageJSON.description}
+  packageName={props.data.name}
+  version={props.data.version}
+  description={props.data.description}
 />
 
 ---
 
 <contentwrapper>
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 <content>
 
 ## Guidelines
@@ -55,7 +56,7 @@ Here's what could happen without unique IDs:
 
 <iframe
   src="https://codesandbox.io/embed/blue-http-xqqo4?fontsize=14&hidenavigation=1&theme=dark"
-  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  style={{width: '100%', height: '310px', border: 0, borderRadius: '4px', overflow: 'hidden'}}
   title="blue-http-xqqo4"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -104,7 +105,7 @@ This is a React Hook to generate a UID.
 
 <iframe
   src="https://codesandbox.io/embed/happy-bush-ued0c?fontsize=14&hidenavigation=1&theme=dark"
-  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  style={{width: '100%', height: '310px', border: 0, borderRadius: '4px', overflow: 'hidden'}}
   title="useUID example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -118,7 +119,7 @@ This React Hook creates a seed from which you can generate several UIDs. It's ha
 
 <iframe
   src="https://codesandbox.io/embed/useuidseed-example-p0sxb?fontsize=14&hidenavigation=1&theme=dark"
-  style="width:100%; height:310px; border:0; border-radius: 4px; overflow:hidden;"
+  style={{width: '100%', height: '310px', border: 0, borderRadius: '4px', overflow: 'hidden'}}
   title="useUIDSeed example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -155,7 +156,7 @@ We provide this export for quick UID generation in utility files.
 
 <iframe
   src="https://codesandbox.io/embed/uid-example-s35fo?fontsize=14&hidenavigation=1&theme=dark"
-  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden'}}
   title="uid Example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"

--- a/packages/paste-website/src/pages/core/upgrade-guide.mdx
+++ b/packages/paste-website/src/pages/core/upgrade-guide.mdx
@@ -1,8 +1,8 @@
----
-title: Upgrade Guide
-description: Summary of Breaking Changes to Core, with actions that should be taken before upgrading
-slug: /core/upgrade-guide
----
+export const meta = {
+  title: 'Upgrade Guide',
+  description: 'Summary of Breaking Changes to Core, with actions that should be taken before upgrading',
+  slug: '/core/upgrade-guide',
+};
 
 import {Card} from '@twilio-paste/card';
 import {Box} from '@twilio-paste/box';
@@ -12,30 +12,28 @@ import {UnorderedList, ListItem} from '@twilio-paste/list';
 import {Disclosure, DisclosureHeading, DisclosureContent} from '@twilio-paste/disclosure';
 import {Codeblock} from '../../components/codeblock';
 import {SidebarCategoryRoutes} from '../../constants';
-export const pageQuery = `
-  {
-    mdx(frontmatter: {slug: {eq: "/core/upgrade-guide"}}) {
-      fileAbsolutePath
-      frontmatter {
-        slug
-        title
-      }
-      headings {
-        depth
-        value
-      }
-    }
-  }
-`;
+import {getNavigationData} from '../../utils/api';
+import DefaultLayout from '../../layouts/DefaultLayout';
 
-<GenericHeader name={props.pageContext.frontmatter.title} categoryRoute={SidebarCategoryRoutes.CORE} />
-<p>{props.pageContext.frontmatter.description}</p>
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  return {
+    props: {
+      navigationData,
+    },
+  };
+};
+
+<GenericHeader name={meta.title} categoryRoute={SidebarCategoryRoutes.CORE} />
+<p>{meta.description}</p>
 
 ---
 
  <contentwrapper>
 
-<PageAside data={props.data.mdx} />
+<PageAside data={mdxHeadings} />
 
 <content>
 


### PR DESCRIPTION
This PR migrates the `src/pages/core` dir to use NextJS patterns.

The six pages migrated are broken apart [by commit in this PR:](https://github.com/twilio-labs/paste/pull/2997/commits)

* https://paste.twilio.design/core/changelog
* https://paste.twilio.design/core/upgrade-guide
* https://paste.twilio.design/core/libraries
* https://paste.twilio.design/core/libraries/uid-library
* https://paste.twilio.design/core/libraries/codemods
* https://paste.twilio.design/core/libraries/data-visualization


