### PR TITLE
chore: animate SideModal component

### DIFF
--- a/.changeset/brown-yaks-heal.md
+++ b/.changeset/brown-yaks-heal.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/side-modal': patch
+'@twilio-paste/core': patch
+---
+
+[Side modal] Add an opening animation

--- a/packages/paste-core/components/side-modal/__tests__/customization.spec.tsx
+++ b/packages/paste-core/components/side-modal/__tests__/customization.spec.tsx
@@ -97,7 +97,7 @@ const MyCustomizationWrapper: React.FC<React.PropsWithChildren> = ({children}) =
 );
 
 describe('Customization', () => {
-  it('should have default element data attributes', () => {
+  it('should have default element data attributes', async () => {
     render(
       <SideModalContainer>
         <SideModalButton variant="primary">Button</SideModalButton>
@@ -115,7 +115,11 @@ describe('Customization', () => {
       </SideModalContainer>
     );
 
-    const dialogButton = screen.getByRole('button', {name: 'Button'});
+    const showButton = screen.getByRole('button', {name: 'Button'});
+    await waitFor(() => {
+      fireEvent.click(showButton);
+    });
+
     const closeButton = screen.getByRole('button', {name: 'close', hidden: true});
     const dialog = screen.getByRole('dialog', {hidden: true});
     const dialogContents = screen.getByTestId('dialog-contents');
@@ -124,7 +128,7 @@ describe('Customization', () => {
     const dialogFooter = screen.getByTestId('dialog-footer');
     const dialogFooterActions = screen.getByTestId('dialog-footer-actions');
 
-    expect(dialogButton.dataset.pasteElement).toEqual('SIDE_MODAL_BUTTON');
+    expect(showButton.dataset.pasteElement).toEqual('SIDE_MODAL_BUTTON');
     expect(closeButton.dataset.pasteElement).toEqual('SIDE_MODAL_HEADER_CLOSE_BUTTON');
     expect(dialogContents.dataset.pasteElement).toEqual('SIDE_MODAL_BODY');
     expect(dialogHeader.dataset.pasteElement).toEqual('SIDE_MODAL_HEADER');
@@ -155,10 +159,9 @@ describe('Customization', () => {
       {wrapper: CustomizationWrapper}
     );
 
-    const dialogButton = screen.getByRole('button', {name: 'Button'});
-
+    const showButton = screen.getByRole('button', {name: 'Button'});
     await waitFor(() => {
-      fireEvent.click(dialogButton);
+      fireEvent.click(showButton);
     });
     const closeButton = screen.getByRole('button', {name: 'close'});
     const closeIcon = closeButton.querySelector('[data-paste-element="SIDE_MODAL_HEADER_CLOSE_ICON"]');
@@ -169,7 +172,7 @@ describe('Customization', () => {
     const dialogFooter = screen.getByTestId('dialog-footer');
     const dialogFooterActions = screen.getByTestId('dialog-footer-actions');
 
-    expect(dialogButton).toHaveStyleRule('background-color', 'rgb(254, 236, 236)');
+    expect(showButton).toHaveStyleRule('background-color', 'rgb(254, 236, 236)');
     expect(dialogHeader).toHaveStyleRule('padding', '1.75rem');
     expect(dialogHeading).toHaveStyleRule('font-size', '1.25rem');
     expect(dialogContents).toHaveStyleRule('background-color', 'rgb(254, 236, 236)');
@@ -184,7 +187,7 @@ describe('Customization', () => {
     expect(dialogFooterActions).toHaveStyleRule('justify-content', 'flex-start');
   });
 
-  it('should set custom element data attributes', () => {
+  it('should set custom element data attributes', async () => {
     render(
       <SideModalContainer>
         <SideModalButton variant="primary" element="FOO_DIALOG_BUTTON">
@@ -206,7 +209,11 @@ describe('Customization', () => {
       </SideModalContainer>
     );
 
-    const dialogButton = screen.getByRole('button', {name: 'Button'});
+    const showButton = screen.getByRole('button', {name: 'Button'});
+    await waitFor(() => {
+      fireEvent.click(showButton);
+    });
+
     const closeButton = screen.getByRole('button', {name: 'close', hidden: true});
     const dialog = screen.getByRole('dialog', {hidden: true});
     const dialogContents = screen.getByTestId('dialog-contents');
@@ -215,7 +222,7 @@ describe('Customization', () => {
     const dialogFooter = screen.getByTestId('dialog-footer');
     const dialogFooterActions = screen.getByTestId('dialog-footer-actions');
 
-    expect(dialogButton.dataset.pasteElement).toEqual('FOO_DIALOG_BUTTON');
+    expect(showButton.dataset.pasteElement).toEqual('FOO_DIALOG_BUTTON');
     expect(closeButton.dataset.pasteElement).toEqual('FOO_DIALOG_HEADER_CLOSE_BUTTON');
     expect(dialogContents.dataset.pasteElement).toEqual('FOO_DIALOG_BODY');
     expect(dialogHeader.dataset.pasteElement).toEqual('FOO_DIALOG_HEADER');

--- a/packages/paste-core/components/side-modal/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/side-modal/__tests__/index.spec.tsx
@@ -35,17 +35,16 @@ describe('SideModal', () => {
       );
 
       const dialogButton = screen.getByRole('button', {name: 'Button'});
-      const dialog = screen.getByRole('dialog', {hidden: true});
-
       expect(dialogButton.getAttribute('aria-haspopup')).toEqual('dialog');
-      expect(dialogButton.getAttribute('aria-controls')).toEqual(dialog.id);
       expect(dialogButton.getAttribute('aria-expanded')).toEqual('false');
 
-      expect(dialog).not.toBeVisible();
       await waitFor(() => {
         fireEvent.click(dialogButton);
       });
-      expect(dialog).toBeVisible();
+
+      const dialog = screen.getByRole('dialog', {hidden: true});
+      expect(dialogButton.getAttribute('aria-controls')).toEqual(dialog.id);
+      expect(dialog).toBeInTheDocument();
     });
 
     it('should render a dialog and toggle visible and minimized with external buttons', async () => {
@@ -53,13 +52,13 @@ describe('SideModal', () => {
 
       const showButton = screen.getByRole('button', {name: 'Open dialog'});
       const closeButton = screen.getByRole('button', {name: 'Close dialog'});
-      const dialog = screen.getByRole('dialog', {hidden: true});
 
-      expect(dialog).not.toBeVisible();
       await waitFor(() => {
         fireEvent.click(showButton);
       });
-      expect(dialog).toBeVisible();
+
+      const dialog = screen.getByRole('dialog', {hidden: true});
+      expect(dialog).toBeInTheDocument();
 
       await waitFor(() => {
         fireEvent.click(closeButton);
@@ -74,13 +73,20 @@ describe('SideModal', () => {
         <SideModalContainer>
           <SideModalButton variant="primary">Button</SideModalButton>
           <SideModal aria-label="My custom dialog">
-            <SideModalHeader>
+            <SideModalHeader data-testid="dialog-header">
               <SideModalHeading>My custom dialog</SideModalHeading>
             </SideModalHeader>
             <SideModalBody>This is a dialog.</SideModalBody>
           </SideModal>
         </SideModalContainer>
       );
+
+      const dialogButton = screen.getByRole('button', {name: 'Button'});
+      await waitFor(() => {
+        fireEvent.click(dialogButton);
+      });
+
+      expect(screen.getByRole('dialog', {hidden: true})).toBeInTheDocument();
 
       const dismissButton = screen.getByRole('button', {name: 'close', hidden: true});
       expect(dismissButton).toBeDefined();

--- a/packages/paste-core/components/side-modal/src/SideModal.tsx
+++ b/packages/paste-core/components/side-modal/src/SideModal.tsx
@@ -12,10 +12,11 @@ const StyledSideModal = React.forwardRef<HTMLDivElement, BoxProps>(({style, ...p
   <Box
     {...safelySpreadBoxProps(props)}
     ref={ref}
-    style={{...style, position: 'fixed'}}
+    style={style}
     boxShadow="shadow"
     width="size80"
     zIndex="zIndex80"
+    position="fixed"
     top="0 !important"
     left="auto !important"
     right="0 !important"
@@ -53,37 +54,39 @@ export const SideModal = React.forwardRef<HTMLDivElement, SideModalProps>(
     const dialog = React.useContext(SideModalContext);
     const transitions = useTransition(dialog.visible, getAnimationStates());
 
-    return (
-      <div>
-        {transitions(
-          (styles, item) =>
-            item && (
-              <NonModalDialogPrimitive
-                {...dialog}
-                {...safelySpreadBoxProps(props)}
-                as={AnimatedStyledSideModal}
-                element={`${element}_CONTAINER`}
-                ref={ref}
-                preventBodyScroll={false}
-                hideOnClickOutside={false}
-                style={styles}
+    /*
+     * The portal from Reakit closes/cleans up before the animation can handle the unmount.
+     * To enable an unmount animation we need to hardcode `visible={true}` on NonModalDialogPrimitive
+     * so that react-spring can manage cleanup. That said, I think it looks better to close instantly.
+     */
+    return transitions((styles, item) => {
+      return (
+        item && (
+          <NonModalDialogPrimitive
+            {...dialog}
+            {...safelySpreadBoxProps(props)}
+            as={AnimatedStyledSideModal}
+            element={`${element}_CONTAINER`}
+            ref={ref}
+            preventBodyScroll={false}
+            hideOnClickOutside={false}
+            style={styles}
+          >
+            <StyledBase>
+              <Box
+                element={element}
+                display="grid"
+                gridTemplateRows="auto 1fr auto"
+                height="100vh"
+                backgroundColor="colorBackgroundBody"
               >
-                <StyledBase>
-                  <Box
-                    element={element}
-                    display="grid"
-                    gridTemplateRows="auto 1fr auto"
-                    height="100vh"
-                    backgroundColor="colorBackgroundBody"
-                  >
-                    {children}
-                  </Box>
-                </StyledBase>
-              </NonModalDialogPrimitive>
-            )
-        )}
-      </div>
-    );
+                {children}
+              </Box>
+            </StyledBase>
+          </NonModalDialogPrimitive>
+        )
+      );
+    });
   }
 );
 

--- a/packages/paste-core/components/side-modal/src/SideModal.tsx
+++ b/packages/paste-core/components/side-modal/src/SideModal.tsx
@@ -37,9 +37,9 @@ const getAnimationStates = (): any => ({
   leave: {opacity: 0, transform: `translateX(100%)`},
   // https://www.react-spring.io/docs/hooks/api
   config: {
-    mass: 0.5,
-    tension: 370,
-    friction: 26,
+    mass: 0.3,
+    tension: 288,
+    friction: 15,
   },
 });
 

--- a/packages/paste-core/components/side-modal/src/SideModal.tsx
+++ b/packages/paste-core/components/side-modal/src/SideModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import type {BoxProps} from '@twilio-paste/box';
+import {useTransition, animated} from '@twilio-paste/animation-library';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import {StyledBase} from '@twilio-paste/theme';
 import {NonModalDialogPrimitive} from '@twilio-paste/non-modal-dialog-primitive';
@@ -11,19 +12,35 @@ const StyledSideModal = React.forwardRef<HTMLDivElement, BoxProps>(({style, ...p
   <Box
     {...safelySpreadBoxProps(props)}
     ref={ref}
-    style={style}
+    style={{...style, position: 'fixed'}}
     boxShadow="shadow"
     width="size80"
     zIndex="zIndex80"
-    transform="none!important"
-    inset="0rem 0rem 0rem auto!important"
+    top="0 !important"
+    left="auto !important"
+    right="0 !important"
+    bottom="0 !important"
     _focus={{
       outline: 'none',
     }}
   />
 ));
-
 StyledSideModal.displayName = 'StyledSideModal';
+
+const AnimatedStyledSideModal = animated(StyledSideModal);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getAnimationStates = (): any => ({
+  from: {opacity: 0, transform: `translateX(100%)`},
+  enter: {opacity: 1, transform: `translateX(0%)`},
+  leave: {opacity: 0, transform: `translateX(100%)`},
+  // https://www.react-spring.io/docs/hooks/api
+  config: {
+    mass: 0.5,
+    tension: 370,
+    friction: 26,
+  },
+});
 
 export interface SideModalProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -34,30 +51,38 @@ export interface SideModalProps extends React.HTMLAttributes<HTMLDivElement> {
 export const SideModal = React.forwardRef<HTMLDivElement, SideModalProps>(
   ({children, element = 'SIDE_MODAL', ...props}, ref) => {
     const dialog = React.useContext(SideModalContext);
+    const transitions = useTransition(dialog.visible, getAnimationStates());
 
     return (
-      <NonModalDialogPrimitive
-        {...dialog}
-        {...safelySpreadBoxProps(props)}
-        as={StyledSideModal}
-        element={`${element}_CONTAINER`}
-        ref={ref}
-        preventBodyScroll={false}
-        hideOnClickOutside={false}
-      >
-        {/* import Paste Theme Based Styles due to portal positioning. */}
-        <StyledBase>
-          <Box
-            element={element}
-            display="grid"
-            gridTemplateRows="auto 1fr auto"
-            height="100vh"
-            backgroundColor="colorBackgroundBody"
-          >
-            {children}
-          </Box>
-        </StyledBase>
-      </NonModalDialogPrimitive>
+      <div>
+        {transitions(
+          (styles, item) =>
+            item && (
+              <NonModalDialogPrimitive
+                {...dialog}
+                {...safelySpreadBoxProps(props)}
+                as={AnimatedStyledSideModal}
+                element={`${element}_CONTAINER`}
+                ref={ref}
+                preventBodyScroll={false}
+                hideOnClickOutside={false}
+                style={styles}
+              >
+                <StyledBase>
+                  <Box
+                    element={element}
+                    display="grid"
+                    gridTemplateRows="auto 1fr auto"
+                    height="100vh"
+                    backgroundColor="colorBackgroundBody"
+                  >
+                    {children}
+                  </Box>
+                </StyledBase>
+              </NonModalDialogPrimitive>
+            )
+        )}
+      </div>
     );
   }
 );

--- a/packages/paste-core/components/side-modal/src/SideModalContainer.tsx
+++ b/packages/paste-core/components/side-modal/src/SideModalContainer.tsx
@@ -1,21 +1,18 @@
 import * as React from 'react';
 import type {
-  NonModalDialogPrimitiveStateReturn,
+  NonModalDialogPrimitiveStateReturn as SideModalStateReturn,
   NonModalDialogPrimitivePopoverInitialState,
 } from '@twilio-paste/non-modal-dialog-primitive';
 import {useNonModalDialogPrimitiveState} from '@twilio-paste/non-modal-dialog-primitive';
 
 import {SideModalContext} from './SideModalContext';
 
-export interface SideModalStateReturn extends NonModalDialogPrimitiveStateReturn {
-  [key: string]: any;
-}
-export interface SideModalContainerProps extends NonModalDialogPrimitivePopoverInitialState {
+interface SideModalContainerProps extends NonModalDialogPrimitivePopoverInitialState {
   children: NonNullable<React.ReactNode>;
   state?: SideModalStateReturn;
 }
 
-const BaseSideModalContainer: React.FC<React.PropsWithChildren<SideModalContainerProps>> = ({
+const BaseSideModalContainer: React.FC<SideModalContainerProps> = ({
   gutter,
   children,
   placement,
@@ -36,8 +33,7 @@ const BaseSideModalContainer: React.FC<React.PropsWithChildren<SideModalContaine
 BaseSideModalContainer.displayName = 'BaseSideModalContainer';
 
 const SideModalContainer = React.memo(BaseSideModalContainer);
-
 SideModalContainer.displayName = 'SideModalContainer';
-export {SideModalContainer};
 
-export {useNonModalDialogPrimitiveState as useSideModalState} from '@twilio-paste/non-modal-dialog-primitive';
+export type {SideModalStateReturn, SideModalContainerProps};
+export {SideModalContainer};

--- a/packages/paste-core/components/side-modal/src/index.tsx
+++ b/packages/paste-core/components/side-modal/src/index.tsx
@@ -1,3 +1,4 @@
+export {useNonModalDialogPrimitiveState as useSideModalState} from '@twilio-paste/non-modal-dialog-primitive';
 export * from './SideModal';
 export * from './SideModalButton';
 export * from './SideModalHeader';


### PR DESCRIPTION
Currently passing  an `animated` prop to the `useSideModalState` hook does not allow the modal to close. [See this bug reproduction](https://codesandbox.io/s/new-pine-83hx99?file=/src/index.tsx)

Originally reported via discussion here: https://github.com/twilio-labs/paste/discussions/2839

Let's animate the SideModal ourselves instead so it leverages prefers-reduced-motion properly.