### PR TITLE
fix(CustomizationProvider): add missing theme types to baseTheme prop

### DIFF
--- a/.changeset/eleven-deers-kiss.md
+++ b/.changeset/eleven-deers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/customization': patch
+---
+
+[CustomizationProvider] Add missing theme types to baseTheme prop

--- a/packages/paste-customization/src/types/CustomizationProvider.ts
+++ b/packages/paste-customization/src/types/CustomizationProvider.ts
@@ -6,10 +6,10 @@ export interface CustomizationProviderProps {
   /**
    * Choose the base theme you would like your application to extend from
    *
-   * @type {('default' | 'dark')}
+   * @type {('default' | 'sendgrid' | 'flex' | 'dark' | 'twilio' | 'twilio-dark' | 'evergreen')}
    * @memberof CustomizationProviderProps
    */
-  baseTheme?: 'default' | 'dark';
+  baseTheme?: 'default' | 'sendgrid' | 'flex' | 'dark' | 'twilio' | 'twilio-dark' | 'evergreen';
   /**
    * Provide an array of breakpoint sizes that you would like to be able to use in responsive
    * layouts, using the responsive style props


### PR DESCRIPTION
<!-- Describe your Pull Request -->

While I was working around the Modal backgroundColor issue described in #3036, I noticed the type for the `CustomizationProvider.baseTheme` prop is out of date, limited to just `default | dark`, and requires a `@ts-ignore` comment to pass anything else. I've updated the type to include all of the values of `ThemeVariants`, but it's hard-coded. 

Something seems to be off with the TS config or version, because `ThemeVariants`, which I believe should resolve to a type union of the values of this constant object, just resolves to a string:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/11774799/218761405-3371b6cd-6f54-4eb7-a1a7-221761ce6f9e.png">

<img width="605" alt="image" src="https://user-images.githubusercontent.com/11774799/218761700-8dd3614d-7107-4148-9705-a89e8aa51ba0.png">

Happy to do some further digging to figure out what's going on here if we'd prefer to solve the root issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
