### PR TITLE
fix: sidebar examples by iframing in storybook story

### DIFF
--- a/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
@@ -14,7 +14,6 @@ import {
   SidebarCollapseButton,
   SidebarFooter,
   SidebarOverlayContentWrapper,
-  SidebarBetaBadge,
   SidebarBody,
 } from '../src';
 
@@ -29,7 +28,6 @@ export const Default: StoryFn = () => {
 
   return (
     <Box>
-      {/* Can be placed anywhere - position fixed */}
       <Sidebar aria-label={id} collapsed={overlaySidebarExpanded} variant="default">
         <SidebarHeader>
           <SidebarHeaderIconButton as="a" href="#">
@@ -37,9 +35,7 @@ export const Default: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody>
-          <SidebarBetaBadge as="span">Beta</SidebarBetaBadge>
-        </SidebarBody>
+        <SidebarBody></SidebarBody>
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}
@@ -48,12 +44,12 @@ export const Default: StoryFn = () => {
           />
         </SidebarFooter>
       </Sidebar>
-
-      {/* Must wrap content area */}
       <SidebarOverlayContentWrapper collapsed={overlaySidebarExpanded} variant="default">
-        <Button variant="primary" onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}>
-          Toggle Overlay Sidebar
-        </Button>
+        <Box padding="space70">
+          <Button variant="primary" onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}>
+            Toggle Overlay Sidebar
+          </Button>
+        </Box>
       </SidebarOverlayContentWrapper>
     </Box>
   );
@@ -76,15 +72,15 @@ export const Compact: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody>
-          <SidebarBetaBadge as="button">Beta</SidebarBetaBadge>
-        </SidebarBody>
+        <SidebarBody></SidebarBody>
         <SidebarFooter>
-          <SidebarCollapseButton
-            onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}
-            i18nCollapseLabel="Close sidebar"
-            i18nExpandLabel="Open sidebar"
-          />
+          <Box padding="space70">
+            <SidebarCollapseButton
+              onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}
+              i18nCollapseLabel="Close sidebar"
+              i18nExpandLabel="Open sidebar"
+            />
+          </Box>
         </SidebarFooter>
       </Sidebar>
 

--- a/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/overlay.stories.tsx
@@ -35,7 +35,7 @@ export const Default: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody></SidebarBody>
+        <SidebarBody />
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setOverlaySidebarExpanded(!overlaySidebarExpanded)}
@@ -72,7 +72,7 @@ export const Compact: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody></SidebarBody>
+        <SidebarBody />
         <SidebarFooter>
           <Box padding="space70">
             <SidebarCollapseButton

--- a/packages/paste-core/components/sidebar/stories/push.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/push.stories.tsx
@@ -36,7 +36,7 @@ export const Default: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody></SidebarBody>
+        <SidebarBody />
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}
@@ -74,7 +74,7 @@ export const Compact: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody></SidebarBody>
+        <SidebarBody />
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}

--- a/packages/paste-core/components/sidebar/stories/push.stories.tsx
+++ b/packages/paste-core/components/sidebar/stories/push.stories.tsx
@@ -14,7 +14,6 @@ import {
   SidebarCollapseButton,
   SidebarFooter,
   SidebarPushContentWrapper,
-  SidebarBetaBadge,
   SidebarBody,
 } from '../src';
 
