### PR TITLE
chore: replace deprecated extension and call playwright cache after install

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -299,6 +299,10 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Install Dependencies
+        if: steps.yarn_cache_id.outputs.cache-hit != 'true' || steps.node_modules_cache_id.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
       - name: Get playwright version
         id: pw-version
         run: echo "version=$(yarn playwright --version)" >> $GITHUB_OUTPUT
@@ -309,10 +313,6 @@ jobs:
         with:
           path: "~/.cache/ms-playwright"
           key: cache-playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
-
-      - name: Install Dependencies
-        if: steps.yarn_cache_id.outputs.cache-hit != 'true' || steps.node_modules_cache_id.outputs.cache-hit != 'true'
-        run: yarn install --immutable
 
       - name: Build packages
         run: yarn build

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "silvenon.mdx",
+    "unifiedjs.vscode-mdx",
     "styled-components.vscode-styled-components",
     "eamodio.gitlens",
     "patbenatar.advanced-new-file",


### PR DESCRIPTION
## Changes in this PR:

### Fix the storybook test runner flake

When we change the lockfile we cause the test runner tests to break, becuase we try to find out the version number of playwright before its installed and there is no cache. Install first, and then theoretically there should always be a version number regardless of cache invalidation.

### Replace deprecated vscode extension

The MDX extension we recommend is deprecated in favour of the official one, swap in our code base.

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
