### PR TITLE
fix(data-grid): improve ts typings and react proptypes

### DIFF
--- a/.changeset/short-gifts-glow.md
+++ b/.changeset/short-gifts-glow.md
@@ -1,0 +1,7 @@
+---
+'@twilio-paste/data-grid': patch
+'@twilio-paste/table': patch
+'@twilio-paste/core': patch
+---
+
+[Table, DataGrid] Typescript type improvements for Tr, Th, and Td elements

--- a/packages/paste-core/components/data-grid/src/DataGridRow.tsx
+++ b/packages/paste-core/components/data-grid/src/DataGridRow.tsx
@@ -7,7 +7,7 @@ import {Tr} from './table/Tr';
 import {DataGridContext} from './DataGridContext';
 
 export interface DataGridRowProps {
-  children?: React.ReactNode;
+  children: NonNullable<React.ReactNode>;
   selected?: boolean;
   element?: BoxElementProps['element'];
 }

--- a/packages/paste-core/components/data-grid/src/table/Td.tsx
+++ b/packages/paste-core/components/data-grid/src/table/Td.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
-import type {BoxElementProps} from '@twilio-paste/box';
-import type {TextAlign} from '@twilio-paste/style-props';
+import {TdPropTypes} from '@twilio-paste/table';
+import type {TdProps as TableTdProps} from '@twilio-paste/table';
 
-export interface TdProps {
-  textAlign?: TextAlign;
+export interface TdProps extends TableTdProps {
   onClick?: React.MouseEventHandler;
-  element?: BoxElementProps['element'];
 }
 
 export const Td = React.forwardRef<HTMLTableCellElement, TdProps>(
@@ -47,6 +45,6 @@ export const Td = React.forwardRef<HTMLTableCellElement, TdProps>(
 
 Td.displayName = 'Td';
 Td.propTypes = {
+  ...TdPropTypes,
   onClick: PropTypes.func,
-  element: PropTypes.string,
 };

--- a/packages/paste-core/components/data-grid/src/table/Th.tsx
+++ b/packages/paste-core/components/data-grid/src/table/Th.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
-import type {BoxElementProps} from '@twilio-paste/box';
-import type {TextAlign} from '@twilio-paste/style-props';
+import {ThPropTypes} from '@twilio-paste/table';
+import type {ThProps as TableThProps} from '@twilio-paste/table';
 
-export interface ThProps {
-  textAlign?: TextAlign;
-  width?: string;
+export interface ThProps extends TableThProps {
   onClick?: React.MouseEventHandler;
-  element?: BoxElementProps['element'];
-  colSpan?: number;
 }
 
 export const Th = React.forwardRef<HTMLTableCellElement, ThProps>(
@@ -50,8 +46,6 @@ export const Th = React.forwardRef<HTMLTableCellElement, ThProps>(
 
 Th.displayName = 'Th';
 Th.propTypes = {
+  ...ThPropTypes,
   onClick: PropTypes.func,
-  width: PropTypes.string,
-  element: PropTypes.string,
-  colSpan: PropTypes.number,
 };

--- a/packages/paste-core/components/data-grid/src/table/Tr.tsx
+++ b/packages/paste-core/components/data-grid/src/table/Tr.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {styled, css} from '@twilio-paste/styling-library';
 import {Box, safelySpreadBoxProps} from '@twilio-paste/box';
-import type {BoxElementProps} from '@twilio-paste/box';
+import {TrPropTypes} from '@twilio-paste/table';
+import type {TrProps as TableTrProps} from '@twilio-paste/table';
 
-export interface TrProps {
+export interface TrProps extends TableTrProps {
   role: string;
   striped: boolean;
   selected?: boolean;
-  element?: BoxElementProps['element'];
 }
 
 const StyledTr = styled.tr<TrProps>(
@@ -43,7 +43,8 @@ export const Tr = React.forwardRef<HTMLTableRowElement, TrProps>(
 
 Tr.displayName = 'Tr';
 Tr.propTypes = {
+  ...TrPropTypes,
   role: PropTypes.string.isRequired,
   selected: PropTypes.bool,
-  element: PropTypes.string,
+  striped: PropTypes.bool.isRequired,
 };

--- a/packages/paste-core/components/table/src/proptypes.ts
+++ b/packages/paste-core/components/table/src/proptypes.ts
@@ -18,11 +18,8 @@ export const THeadPropTypes = {
   children: PropTypes.node.isRequired,
   element: PropTypes.string,
 };
-
-export const TBodyPropTypes = {
-  children: PropTypes.node.isRequired,
-  element: PropTypes.string,
-};
+export const TBodyPropTypes = THeadPropTypes;
+export const TFootPropTypes = THeadPropTypes;
 
 export const TrPropTypes = {
   children: PropTypes.node.isRequired,
@@ -35,15 +32,12 @@ export const ThPropTypes = {
   element: PropTypes.string,
   textAlign: PropTypes.oneOf(Object.values(TableAlignmentObject)),
   width: isWidthTokenProp,
+  colSpan: PropTypes.number,
 };
 
 export const TdPropTypes = {
+  colSpan: PropTypes.number,
   children: PropTypes.node,
   element: PropTypes.string,
   textAlign: PropTypes.oneOf(Object.values(TableAlignmentObject)),
-};
-
-export const TFootPropTypes = {
-  children: PropTypes.node.isRequired,
-  element: PropTypes.string,
 };

--- a/packages/paste-core/components/table/src/types.ts
+++ b/packages/paste-core/components/table/src/types.ts
@@ -62,9 +62,8 @@ export interface TrProps extends React.TableHTMLAttributes<HTMLTableRowElement> 
   children: NonNullable<React.ReactNode>;
   element?: BoxProps['element'];
   verticalAlign?: TableVerticalAlignmentOptions;
-  isLastRow?: boolean;
 }
-export interface ThProps extends React.ThHTMLAttributes<HTMLTableHeaderCellElement> {
+export interface ThProps extends React.ThHTMLAttributes<HTMLTableCellElement> {
   children?: React.ReactNode;
   element?: BoxProps['element'];
   textAlign?: TableAlignmentOptions;


### PR DESCRIPTION
Improves TS typings and proptypes on DataGrid and Table's Tr, Td, and Th elements.

Based on discussions that happened here: https://github.com/twilio-labs/paste/pull/2597