### PR TITLE
fix: tell nx that the .next directory is a cachable output for netlify build

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -33,7 +33,8 @@
         "{projectRoot}/cjs",
         "{projectRoot}/esm",
         "{projectRoot}/json",
-        "{projectRoot}/types"
+        "{projectRoot}/types",
+        "{projectRoot}/.next"
       ]
     },
     "build:js": {


### PR DESCRIPTION
Noticed that Netlify builds may fail when it relies on a cached build, i.e. nothing changed so it grabs the local cache. It then fails saying it can't find the contents of `.next` and I think that means it didn't actually pull anything from the cache, and that's because we don't tell nx there's anything there to cache.

This should fix it. 🤞🏼 

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
