### PR TITLE
feat: add preview for color tokens

### DIFF
--- a/apps/vs-code-intellisense/package.json
+++ b/apps/vs-code-intellisense/package.json
@@ -77,15 +77,19 @@
   },
   "dependencies": {
     "@twilio-paste/design-tokens": "^9.0.2",
+    "base-64": "^1.0.0",
     "lodash.camelcase": "4.3.0",
-    "lodash.kebabcase": "4.1.1"
+    "lodash.kebabcase": "4.1.1",
+    "utf8": "^3.0.0"
   },
   "devDependencies": {
+    "@types/base-64": "^1.0.0",
     "@types/glob": "^8.1.0",
     "@types/lodash.camelcase": "^4.3.7",
     "@types/lodash.kebabcase": "^4.1.7",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.13",
+    "@types/utf8": "^3.0.1",
     "@types/vscode": "^1.68.0",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",

--- a/apps/vs-code-intellisense/src/extension.ts
+++ b/apps/vs-code-intellisense/src/extension.ts
@@ -6,7 +6,9 @@ import kebabCase from 'lodash.kebabcase';
 
 import {pasteTokenAttributes} from './tokens';
 import {PasteToken} from './types';
-import {getThemeSetting, getThemeTokens, remToPx} from './utils';
+import {getColorPreview, getThemeSetting, getThemeTokens, remToPx, isColorCategory} from './utils';
+
+const DIVIDER = `___\n`;
 
 export function findPasteToken(word?: string): PasteToken | undefined {
   if (!word) {
@@ -78,16 +80,20 @@ export function activate(context: vscode.ExtensionContext) {
 
         const hoverMessage = new vscode.MarkdownString();
 
-        const {name, value, comment} = foundPasteToken;
+        const {name, value, comment, category} = foundPasteToken;
 
         // Run any formatters/converters on value before appending
         const formattedValue = remToPx(value);
 
-        hoverMessage.appendMarkdown(`${name}: \`${formattedValue}\`\n`);
-        hoverMessage.appendMarkdown(`___\n`);
+        hoverMessage.appendMarkdown(`${name}: \`${formattedValue}\`\n`).appendMarkdown(DIVIDER);
 
         if (comment) {
           hoverMessage.appendMarkdown(`${comment}\n`);
+        }
+
+        if (isColorCategory(category)) {
+          const preview = getColorPreview(value);
+          hoverMessage.appendMarkdown(DIVIDER).appendMarkdown(preview);
         }
 
         hoverMessage.isTrusted = true;

--- a/apps/vs-code-intellisense/src/test/runTest.ts
+++ b/apps/vs-code-intellisense/src/test/runTest.ts
@@ -15,7 +15,7 @@ async function main() {
     // Download VS Code, unzip it and run the integration test
     await runTests({extensionDevelopmentPath, extensionTestsPath});
   } catch (err) {
-    console.error('Failed to run tests');
+    console.error('Failed to run tests', err);
     process.exit(1);
   }
 }

--- a/apps/vs-code-intellisense/src/test/suite/utils/is-color-category.test.ts
+++ b/apps/vs-code-intellisense/src/test/suite/utils/is-color-category.test.ts
@@ -1,0 +1,34 @@
+import assert from 'assert';
+
+import {isColorCategory} from '../../../utils/is-color-category';
+import {TokenCategory} from '../../../types';
+
+const COLOR_CATEGORIES: TokenCategory[] = ['border-color', 'background-color', 'color', 'text-color'];
+
+const NON_COLOR_CATEGORIES: TokenCategory[] = [
+  'radius',
+  'border-width',
+  'box-shadow',
+  'data-visualization',
+  'font',
+  'font-size',
+  'font-weight',
+  'line-height',
+  'sizing',
+  'spacing',
+  'z-index',
+];
+
+suite('isColorCategory', () => {
+  COLOR_CATEGORIES.forEach((category) => {
+    test(`should return true for ${category}`, () => {
+      assert.strictEqual(true, isColorCategory(category));
+    });
+  });
+
+  NON_COLOR_CATEGORIES.forEach((category) => {
+    test(`should return false for ${category}`, () => {
+      assert.strictEqual(false, isColorCategory(category));
+    });
+  });
+});

--- a/apps/vs-code-intellisense/src/utils/get-color-preview.ts
+++ b/apps/vs-code-intellisense/src/utils/get-color-preview.ts
@@ -1,0 +1,23 @@
+import * as base64 from 'base-64';
+import * as utf8 from 'utf8';
+
+const HEIGHT = 50;
+const WIDTH = '100%';
+
+/**
+ * Generates markdown to render an svg of the provided color
+ * @see https://github.com/mattbierner/vscode-color-info/blob/cf3b476920ec9bf3bee061c4901f352010afcc89/src/displays/preview_display.ts#L19-L29
+ */
+export const getColorPreview = (value: string): string => {
+  const src = `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" style="background-color: white;"
+	 width="${WIDTH}" height="${HEIGHT}px" viewBox="0 0 ${WIDTH} ${HEIGHT}" xml:space="preserve">
+        <rect width="${WIDTH}" height="${HEIGHT}" fill="${value}" fill-opacity="1" />
+        <polygon points="0,0 ${WIDTH},0 ${WIDTH},${HEIGHT}" fill="${value}" />
+        <rect width="${WIDTH}" height="${HEIGHT}" fill-opacity="0" stroke="gray" strokeWidth="1" />
+</svg>`;
+  const dataUri = `data:image/svg+xml;charset=UTF-8;base64,${base64.encode(utf8.encode(src))}`;
+  return `![](${dataUri})`;
+};

--- a/apps/vs-code-intellisense/src/utils/index.ts
+++ b/apps/vs-code-intellisense/src/utils/index.ts
@@ -1,3 +1,5 @@
+export * from './get-color-preview';
 export * from './get-theme-setting';
 export * from './get-theme-tokens';
+export * from './is-color-category';
 export * from './rem-to-px';

--- a/apps/vs-code-intellisense/src/utils/is-color-category.ts
+++ b/apps/vs-code-intellisense/src/utils/is-color-category.ts
@@ -1,0 +1,4 @@
+import {TokenCategory} from '../types';
+
+export const isColorCategory = (category: TokenCategory): boolean =>
+  category === 'background-color' || category === 'border-color' || category === 'color' || category === 'text-color';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13460,6 +13460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/base-64@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@types/base-64@npm:1.0.0"
+  checksum: bcb1b52b404a0a6e3cfdefab6d2eb04a0a23dd3881890944f56e0885866b97e8b7e13988b2fd74359a1258b68c7e399d58c0e2aaed3f03fcd801af62a0040ee2
+  languageName: node
+  linkType: hard
+
 "@types/body-parser@npm:*":
   version: 1.19.2
   resolution: "@types/body-parser@npm:1.19.2"
@@ -14575,6 +14582,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/unist@npm:2.0.3"
   checksum: 4427306b094561da28164e7e5250c4e6b382cb8eac40bf7e6bb0ff1e6e00c13e47aaf32e4a08fc8ba54602d07f79a39fb9ba304cc9dc886b1e3caf824649edbd
+  languageName: node
+  linkType: hard
+
+"@types/utf8@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/utf8@npm:3.0.1"
+  checksum: d6f0de86a1bb025e876d896fc0c1120aea2989986c862c979968558ee4c668c0c785e574bff59348afc060c8860d621bbe8c6d81c4a71782fc5044de9025aa6b
   languageName: node
   linkType: hard
 
@@ -17498,6 +17512,13 @@ __metadata:
   version: 1.0.0
   resolution: "balanced-match@npm:1.0.0"
   checksum: 9b67bfe558772f40cf743a3469b48b286aecec2ea9fe80c48d74845e53aab1cef524fafedf123a63019b49ac397760573ef5f173f539423061f7217cbb5fbd40
+  languageName: node
+  linkType: hard
+
+"base-64@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "base-64@npm:1.0.0"
+  checksum: d10b64a1fc9b2c5a5f39f1ce1e6c9d1c5b249222bbfa3a0604c592d90623caf74419983feadd8a170f27dc0c3389704f72faafa3e645aeb56bfc030c93ff074a
   languageName: node
   linkType: hard
 
@@ -43214,6 +43235,13 @@ typescript@^4.9.4:
   languageName: node
   linkType: hard
 
+"utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "utf8@npm:3.0.0"
+  checksum: cb89a69ad9ab393e3eae9b25305b3ff08bebca9adc839191a34f90777eb2942f86a96369d2839925fea58f8f722f7e27031d697f10f5f39690f8c5047303e62d
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -43612,15 +43640,18 @@ typescript@^4.9.4:
   resolution: "vs-code-intellisense@workspace:apps/vs-code-intellisense"
   dependencies:
     "@twilio-paste/design-tokens": ^9.0.2
+    "@types/base-64": ^1.0.0
     "@types/glob": ^8.1.0
     "@types/lodash.camelcase": ^4.3.7
     "@types/lodash.kebabcase": ^4.1.7
     "@types/mocha": ^10.0.1
     "@types/node": ^18.11.13
+    "@types/utf8": ^3.0.1
     "@types/vscode": ^1.68.0
     "@typescript-eslint/eslint-plugin": ^5.46.0
     "@typescript-eslint/parser": ^5.46.0
     "@vscode/test-electron": ^2.1.5
+    base-64: ^1.0.0
     esbuild: ^0.15.18
     eslint: ^8.29.0
     glob: ^8.0.3
@@ -43628,6 +43659,7 @@ typescript@^4.9.4:
     lodash.kebabcase: 4.1.1
     mocha: ^10.0.0
     typescript: ^4.9.4
+    utf8: ^3.0.0
     vsce: ^2.15.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This PR introduces a preview functionality for color tokens in the VS Code extension. It is based off of another VS Code extension: https://github.com/mattbierner/vscode-color-info

![image](https://user-images.githubusercontent.com/11774799/231490259-709cce1c-4eb6-46bc-a08a-a3856d1653c8.png)
![image](https://user-images.githubusercontent.com/11774799/231490310-d2b6a29f-8258-488e-99ea-7a8691045698.png)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
