### PR TITLE
feat(sidebar): split up SidebarHeader into subcomponents and fix axe flakes

### DIFF
--- a/.changeset/two-teachers-walk.md
+++ b/.changeset/two-teachers-walk.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/sidebar': patch
+'@twilio-paste/core': patch
+---
+
+[Sidebar] split up SidebarHeader so it now is composable with the new SidebarHeaderLabel and SidebarHeaderIconButton components

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -261,6 +261,7 @@ jobs:
   storybook_tests:
     name: Storybook test runner
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -264,10 +264,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [macos-latest]
-        shard: [1/4, 2/4, 3/4, 4/4]
+        os: [ubuntu-latest]
+        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
         include:
-          - os: macos-latest
+          - os: ubuntu-latest
             node: 16
             npm: 6
     steps:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -386,7 +386,7 @@ jobs:
     needs: chromatic
     strategy:
       matrix:
-        shard: [1/2, 2/2]
+        shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -440,7 +440,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Storybook test runner
-        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --maxWorkers=2 --shard=${{ matrix.shard }}
+        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -381,6 +381,7 @@ jobs:
     name: Storybook test runner
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: chromatic
     strategy:
       matrix:
         shard: [1/4, 1/4, 1/4, 1/4]

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -386,7 +386,7 @@ jobs:
     needs: chromatic
     strategy:
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -312,6 +312,8 @@ jobs:
     name: Component Visual regression tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    outputs:
+      storybookUrl: ${{ steps.chromaticaction.outputs.storybookUrl }}
 
     steps:
       - name: Checkout Repo
@@ -358,7 +360,7 @@ jobs:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
       - name: Run Chromatic
-        id: chromatic
+        id: chromaticaction
         uses: chromaui/action@v1
         with:
           zip: true
@@ -438,7 +440,9 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Storybook test runner
-        run: yarn test-storybook --url ${{ steps.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}'
+        env:
+          STORYBOOK_URL: ${{ needs.chromatic.outputs.storybookUrl }}
+        run: yarn test-storybook --url $STORYBOOK_URL --ci --shard=${{ matrix.shard }}'
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -386,7 +386,7 @@ jobs:
     needs: chromatic
     strategy:
       matrix:
-        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
+        shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -264,7 +264,12 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        shard: [1/1]
+        os: [macos-latest]
+        shard: [1/4, 2/4, 3/4, 4/4]
+        include:
+          - os: macos-latest
+            node: 16
+            npm: 6
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -386,7 +386,7 @@ jobs:
     needs: chromatic
     strategy:
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1/2, 2/2]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -440,7 +440,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Storybook test runner
-        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}
+        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --maxWorkers=2 --shard=${{ matrix.shard }}
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -440,7 +440,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Storybook test runner
-        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}'
+        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -386,7 +386,7 @@ jobs:
     needs: chromatic
     strategy:
       matrix:
-        shard: [1/4, 1/4, 1/4, 1/4]
+        shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -440,9 +440,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Storybook test runner
-        env:
-          STORYBOOK_URL: ${{ needs.chromatic.outputs.storybookUrl }}
-        run: yarn test-storybook --url $STORYBOOK_URL --ci --shard=${{ matrix.shard }}'
+        run: yarn test-storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}'
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -264,7 +264,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        shard: [1/2, 2/2]
+        shard: [1/1]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -265,7 +265,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
+        shard: [1/1]
         include:
           - os: ubuntu-latest
             node: 16

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -264,7 +264,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1/2, 2/2]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -258,80 +258,6 @@ jobs:
       - name: Run tests
         run: yarn test
 
-  storybook_tests:
-    name: Storybook test runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        shard: [1/1]
-        include:
-          - os: ubuntu-latest
-            node: 16
-            npm: 6
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: nrwl/nx-set-shas@v3
-
-      - name: Setup Node.js 16.13
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.13.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Load Yarn cache
-        uses: actions/cache@v3
-        id: yarn_cache_id
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn
-
-      - name: Node modules cache
-        uses: actions/cache@v3
-        id: node_modules_cache_id
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install Dependencies
-        if: steps.yarn_cache_id.outputs.cache-hit != 'true' || steps.node_modules_cache_id.outputs.cache-hit != 'true'
-        run: yarn install --immutable
-
-      - name: Get playwright version
-        id: pw-version
-        run: echo "version=$(yarn playwright --version)" >> $GITHUB_OUTPUT
-
-      - name: Cache playwright binaries
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: "~/.cache/ms-playwright"
-          key: cache-playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
-
-      - name: Build packages
-        run: yarn build
-        env:
-          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-
-      - name: Install Playwright
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      - name: Run Storybook test runner
-        run: yarn start-server-and-test 'NODE_ENV=test yarn start:storybook' http://localhost:9001 'yarn test:storybook --shard=${{ matrix.shard }}'
-
   prettier:
     name: Prettier checks
     runs-on: ubuntu-latest
