### PR TITLE
fix(code-block): add default story to fix broken Storybook link on doc page

### DIFF
--- a/packages/paste-core/components/code-block/stories/index.stories.tsx
+++ b/packages/paste-core/components/code-block/stories/index.stories.tsx
@@ -148,3 +148,5 @@ export const CustomCopyFormatter: StoryFn = () => (
     }}
   />
 );
+
+export const Default: StoryFn = MultiLine;


### PR DESCRIPTION


<!-- Describe your Pull Request -->

Hey team! Travis noticed the [Storybook link](https://paste-storybook.twilio.design/?path=/story/components-code-block--default) for the [Code Block](https://paste.twilio.design/components/code-block) was broken. I exported a story named 'Default' which should fix it, or we could update the link to point to `--multi-line` instead of `--default`. Let me know if you'd prefer that!

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/11774799/232119377-27fed6e5-0a94-4ba5-80ff-24afa7c57b6d.png">

 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
