### PR TITLE
feat(aliases): add new secondary brand colors

### DIFF
--- a/packages/paste-design-tokens/tokens/aliases/color.yml
+++ b/packages/paste-design-tokens/tokens/aliases/color.yml
@@ -1,5 +1,8 @@
 aliases:
   amaranth: "#F22F46"
   amaranth-transparent-10: "rgba(242, 47, 70, 0.1)"
+  mint: "#6ADDB2"
   black: "#000000"
+  saffron: "#F2BE5A"
+  sky: "#51A9E3"
   white: "#FFFFFF"


### PR DESCRIPTION
Add new secondary brand colors: https://www.twilio.com/brand/elements/colorresources#Secondary_palette

Amaranth already exists, and paper exists as orange-05. This PR adds only saffron, mint, and sky