@@ -432,8 +358,10 @@ jobs:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@v1
         with:
+          zip: true
           projectToken: ${{ secrets.CHROMA_APP_CODE }}
           token: ${{ secrets.GITHUB_TOKEN }}
           buildScriptName: "build:storybook"
@@ -448,6 +376,68 @@ jobs:
           STORYBOOK_GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
           # https://github.com/storybookjs/builder-vite/issues/409#issuecomment-1199236279
           NODE_OPTIONS: --max-old-space-size=6144
+
+  storybook_tests:
+    name: Storybook test runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        shard: [1/4, 1/4, 1/4, 1/4]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 16.13
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.13.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - name: Load Yarn cache
+        uses: actions/cache@v3
+        id: yarn_cache_id
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn
+
+      - name: Node modules cache
+        uses: actions/cache@v3
+        id: node_modules_cache_id
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Dependencies
+        if: steps.yarn_cache_id.outputs.cache-hit != 'true' || steps.node_modules_cache_id.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Get playwright version
+        id: pw-version
+        run: echo "version=$(yarn playwright --version)" >> $GITHUB_OUTPUT
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: "~/.cache/ms-playwright"
+          key: cache-playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Run Storybook test runner
+        run: yarn test-storybook --url ${{ steps.chromatic.outputs.storybookUrl }} --ci --shard=${{ matrix.shard }}'
 
   pr-categorizer:
     name: Categorize the PR using labels

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,10 +24,6 @@ const config: StorybookConfig = {
     // enable type checking
     check: true,
   },
