### PR TITLE
fix: dangerJS check now correctly detects missing design token changes

### DIFF
--- a/.danger/__tests__/missing-changesets-check.spec.ts
+++ b/.danger/__tests__/missing-changesets-check.spec.ts
@@ -29,6 +29,12 @@ const mockPackList = [
     private: true,
     location: '/Users/simon/dev/twilio/design-systems/paste/packages/paste-core/primitives/box',
   },
+  {
+    name: '@twilio-paste/design-tokens',
+    version: '0.0.0',
+    private: false,
+    location: '/Users/simon/dev/twilio/design-systems/paste/packages/paste-design-tokens',
+  },
 ];
 
 describe('getMissingPackagesFromChangesets()', () => {
@@ -54,9 +60,15 @@ describe('getMissingPackagesFromChangesets()', () => {
           './.danger/__fixtures__/changeset/popular-cheetahs-punch.md',
           './.danger/__fixtures__/changeset/pretty-cameras-burn.md',
         ],
-        ['@twilio-paste/avatar', '@twilio-paste/box', '@twilio-paste/icons', '@twilio-paste/core']
+        [
+          '@twilio-paste/avatar',
+          '@twilio-paste/box',
+          '@twilio-paste/icons',
+          '@twilio-paste/core',
+          '@twilio-paste/design-tokens',
+        ]
       )
-    ).toEqual(['@twilio-paste/core']);
+    ).toEqual(['@twilio-paste/core', '@twilio-paste/design-tokens']);
 
     expect(
       getMissingPackagesFromChangesets(
@@ -92,6 +104,7 @@ describe('missingChangesetCheck()', () => {
           'packages/paste-icons/src/index.tsx',
           'packages/paste-core/components/avatar/src/index.tsx',
           'packages/paste-core/primitives/box/src/index.tsx',
+          'packages/paste-design-tokens/tokens/themes/evergreen/global/background-color.yml',
           'yarn.lock',
           './.danger/__fixtures__/changeset/pretty-cameras-burn.md',
         ],
@@ -99,7 +112,7 @@ describe('missingChangesetCheck()', () => {
       },
     };
     missingChangesetCheck(mockPackList);
-    expect(global.fail).toHaveBeenCalledTimes(1);
+    expect(global.fail).toHaveBeenCalledTimes(2);
   });
 
   it('should fail twice for two packages that are not in a changeset', () => {

--- a/.danger/__tests__/utils.spec.ts
+++ b/.danger/__tests__/utils.spec.ts
@@ -232,6 +232,41 @@ describe('danger utils', () => {
         )
       ).toEqual(['@twilio-paste/style-props', '@twilio-paste/alert-dialog']);
     });
+
+    it('should return the design-tokens package with even though no src files are updated', () => {
+      expect(
+        getUnpublishedPackageNames(
+          [
+            'package.json',
+            'packages/paste-style-props/src/index.ts',
+            'packages/paste-core/components/alert-dialog/stories/index.stories.tsx',
+            'packages/paste-design-tokens/tokens/themes/evergreen/global/background-color.yml',
+            'yarn.lock',
+            '.changeset/pretty-cameras-burn.md',
+          ],
+          [
+            {
+              name: '@twilio-paste/alert-dialog',
+              version: '3.1.0',
+              private: false,
+              location: '/Users/simon/dev/twilio/design-systems/paste/packages/paste-core/components/alert-dialog',
+            },
+            {
+              name: '@twilio-paste/style-props',
+              version: '3.1.0',
+              private: false,
+              location: '/Users/simon/dev/twilio/design-systems/paste/packages/paste-style-props',
+            },
+            {
+              name: '@twilio-paste/design-tokens',
+              version: '3.1.0',
+              private: false,
+              location: '/Users/simon/dev/twilio/design-systems/paste/packages/paste-design-tokens',
+            },
+          ]
+        )
+      ).toEqual(['@twilio-paste/style-props', '@twilio-paste/design-tokens']);
+    });
   });
 
   describe('getChangesetsFromFiles', () => {

--- a/.danger/utils.ts
+++ b/.danger/utils.ts
@@ -68,7 +68,14 @@ export const getUnpublishedPackageNames = (touchedFiles: string[], publicPackage
   touchedFiles.forEach((filePath) => {
     const packageName = getPackageNameFromPath(filePath, publicPackages);
 
-    if (filePath.includes('/src/')) {
+    // all packages are uniform, except for design tokens. Source files are in the src directory.
+    // any changes to tokens, formatters or types in design tokens also need to be released
+    if (
+      filePath.includes('/src/') ||
+      filePath.includes('/paste-design-tokens/tokens/') ||
+      filePath.includes('/paste-design-tokens/formatters/') ||
+      filePath.includes('/paste-design-tokens/types/')
+    ) {
       uniquePackages.add(packageName);
     }
   });


### PR DESCRIPTION
We missed a changeset for a design token change, due to the dangerJS check not correctly identifying design token files

## Changes in this PR:

### Detect design token files for changesets

We naively only checked for changes in `src` which works for every package except design tokens.

This PR makes sure we detect the unique design tokens file structure for changes that need to be published in the dangerJS check

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