@@ -37,9 +36,7 @@ export const Default: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody>
-          <SidebarBetaBadge as="span">Beta</SidebarBetaBadge>
-        </SidebarBody>
+        <SidebarBody></SidebarBody>
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}
@@ -70,7 +67,6 @@ export const Compact: StoryFn = () => {
 
   return (
     <Box>
-      {/* Can be placed anywhere - position fixed */}
       <Sidebar aria-label={id} collapsed={pushSidebarCollapsed} variant="compact">
         <SidebarHeader>
           <SidebarHeaderIconButton as="a" href="#">
@@ -78,9 +74,7 @@ export const Compact: StoryFn = () => {
           </SidebarHeaderIconButton>
           <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
         </SidebarHeader>
-        <SidebarBody>
-          <SidebarBetaBadge as="button">Beta</SidebarBetaBadge>
-        </SidebarBody>
+        <SidebarBody></SidebarBody>
         <SidebarFooter>
           <SidebarCollapseButton
             onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}
@@ -89,8 +83,6 @@ export const Compact: StoryFn = () => {
           />
         </SidebarFooter>
       </Sidebar>
-
-      {/* Must wrap content area */}
       <SidebarPushContentWrapper collapsed={pushSidebarCollapsed} variant="compact">
         <Box padding="space70">
           <Button variant="primary" onClick={() => setPushSidebarCollapsed(!pushSidebarCollapsed)}>

--- a/packages/paste-website/src/components/paste-mdx-provider/index.tsx
+++ b/packages/paste-website/src/components/paste-mdx-provider/index.tsx
@@ -24,6 +24,7 @@ import {LivePreview} from '../shortcodes/live-preview';
 import {TableOfContents} from '../shortcodes/table-of-contents';
 import {PageAside} from '../shortcodes/PageAside';
 import {ChangelogRevealer} from '../shortcodes/ChangelogRevealer';
+import {StoryPreview} from '../shortcodes/StoryPreview';
 import {ArticleHeader} from '../shortcodes/ArticleHeader';
 import {ArticleContent, ArticleAside} from '../shortcodes/ArticleLayouts';
 import {NormalizedComponentHeader} from '../shortcodes/normalized-component-header';
@@ -54,6 +55,7 @@ const shortcodes = {
   ArticleContent,
   ArticleAside,
   NormalizedComponentHeader,
+  StoryPreview,
 };
 
 const MDXPoviderComponents = {

--- a/packages/paste-website/src/components/shortcodes/StoryPreview.tsx
+++ b/packages/paste-website/src/components/shortcodes/StoryPreview.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import {Box} from '@twilio-paste/box';
+import {CodeBlock, CodeBlockWrapper} from '@twilio-paste/code-block';
+
+export interface StoryPreviewProps {
+  storyID: string;
+  title: string;
+  code: string;
+}
+
+const StoryPreview: React.FC<React.PropsWithChildren<StoryPreviewProps>> = ({storyID, title, code}) => {
+  return (
+    <Box
+      padding="space20"
+      borderRadius="borderRadius30"
+      borderStyle="solid"
+      borderWidth="borderWidth20"
+      borderColor="colorBorderWeak"
+      marginBottom="space70"
+    >
+      <iframe
+        src={`https://paste-storybook.twilio.design/iframe.html?args=&id=${storyID}&viewMode=story`}
+        style={{
+          width: '100%',
+          height: '500px',
+          border: 0,
+          overflow: 'hidden',
+          padding: '1.5rem',
+        }}
+        title={`${title}`}
+        allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+        sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+      />
+      <CodeBlockWrapper>
+        <CodeBlock
+          i18nLinkLabel="Open in Storybook"
+          language="jsx"
+          maxLines={10}
+          externalLink={`https://paste-storybook.twilio.design/?path=/story/${storyID}`}
+          code={code}
+        />
+      </CodeBlockWrapper>
+    </Box>
+  );
+};
+
+StoryPreview.displayName = 'StoryPreview';
+export {StoryPreview};

--- a/packages/paste-website/src/pages/components/sidebar/index.mdx
+++ b/packages/paste-website/src/pages/components/sidebar/index.mdx
@@ -65,13 +65,32 @@ export const getStaticProps = async () => {
 
 <content>
 
-<iframe
-  src="https://codesandbox.io/embed/sidebar-push-variant-default-55wkwx?fontsize=14&hidenavigation=1&theme=dark&view=preview"
-  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden', marginBottom: '40px'}}
-  title="Sidebar Push variant=default"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
+<StoryPreview
+  title="Compact push Sidebar example"
+  storyID="components-sidebar-sidebar-push--compact"
+  code={`
+<Sidebar aria-label={id} collapsed={true} variant="compact">
+  <SidebarHeader>
+    <SidebarHeaderIconButton as="a" href="#">
+      <LogoTwilioIcon size="sizeIcon20" decorative={false} title="Go to Console homepage" />
+    </SidebarHeaderIconButton>
+    <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
+  </SidebarHeader>
+  <SidebarBody>
+  </SidebarBody>
+  <SidebarFooter>
+    <SidebarCollapseButton
+      i18nCollapseLabel="Close sidebar"
+      i18nExpandLabel="Open sidebar"
+    />
+  </SidebarFooter>
+</Sidebar>
+<SidebarPushContentWrapper collapsed={true} variant="compact">
+  <Button variant="primary">
+    Toggle Push Sidebar
+  </Button>
+</SidebarPushContentWrapper>`}
+/>
 
 ## Guidelines
 
@@ -99,25 +118,64 @@ For most Twilio products, which are desktop experiences, we currently believe th
   <CalloutText>This is the variant that the Paste team recommends in most Twilio applications.</CalloutText>
 </Callout>
 
-<iframe
-  src="https://codesandbox.io/embed/sidebar-push-variant-compact-j7d2yr?fontsize=14&hidenavigation=1&theme=dark"
-  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden', marginBottom: '40px'}}
-  title="Sidebar Push variant=compact"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
+<StoryPreview
+  title="Compact push Sidebar example"
+  storyID="components-sidebar-sidebar-push--compact"
+  code={`
+<Sidebar aria-label={id} collapsed={true} variant="compact">
+  <SidebarHeader>
+    <SidebarHeaderIconButton as="a" href="#">
+      <LogoTwilioIcon size="sizeIcon20" decorative={false} title="Go to Console homepage" />
+    </SidebarHeaderIconButton>
+    <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
+  </SidebarHeader>
+  <SidebarBody>
+  </SidebarBody>
+  <SidebarFooter>
+    <SidebarCollapseButton
+      i18nCollapseLabel="Close sidebar"
+      i18nExpandLabel="Open sidebar"
+    />
+  </SidebarFooter>
+</Sidebar>
+<SidebarPushContentWrapper collapsed={true} variant="compact">
+  <Button variant="primary">
+    Toggle Push Sidebar
+  </Button>
+</SidebarPushContentWrapper>`}
+/>
 
 ### Push Sidebar
 
 The "push" Sidebar moves the page content as it expands and collapses. The default variant hides completely on collapse. This can be a useful variant for responsive layouts, where screen real estate can be limited on smaller viewports.
 
-<iframe
-  src="https://codesandbox.io/embed/sidebar-push-variant-default-55wkwx?fontsize=14&hidenavigation=1&theme=dark&view=preview"
-  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden', marginBottom: '40px'}}
-  title="Sidebar Push variant=default"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
+<StoryPreview
+  title="Push Sidebar example"
+  storyID="components-sidebar-sidebar-push--default"
+  code={`
+<Sidebar aria-label={id} collapsed={false} variant="default">
+  <SidebarHeader>
+    <SidebarHeaderIconButton as="a" href="#">
+      <LogoTwilioIcon size="sizeIcon20" decorative={false} title="Go to Console homepage" />
+    </SidebarHeaderIconButton>
+    <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
+  </SidebarHeader>
+  <SidebarBody></SidebarBody>
+  <SidebarFooter>
+    <SidebarCollapseButton
+      i18nCollapseLabel="Close sidebar"
+      i18nExpandLabel="Open sidebar"
+    />
+  </SidebarFooter>
+</Sidebar>
+<SidebarPushContentWrapper collapsed={false} variant="default">
+  <Box padding="space70">
+    <Button variant="primary">
+      Toggle Push Sidebar
+    </Button>
+  </Box>
+</SidebarPushContentWrapper>`}
+/>
 
 ### Compact overlay Sidebar
 
@@ -125,25 +183,65 @@ The "overlay" Sidebar sits on top of the page content as it expands and collapse
 
 A significant downside to the overlay Sidebar is that it can cover up or hide page content, which can result in a poor user experience for some users, particularly those with low vision or cognitive disabilities. If you choose to use this option in your application, you should carefully weigh up the accessibility challenges you might introduce to some Twilio customers against your desired experience and use case.
 
-<iframe
-  src="https://codesandbox.io/embed/sidebar-overlay-variant-compact-i9gbf7?fontsize=14&hidenavigation=1&theme=dark"
-  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden', marginBottom: '40px'}}
-  title="Sidebar Overlay variant=compact"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
+<StoryPreview
+  title="Compact overlay Sidebar example"
+  storyID="components-sidebar-sidebar-overlay--compact"
+  code={`
+<Sidebar aria-label={id} collapsed={true} variant="compact">
+  <SidebarHeader>
+    <SidebarHeaderIconButton as="a" href="#">
+      <LogoTwilioIcon size="sizeIcon20" decorative={false} title="Go to Console homepage" />
+    </SidebarHeaderIconButton>
+    <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
+  </SidebarHeader>
+  <SidebarBody></SidebarBody>
+  <SidebarFooter>
+    <Box padding="space70">
+      <SidebarCollapseButton
+        i18nCollapseLabel="Close sidebar"
+        i18nExpandLabel="Open sidebar"
+      />
+    </Box>
+  </SidebarFooter>
+</Sidebar>
+<SidebarOverlayContentWrapper collapsed={true} variant="compact">
+  <Button variant="primary">
+    Toggle Overlay Sidebar
+  </Button>
+</SidebarOverlayContentWrapper>`}
+/>
 
 ### Overlay Sidebar
 
 The "overlay" Sidebar sits on top of the page content as it expands and collapses. The default variant hides completely on collapse.
 
-<iframe
-  src="https://codesandbox.io/embed/sidebar-overlay-variant-default-i4ktck?fontsize=14&hidenavigation=1&theme=dark"
-  style={{width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden', marginBottom: '40px'}}
-  title="Sidebar Overlay variant=default"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
+<StoryPreview
+  title="Overlay Sidebar example"
+  storyID="components-sidebar-sidebar-overlay--default"
+  code={`
+<Sidebar aria-label={id} collapsed={false} variant="default">
+  <SidebarHeader>
+    <SidebarHeaderIconButton as="a" href="#">
+      <LogoTwilioIcon size="sizeIcon20" decorative={false} title="Go to Console homepage" />
+    </SidebarHeaderIconButton>
+    <SidebarHeaderLabel>Twilio Console</SidebarHeaderLabel>
+  </SidebarHeader>
+  <SidebarBody></SidebarBody>
+  <SidebarFooter>
+    <SidebarCollapseButton
+      i18nCollapseLabel="Close sidebar"
+      i18nExpandLabel="Open sidebar"
+    />
+  </SidebarFooter>
+</Sidebar>
+<SidebarOverlayContentWrapper collapsed={false} variant="default">
+  <Box padding="space70">
+    <Button variant="primary">
+      Toggle Overlay Sidebar
+    </Button>
+  </Box>
+</SidebarOverlayContentWrapper>`}
+/>
 
 ## Composition notes
 


### PR DESCRIPTION
A quick way to display a story in docs and add a code snippet underneath for component examples that can't be inlined

![image](https://github.com/twilio-labs/paste/assets/368249/8cd76e4b-805a-4f00-aa0a-aec5a06d2d00)


## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