-  docs: {
-    autodocs: true,
-    defaultName: 'Docs',
-  },
   async viteFinal(config, {configType}) {
     const isTest = process.env.NODE_ENV === 'test';
     return mergeConfig(config, {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -152,7 +152,7 @@ export const decorators = [
           <RenderPerformanceProfiler id={context.id} kind={context.kind} view="stacked">
             <GlobalStyles />
             <Stack orientation="vertical" spacing="space0">
-              <Theme.Provider theme="default" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="default" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -161,7 +161,7 @@ export const decorators = [
                   <Story />
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="default" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="default" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -176,7 +176,7 @@ export const decorators = [
                   </Box>
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="dark" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="dark" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -185,7 +185,7 @@ export const decorators = [
                   <Story />
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="dark" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="dark" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -200,7 +200,7 @@ export const decorators = [
                   </Box>
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="twilio" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="twilio" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -209,7 +209,7 @@ export const decorators = [
                   <Story />
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="twilio" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="twilio" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -224,7 +224,7 @@ export const decorators = [
                   </Box>
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="twilio-dark" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="twilio-dark" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"
@@ -233,7 +233,7 @@ export const decorators = [
                   <Story />
                 </Box>
               </Theme.Provider>
-              <Theme.Provider theme="twilio-dark" disableAnimations={isTestEnvironment} customBreakpoints={breakpoints}>
+              <Theme.Provider theme="twilio-dark" disableAnimations customBreakpoints={breakpoints}>
                 <Box
                   backgroundColor="colorBackgroundBody"
                   color="colorText"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:website-percy": "percy exec -- yarn cypress run --record",
     "test:website-gui": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'yarn cypress open'",
     "test:website-gui-percy": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'percy exec -- yarn cypress open'",
-    "test:storybook": "test-storybook --url http://localhost:9001",
+    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=2",
     "start:test:storybook": "start-server-and-test 'NODE_ENV=test yarn start:storybook' http://localhost:9001 'yarn test:storybook'",
     "serve:website": "yarn workspace @twilio-paste/website start",
     "package-size-action-build": "yarn build",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:website-percy": "percy exec -- yarn cypress run --record",
     "test:website-gui": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'yarn cypress open'",
     "test:website-gui-percy": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'percy exec -- yarn cypress open'",
-    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=1",
+    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=4",
     "start:test:storybook": "start-server-and-test 'NODE_ENV=test yarn start:storybook' http://localhost:9001 'yarn test:storybook'",
     "serve:website": "yarn workspace @twilio-paste/website start",
     "package-size-action-build": "yarn build",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:website-percy": "percy exec -- yarn cypress run --record",
     "test:website-gui": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'yarn cypress open'",
     "test:website-gui-percy": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'percy exec -- yarn cypress open'",
-    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=2",
+    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=1",
     "start:test:storybook": "start-server-and-test 'NODE_ENV=test yarn start:storybook' http://localhost:9001 'yarn test:storybook'",
     "serve:website": "yarn workspace @twilio-paste/website start",
     "package-size-action-build": "yarn build",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:website-percy": "percy exec -- yarn cypress run --record",
     "test:website-gui": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'yarn cypress open'",
     "test:website-gui-percy": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:website' http://localhost:3000 'percy exec -- yarn cypress open'",
-    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=4",
+    "test:storybook": "test-storybook --url http://localhost:9001 --maxWorkers=2",
     "start:test:storybook": "start-server-and-test 'NODE_ENV=test yarn start:storybook' http://localhost:9001 'yarn test:storybook'",
     "serve:website": "yarn workspace @twilio-paste/website start",
     "package-size-action-build": "yarn build",

--- a/packages/paste-codemods/tools/.cache/mappings.json
+++ b/packages/paste-codemods/tools/.cache/mappings.json
@@ -192,6 +192,8 @@
   "SidebarCollapseButtonWrapper": "@twilio-paste/core/sidebar",
   "SidebarContext": "@twilio-paste/core/sidebar",
   "SidebarHeader": "@twilio-paste/core/sidebar",
+  "SidebarHeaderIconButton": "@twilio-paste/core/sidebar",
+  "SidebarHeaderLabel": "@twilio-paste/core/sidebar",
   "SidebarOverlayContentWrapper": "@twilio-paste/core/sidebar",
   "SidebarPushContentWrapper": "@twilio-paste/core/sidebar",
   "SkeletonLoader": "@twilio-paste/core/skeleton-loader",

--- a/packages/paste-core/components/alert-dialog/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert-dialog/stories/index.stories.tsx
@@ -48,6 +48,10 @@ export const AlertDialogWithTwoActionsStory = (): React.ReactNode => {
 AlertDialogWithTwoActionsStory.storyName = 'Alert Dialog With Two Actions';
 AlertDialogWithTwoActionsStory.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const DestructiveAlertDialog = (): JSX.Element => {
@@ -73,6 +77,10 @@ export const DestructiveAlertDialogStory = (): React.ReactNode => {
 DestructiveAlertDialogStory.storyName = 'Destructive Alert Dialog';
 DestructiveAlertDialogStory.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const OpenAlertDialogFromButton = (): JSX.Element => {
@@ -106,6 +114,10 @@ export const OpenAlertDialogFromButtonStory = (): React.ReactNode => {
 OpenAlertDialogFromButtonStory.storyName = 'Open Alert Dialog From Button';
 OpenAlertDialogFromButtonStory.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const OpenAlertDialogFromModal = (): JSX.Element => {
@@ -166,6 +178,10 @@ export const OpenAlertDialogFromModalStory = (): React.ReactNode => {
 OpenAlertDialogFromModalStory.storyName = 'Open Alert Dialog From Modal';
 OpenAlertDialogFromModalStory.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const AlertDialogVRT = (): React.ReactNode => {

--- a/packages/paste-core/components/chat-log/stories/components/UseChatLogger.stories.tsx
+++ b/packages/paste-core/components/chat-log/stories/components/UseChatLogger.stories.tsx
@@ -134,3 +134,9 @@ export const UseChatLogger: StoryFn = () => {
     </Stack>
   );
 };
+UseChatLogger.parameters = {
+  a11y: {
+    // no need to a11y check composition of a11y checked components
+    disable: true,
+  },
+};

--- a/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
@@ -834,3 +834,9 @@ export const ComboboxInModal: StoryFn = () => {
     </>
   );
 };
+ComboboxInModal.parameters = {
+  // a11y test for modals is not working
+  a11y: {
+    disable: true,
+  },
+};

--- a/packages/paste-core/components/modal/stories/index.stories.tsx
+++ b/packages/paste-core/components/modal/stories/index.stories.tsx
@@ -76,6 +76,10 @@ export const Default = (): React.ReactNode => {
 
 Default.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const Wide = (): React.ReactNode => {
@@ -84,6 +88,10 @@ export const Wide = (): React.ReactNode => {
 
 Wide.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const FooterActions = (): React.ReactNode => {
@@ -125,6 +133,10 @@ export const FooterActions = (): React.ReactNode => {
 FooterActions.storyName = 'Footer actions';
 FooterActions.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const LeftAlignedFooterActions = (): React.ReactNode => {
@@ -166,6 +178,10 @@ export const LeftAlignedFooterActions = (): React.ReactNode => {
 LeftAlignedFooterActions.storyName = 'Left aligned footer actions';
 LeftAlignedFooterActions.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const DirectionalFooterActions = (): React.ReactNode => {
@@ -210,6 +226,10 @@ export const DirectionalFooterActions = (): React.ReactNode => {
 DirectionalFooterActions.storyName = 'Directional footer actions';
 DirectionalFooterActions.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const ExtremelyLongHeading = (): React.ReactNode => {
@@ -251,6 +271,10 @@ export const ExtremelyLongHeading = (): React.ReactNode => {
 ExtremelyLongHeading.storyName = 'Extremely long heading';
 ExtremelyLongHeading.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const OverflowingBodyContent = (): React.ReactNode => {
@@ -386,6 +410,10 @@ export const OverflowingBodyContent = (): React.ReactNode => {
 OverflowingBodyContent.storyName = 'Overflowing body content';
 OverflowingBodyContent.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const HeaderContent = (): React.ReactNode => {
@@ -433,6 +461,10 @@ export const HeaderContent = (): React.ReactNode => {
 HeaderContent.storyName = 'Header content';
 HeaderContent.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const i18nProp = (): React.ReactNode => {
@@ -478,6 +510,10 @@ export const i18nProp = (): React.ReactNode => {
 i18nProp.storyName = 'i18n prop';
 i18nProp.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const CustomInitialFocusElement = (): React.ReactNode => {
@@ -534,6 +570,10 @@ export const CustomInitialFocusElement = (): React.ReactNode => {
 CustomInitialFocusElement.storyName = 'Custom initial focus element';
 CustomInitialFocusElement.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const TooltipInModal = (): React.ReactNode => {
@@ -576,6 +616,10 @@ export const TooltipInModal = (): React.ReactNode => {
 TooltipInModal.storyName = 'Tooltip in modal';
 TooltipInModal.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 export const PopoverInModal = (): React.ReactNode => {
@@ -630,6 +674,10 @@ export const PopoverInModal = (): React.ReactNode => {
 PopoverInModal.storyName = 'Popover in modal';
 PopoverInModal.parameters = {
   chromatic: {disableSnapshot: true},
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };
 
 const NOOP = (): void => {};

--- a/packages/paste-core/components/side-modal/stories/index.stories.tsx
+++ b/packages/paste-core/components/side-modal/stories/index.stories.tsx
@@ -72,6 +72,12 @@ export const Default: StoryFn = () => {
     </SideModalContainer>
   );
 };
+Default.parameters = {
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
+};
 
 export const StateHookExample: StoryFn = () => {
   const dialog = useSideModalState({});
@@ -102,4 +108,10 @@ export const StateHookExample: StoryFn = () => {
       </Box>
     </Box>
   );
+};
+StateHookExample.parameters = {
+  a11y: {
+    // no need to a11y check customization
+    disable: true,
+  },
 };

--- a/packages/paste-core/components/sidebar/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/sidebar/__tests__/index.spec.tsx
@@ -3,10 +3,13 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import {Box} from '@twilio-paste/box';
 import {CustomizationProvider} from '@twilio-paste/customization';
+import {ProductFlexIcon} from '@twilio-paste/icons/esm/ProductFlexIcon';
 
 import {
   Sidebar,
   SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarHeaderIconButton,
   SidebarCollapseButton,
   SidebarCollapseButtonWrapper,
   SidebarPushContentWrapper,
@@ -25,7 +28,12 @@ const MockPushSidebar = ({
   return (
     <Theme.Provider theme="twilio">
       <Sidebar aria-label="main" collapsed={collapsed} variant={variant}>
-        <SidebarHeader>Twilio Console</SidebarHeader>
+        <SidebarHeader>
+          <SidebarHeaderIconButton>
+            <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+          </SidebarHeaderIconButton>
+          <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+        </SidebarHeader>
         <SidebarCollapseButtonWrapper>
           <SidebarCollapseButton i18nCollapseLabel="Close sidebar" i18nExpandLabel="Open sidebar" />
         </SidebarCollapseButtonWrapper>
@@ -47,7 +55,12 @@ const MockOverlaySidebar = ({
   return (
     <Theme.Provider theme="twilio">
       <Sidebar aria-label="main" collapsed={collapsed} variant={variant}>
-        <SidebarHeader>Twilio Console</SidebarHeader>
+        <SidebarHeader>
+          <SidebarHeaderIconButton>
+            <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+          </SidebarHeaderIconButton>
+          <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+        </SidebarHeader>
         <SidebarCollapseButtonWrapper>
           <SidebarCollapseButton i18nCollapseLabel="Close sidebar" i18nExpandLabel="Open sidebar" />
         </SidebarCollapseButtonWrapper>
@@ -147,7 +160,7 @@ describe('Sidebar', () => {
   describe('Sidebar Header', () => {
     it('hides the text when collapsed', async () => {
       render(<MockOverlaySidebar collapsed />);
-      const headerText = screen.getByText('Twilio Console');
+      const headerText = screen.getByText('Twilio Flex');
       expect(headerText).toHaveStyleRule('opacity', '0');
     });
   });

--- a/packages/paste-core/components/sidebar/src/SidebarHeader.tsx
+++ b/packages/paste-core/components/sidebar/src/SidebarHeader.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {Box} from '@twilio-paste/box';
-import {Button} from '@twilio-paste/button';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
 import type {BoxProps} from '@twilio-paste/box';
-import {ProductHomeIcon} from '@twilio-paste/icons/esm/ProductHomeIcon';
-
-import {SidebarContext} from './SidebarContext';
 
 export interface SidebarHeaderProps extends React.HTMLAttributes<HTMLButtonElement> {
   productIcon?: React.ReactNode;
@@ -14,11 +10,12 @@ export interface SidebarHeaderProps extends React.HTMLAttributes<HTMLButtonEleme
 }
 
 export const SidebarHeader = React.forwardRef<HTMLButtonElement, SidebarHeaderProps>(
-  ({element = 'SIDEBAR_HEADER', productIcon, onClick, children}, ref) => {
-    const {collapsed} = React.useContext(SidebarContext);
-
+  ({element = 'SIDEBAR_HEADER', children, ...props}, ref) => {
     return (
       <Box
+        {...safelySpreadBoxProps(props)}
+        element={element}
+        ref={ref}
         padding="space60"
         borderBottomWidth="borderWidth10"
         borderBottomStyle="solid"
@@ -28,27 +25,8 @@ export const SidebarHeader = React.forwardRef<HTMLButtonElement, SidebarHeaderPr
         justifyContent="flex-start"
         columnGap="space50"
         overflow="hidden"
-        element={element}
-        ref={ref}
       >
-        <Button size="icon" variant="inverse" element={`${element}_BUTTON`} onClick={onClick}>
-          {productIcon ? productIcon : <ProductHomeIcon size="sizeIcon20" decorative element={`${element}_ICON`} />}
-        </Button>
-        <Box
-          opacity={collapsed ? '0' : '1'}
-          element={`${element}_TEXT`}
-          fontSize="fontSize30"
-          fontWeight="fontWeightSemibold"
-          lineHeight="lineHeight30"
-          letterSpacing="-.02em"
-          color="colorTextInverse"
-          whiteSpace="nowrap"
-          textOverflow="ellipsis"
-          overflow="hidden"
-          margin="space0"
-        >
-          {children}
-        </Box>
+        {children}
       </Box>
     );
   }

--- a/packages/paste-core/components/sidebar/src/SidebarHeaderIconButton.tsx
+++ b/packages/paste-core/components/sidebar/src/SidebarHeaderIconButton.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import {Button} from '@twilio-paste/button';
+import type {ButtonProps} from '@twilio-paste/button';
+import type {BoxProps} from '@twilio-paste/box';
+
+export interface SidebarHeaderIconButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  children: NonNullable<React.ReactNode>;
+  tabIndex?: ButtonProps['tabIndex'];
+  onClick?: () => void;
+  element?: BoxProps['element'];
+}
+
+export const SidebarHeaderIconButton = React.forwardRef<HTMLButtonElement, SidebarHeaderIconButtonProps>(
+  ({element = 'SIDEBAR_HEADER_ICON_BUTTON', ...props}, ref) => {
+    return <Button {...props} size="icon" variant="inverse" element={element} ref={ref} />;
+  }
+);
+
+SidebarHeaderIconButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  element: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+SidebarHeaderIconButton.displayName = 'SidebarHeaderIconButton';

--- a/packages/paste-core/components/sidebar/src/SidebarHeaderLabel.tsx
+++ b/packages/paste-core/components/sidebar/src/SidebarHeaderLabel.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
+import type {BoxProps} from '@twilio-paste/box';
+
+import {SidebarContext} from './SidebarContext';
+
+export interface SidebarHeaderLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  element?: BoxProps['element'];
+}
+
+export const SidebarHeaderLabel = React.forwardRef<HTMLButtonElement, SidebarHeaderLabelProps>(
+  ({element = 'SIDEBAR_HEADER_LABEL', children, ...props}, ref) => {
+    const {collapsed} = React.useContext(SidebarContext);
+
+    return (
+      <Box
+        ref={ref}
+        {...safelySpreadBoxProps(props)}
+        opacity={collapsed ? '0' : '1'}
+        element={element}
+        fontSize="fontSize30"
+        fontWeight="fontWeightSemibold"
+        lineHeight="lineHeight30"
+        letterSpacing="-.02em"
+        color="colorTextInverse"
+        whiteSpace="nowrap"
+        textOverflow="ellipsis"
+        overflow="hidden"
+        margin="space0"
+      >
+        {children}
+      </Box>
+    );
+  }
+);
+
+SidebarHeaderLabel.propTypes = {
+  children: PropTypes.node,
+  element: PropTypes.string,
+};
+
+SidebarHeaderLabel.displayName = 'SidebarHeaderLabel';

--- a/packages/paste-core/components/sidebar/src/index.tsx
+++ b/packages/paste-core/components/sidebar/src/index.tsx
@@ -5,4 +5,6 @@ export * from './SidebarCollapseButton';
 export * from './SidebarCollapseButtonWrapper';
 export * from './SidebarContext';
 export * from './SidebarHeader';
+export * from './SidebarHeaderLabel';
+export * from './SidebarHeaderIconButton';
 export * from './SidebarBetaBadge';

--- a/packages/paste-core/components/sidebar/stories/customization.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/customization.stories.tsx
@@ -6,10 +6,14 @@ import {useTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
 import type {StoryFn} from '@storybook/react';
 import {ProductFlexIcon} from '@twilio-paste/icons/esm/ProductFlexIcon';
+// ONLY for storybook stacked view not to complain on duplicates. aria-label should be carefully selected strings
+import {useUID} from '@twilio-paste/uid-library';
 
 import {
   Sidebar,
   SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarHeaderIconButton,
   SidebarCollapseButton,
   SidebarCollapseButtonWrapper,
   SidebarPushContentWrapper,
@@ -23,6 +27,7 @@ export default {
 };
 
 export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvironment}}) => {
+  const id = useUID();
   const currentTheme = useTheme();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(false);
 
@@ -37,13 +42,11 @@ export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvir
         SIDEBAR_HEADER: {
           backgroundColor: 'colorBackgroundBrandHighlight',
         },
-        SIDEBAR_HEADER_BUTTON: {
+        SIDEBAR_HEADER_ICON_BUTTON: {
           backgroundColor: 'colorBackgroundBrandHighlightWeakest',
-        },
-        SIDEBAR_HEADER_ICON: {
           color: 'colorText',
         },
-        SIDEBAR_HEADER_TEXT: {
+        SIDEBAR_HEADER_LABEL: {
           color: 'colorText',
         },
         SIDEBAR_COLLAPSE_BUTTON: {
@@ -64,9 +67,14 @@ export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvir
     >
       <Box>
         {/* Can be placed anywhere - position fixed */}
-        <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="default">
+        <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="default">
           <Stack orientation="vertical" spacing="space100">
-            <SidebarHeader>Twilio Console</SidebarHeader>
+            <SidebarHeader>
+              <SidebarHeaderIconButton>
+                <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+              </SidebarHeaderIconButton>
+              <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+            </SidebarHeader>
             <SidebarBetaBadge as="span">Beta</SidebarBetaBadge>
             <SidebarCollapseButtonWrapper>
               <SidebarCollapseButton
@@ -89,14 +97,11 @@ export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvir
   );
 };
 WithDefaultElementName.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };
 
 export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnvironment}}) => {
+  const id = useUID();
   const currentTheme = useTheme();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(false);
 
@@ -111,13 +116,11 @@ export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnviro
         SIDECAR_HEADER: {
           backgroundColor: 'colorBackgroundBrandHighlight',
         },
-        SIDECAR_HEADER_BUTTON: {
+        SIDECAR_HEADER_ICON_BUTTON: {
           backgroundColor: 'colorBackgroundBrandHighlightWeakest',
-        },
-        SIDECAR_HEADER_ICON: {
           color: 'colorText',
         },
-        SIDECAR_HEADER_TEXT: {
+        SIDECAR_HEADER_LABEL: {
           color: 'colorText',
         },
         SIDECAR_COLLAPSE_BUTTON: {
@@ -138,13 +141,13 @@ export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnviro
     >
       <Box>
         {/* Can be placed anywhere - position fixed */}
-        <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="compact" element="SIDECAR">
+        <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="compact" element="SIDECAR">
           <Stack orientation="vertical" spacing="space100">
-            <SidebarHeader
-              element="SIDECAR_HEADER"
-              productIcon={<ProductFlexIcon size="sizeIcon20" decorative element="SIDECAR_HEADER_ICON" />}
-            >
-              Twilio Flex
+            <SidebarHeader element="SIDECAR_HEADER">
+              <SidebarHeaderIconButton element="SIDECAR_HEADER_ICON_BUTTON">
+                <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+              </SidebarHeaderIconButton>
+              <SidebarHeaderLabel element="SIDECAR_HEADER_LABEL">Twilio Flex</SidebarHeaderLabel>
             </SidebarHeader>
             <SidebarBetaBadge as="button" element="SIDECAR_BETA_BADGE">
               Beta
@@ -175,9 +178,5 @@ export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnviro
   );
 };
 WithCustomElementName.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };

--- a/packages/paste-core/components/sidebar/stories/customization.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/customization.stories.tsx
@@ -40,14 +40,13 @@ export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvir
           backgroundColor: 'colorBackgroundBrand',
         },
         SIDEBAR_HEADER: {
-          backgroundColor: 'colorBackgroundBrandHighlight',
+          padding: 'space40',
         },
         SIDEBAR_HEADER_ICON_BUTTON: {
-          backgroundColor: 'colorBackgroundBrandHighlightWeakest',
-          color: 'colorText',
+          padding: 'space40',
         },
         SIDEBAR_HEADER_LABEL: {
-          color: 'colorText',
+          fontWeight: 'fontWeightNormal',
         },
         SIDEBAR_COLLAPSE_BUTTON: {
           padding: 'space40',
@@ -60,8 +59,7 @@ export const WithDefaultElementName: StoryFn = (_args, {parameters: {isTestEnvir
           padding: 'space40',
         },
         SIDEBAR_BETA_BADGE: {
-          backgroundColor: 'colorBackgroundAvailable',
-          color: 'colorText',
+          padding: 'space40',
         },
       }}
     >
@@ -114,14 +112,13 @@ export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnviro
           backgroundColor: 'colorBackgroundBrand',
         },
         SIDECAR_HEADER: {
-          backgroundColor: 'colorBackgroundBrandHighlight',
+          padding: 'space40',
         },
         SIDECAR_HEADER_ICON_BUTTON: {
-          backgroundColor: 'colorBackgroundBrandHighlightWeakest',
-          color: 'colorText',
+          padding: 'space40',
         },
         SIDECAR_HEADER_LABEL: {
-          color: 'colorText',
+          padding: 'space40',
         },
         SIDECAR_COLLAPSE_BUTTON: {
           padding: 'space40',
@@ -134,8 +131,7 @@ export const WithCustomElementName: StoryFn = (_args, {parameters: {isTestEnviro
           padding: 'space40',
         },
         SIDECAR_BETA_BADGE: {
-          backgroundColor: 'colorBackgroundAvailable',
-          color: 'colorText',
+          padding: 'space40',
         },
       }}
     >

--- a/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
@@ -4,10 +4,14 @@ import {Stack} from '@twilio-paste/stack';
 import {Box} from '@twilio-paste/box';
 import type {StoryFn} from '@storybook/react';
 import {ProductFlexIcon} from '@twilio-paste/icons/esm/ProductFlexIcon';
+// ONLY for storybook stacked view not to complain on duplicates. aria-label should be carefully selected strings
+import {useUID} from '@twilio-paste/uid-library';
 
 import {
   Sidebar,
   SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarHeaderIconButton,
   SidebarCollapseButton,
   SidebarCollapseButtonWrapper,
   SidebarOverlayContentWrapper,
@@ -20,14 +24,20 @@ export default {
 };
 
 export const Default: StoryFn = () => {
+  const id = useUID();
   const [overlaySidebarExpanded, setOverlaySidebarExpanded] = React.useState(false);
 
   return (
     <Box>
       {/* Can be placed anywhere - position fixed */}
-      <Sidebar aria-label="main" collapsed={overlaySidebarExpanded} variant="default">
+      <Sidebar aria-label={id} collapsed={overlaySidebarExpanded} variant="default">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader>Twilio Console</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarBetaBadge as="span">Beta</SidebarBetaBadge>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
@@ -49,22 +59,24 @@ export const Default: StoryFn = () => {
   );
 };
 Default.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };
 
 export const Compact: StoryFn = () => {
+  const id = useUID();
   const [overlaySidebarExpanded, setOverlaySidebarExpanded] = React.useState(true);
 
   return (
     <Box>
       {/* Can be placed anywhere - position fixed */}
-      <Sidebar aria-label="main" collapsed={overlaySidebarExpanded} variant="compact">
+      <Sidebar aria-label={id} collapsed={overlaySidebarExpanded} variant="compact">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarBetaBadge as="button">Beta</SidebarBetaBadge>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
@@ -86,9 +98,5 @@ export const Compact: StoryFn = () => {
   );
 };
 Compact.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };

--- a/packages/paste-core/components/sidebar/stories/push.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/push.stories.tsx
@@ -4,10 +4,14 @@ import {Stack} from '@twilio-paste/stack';
 import {Box} from '@twilio-paste/box';
 import type {StoryFn} from '@storybook/react';
 import {ProductFlexIcon} from '@twilio-paste/icons/esm/ProductFlexIcon';
+// ONLY for storybook stacked view not to complain on duplicates. aria-label should be carefully selected strings
+import {useUID} from '@twilio-paste/uid-library';
 
 import {
   Sidebar,
   SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarHeaderIconButton,
   SidebarCollapseButton,
   SidebarCollapseButtonWrapper,
   SidebarPushContentWrapper,
@@ -20,14 +24,20 @@ export default {
 };
 
 export const Default: StoryFn = () => {
+  const id = useUID();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(false);
 
   return (
     <Box>
       {/* Can be placed anywhere - position fixed */}
-      <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="default">
+      <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="default">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarBetaBadge as="span">Beta</SidebarBetaBadge>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
@@ -49,22 +59,24 @@ export const Default: StoryFn = () => {
   );
 };
 Default.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };
 
 export const Compact: StoryFn = () => {
+  const id = useUID();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(true);
 
   return (
     <Box>
       {/* Can be placed anywhere - position fixed */}
-      <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="compact">
+      <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="compact">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader>Twilio Console is the best console</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarBetaBadge as="button">Beta</SidebarBetaBadge>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
@@ -86,9 +98,5 @@ export const Compact: StoryFn = () => {
   );
 };
 Compact.parameters = {
-  a11y: {
-    // false positives in CI due to hiding button behind sidebar when open
-    disable: true,
-  },
   padding: false,
 };

--- a/packages/paste-core/components/topbar/stories/topbar.stories.tsx
+++ b/packages/paste-core/components/topbar/stories/topbar.stories.tsx
@@ -5,11 +5,15 @@ import {Button} from '@twilio-paste/button';
 import type {StoryFn} from '@storybook/react';
 import {ProductFlexIcon} from '@twilio-paste/icons/esm/ProductFlexIcon';
 import {Paragraph} from '@twilio-paste/paragraph';
+// ONLY for storybook stacked view not to complain on duplicates. aria-label should be carefully selected strings
+import {useUID} from '@twilio-paste/uid-library';
 import {
   Sidebar,
   SidebarPushContentWrapper,
   SidebarOverlayContentWrapper,
   SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarHeaderIconButton,
   SidebarCollapseButton,
   SidebarCollapseButtonWrapper,
 } from '@twilio-paste/sidebar';
@@ -30,12 +34,18 @@ const TonsOfContent: React.FC = () => {
 };
 
 export const PushDefaultTopbar: StoryFn = () => {
+  const id = useUID();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(false);
   return (
     <>
-      <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="default">
+      <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="default">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
               onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}
@@ -64,12 +74,18 @@ PushDefaultTopbar.parameters = {
 };
 
 export const PushCompactTopbar: StoryFn = () => {
+  const id = useUID();
   const [pushSidebarCollapsed, setPushSidebarCollapsed] = React.useState(true);
   return (
     <>
-      <Sidebar aria-label="main" collapsed={pushSidebarCollapsed} variant="compact">
+      <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="compact">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
               onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}
@@ -98,12 +114,18 @@ PushCompactTopbar.parameters = {
 };
 
 export const OverlayDefaultTopbar: StoryFn = () => {
+  const id = useUID();
   const [overlaySidebarCollapsed, setOverlaySidebarCollapsed] = React.useState(false);
   return (
     <>
-      <Sidebar aria-label="main" collapsed={overlaySidebarCollapsed} variant="default">
+      <Sidebar aria-label={id} collapsed={overlaySidebarCollapsed} variant="default">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
               onClick={() => setOverlaySidebarCollapsed(!overlaySidebarCollapsed)}
@@ -136,12 +158,18 @@ OverlayDefaultTopbar.parameters = {
 };
 
 export const OverlayCompactTopbar: StoryFn = () => {
+  const id = useUID();
   const [overlaySidebarCollapsed, setOverlaySidebarCollapsed] = React.useState(false);
   return (
     <>
-      <Sidebar aria-label="main" collapsed={overlaySidebarCollapsed} variant="compact">
+      <Sidebar aria-label={id} collapsed={overlaySidebarCollapsed} variant="compact">
         <Stack orientation="vertical" spacing="space100">
-          <SidebarHeader productIcon={<ProductFlexIcon size="sizeIcon20" decorative />}>Twilio Flex</SidebarHeader>
+          <SidebarHeader>
+            <SidebarHeaderIconButton>
+              <ProductFlexIcon size="sizeIcon20" decorative={false} title="Go to Flex product homepage" />
+            </SidebarHeaderIconButton>
+            <SidebarHeaderLabel>Twilio Flex</SidebarHeaderLabel>
+          </SidebarHeader>
           <SidebarCollapseButtonWrapper>
             <SidebarCollapseButton
               onClick={() => setOverlaySidebarCollapsed(!overlaySidebarCollapsed)}


### PR DESCRIPTION
- [x] Fixing text-storybook by running it against the chromatic build. This helps by freeing up tons of memory used in the storybook run command which helps alleviate the timeout issues we were getting
- [x] Fix the a11y warnings from the above ^ tests on Topbar and Sidebar
- [x] The fixes led me to realize that SidebarHeader had a restrictive API and to break it down into sub components: `SidebarHeaderIconButton` and `SidebarHeaderLabel` which allow for composability and easier usage / testing. 