### PR TITLE
fix(theme): update inter font to support number emojis

### DIFF
--- a/.changeset/moody-impalas-rescue.md
+++ b/.changeset/moody-impalas-rescue.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/core': patch
+'@twilio-paste/theme': patch
+---
+
+[Theme] Update Inter font version from 3.15 to 3.19, which fixes a Chrome issue with number emojis

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -27,12 +27,12 @@
 <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
 <link
   rel="preload"
-  href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/Inter.var.woff2?v=3.15"
+  href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/Inter.var.woff2?v=3.19"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"
 />
-<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css" />
+<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
 <script>
   window.global = window;
   window.process = {

--- a/internal-docs/engineering/fonts.md
+++ b/internal-docs/engineering/fonts.md
@@ -1,0 +1,3 @@
+# Updating Paste fonts on the CDN
+
+In order to update the fonts on the CDN, you must follow the instructions on the paste-fonts repository hosted on the internal twilio org on public github.

--- a/packages/paste-cra-template/template/public/index.html
+++ b/packages/paste-cra-template/template/public/index.html
@@ -22,7 +22,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
-    <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css" />
+    <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
     <title>React App</title>
   </head>
   <body>

--- a/packages/paste-theme/src/styles/fonts.ts
+++ b/packages/paste-theme/src/styles/fonts.ts
@@ -10,7 +10,7 @@ Variable font.
   font-display: swap;
   font-style: normal;
   font-named-instance: 'Regular';
-  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.0/Inter-roman.var.woff2?v=3.15") format("woff2");
+  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.1/Inter-roman.var.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: 'Inter var';
@@ -18,7 +18,7 @@ Variable font.
   font-display: swap;
   font-style: italic;
   font-named-instance: 'Italic';
-  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.0/Inter-italic.var.woff2?v=3.15") format("woff2");
+  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.1/Inter-italic.var.woff2?v=3.19") format("woff2");
 }
 /* --------------------------------------------------------------------------
 [EXPERIMENTAL] Multi-axis, single variable font.
@@ -38,7 +38,7 @@ explicitly, e.g.
   font-weight: 100 900;
   font-display: swap;
   font-style: oblique 0deg 8deg;
-  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.0/Inter.var.woff2?v=3.15") format("woff2");
+  src: url("https://assets.twilio.com/public_assets/paste-fonts/1.5.1/Inter.var.woff2?v=3.19") format("woff2");
 }
 
 /*
@@ -50,8 +50,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Regular.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Regular.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Regular.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Regular.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansMono';
@@ -59,8 +59,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-RegularItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-RegularItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-RegularItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-RegularItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansMono';
@@ -68,8 +68,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Bold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Bold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Bold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Bold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansMono';
@@ -77,8 +77,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-BoldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-BoldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-BoldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-BoldItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansMono';
@@ -86,8 +86,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Medium.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-Medium.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Medium.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-Medium.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansMono';
@@ -95,8 +95,8 @@ Twilio Sans Mono
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-MediumItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansMono-MediumItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-MediumItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansMono-MediumItl.woff') format('woff');
 }
 
 /*
@@ -108,8 +108,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 300;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Light.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Light.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Light.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Light.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -117,8 +117,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 300;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-LightItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-LightItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-LightItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-LightItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -126,8 +126,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Regular.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Regular.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Regular.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Regular.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -135,8 +135,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-RegularItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-RegularItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-RegularItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-RegularItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -144,8 +144,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Medium.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Medium.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Medium.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Medium.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -153,8 +153,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-MediumItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-MediumItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-MediumItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-MediumItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -162,8 +162,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 600;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Semibold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Semibold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Semibold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Semibold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -171,8 +171,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 600;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-SemiboldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-SemiboldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-SemiboldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-SemiboldItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -180,8 +180,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Bold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Bold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Bold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Bold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -189,8 +189,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-BoldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-BoldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-BoldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-BoldItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -198,8 +198,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 800;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Extrabold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-Extrabold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Extrabold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-Extrabold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansText';
@@ -207,8 +207,8 @@ Twilio Sans Text
   font-display: swap;
   font-weight: 800;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-ExtraboldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansText-ExtraboldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-ExtraboldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansText-ExtraboldItl.woff') format('woff');
 }
 
 /*
@@ -220,8 +220,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 300;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Light.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Light.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Light.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Light.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -229,8 +229,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 300;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-LightItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-LightItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-LightItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-LightItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -238,8 +238,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Regular.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Regular.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Regular.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Regular.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -247,8 +247,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 400;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-RegularItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-RegularItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-RegularItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-RegularItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -256,8 +256,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Medium.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Medium.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Medium.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Medium.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -265,8 +265,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 500;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-MediumItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-MediumItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-MediumItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-MediumItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -274,8 +274,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 600;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Semibold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Semibold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Semibold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Semibold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -283,8 +283,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 600;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-SemiboldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-SemiboldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-SemiboldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-SemiboldItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -292,8 +292,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Bold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Bold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Bold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Bold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -301,8 +301,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 700;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-BoldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-BoldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-BoldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-BoldItl.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -310,8 +310,8 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 800;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Extrabold.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-Extrabold.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Extrabold.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-Extrabold.woff') format('woff');
 }
 @font-face {
   font-family: 'TwilioSansDisplay';
@@ -319,7 +319,7 @@ Twilio Sans Display
   font-display: swap;
   font-weight: 800;
   src: local(''),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-ExtraboldItl.woff2') format('woff2'),
-       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.0/TwilioSansDisplay-ExtraboldItl.woff') format('woff');
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-ExtraboldItl.woff2') format('woff2'),
+       url('https://assets.twilio.com/public_assets/paste-fonts/1.5.1/TwilioSansDisplay-ExtraboldItl.woff') format('woff');
 }
 `;

--- a/packages/paste-token-contrast-checker/public/index.html
+++ b/packages/paste-token-contrast-checker/public/index.html
@@ -22,7 +22,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
-    <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css" />
+    <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
     <title>React App</title>
   </head>
   <body>

--- a/packages/paste-website/src/pages/_document.tsx
+++ b/packages/paste-website/src/pages/_document.tsx
@@ -14,7 +14,7 @@ class _Document extends Document {
       <Html lang="en" dir="ltr">
         <Head>
           <link rel="preconnect" href="https://assets.twilio.com" crossOrigin="" />
-          <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css" />
+          <link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
 
           <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
           <link rel="manifest" href="/manifest.json" />

--- a/packages/paste-website/src/pages/components/heading/index.mdx
+++ b/packages/paste-website/src/pages/components/heading/index.mdx
@@ -66,8 +66,8 @@ Headings should allow users to easily distinguish content sections on the page.
 - Heading types provide specific styles to the font-size, font-weight, and line-height of the text to create hierarchy that allow users to easily scan pages and content
 - Headings should be used with intention that maintains a coherent document outline
 - Don’t use heading tags to resize text. Instead use the `<Text>` primitive
-- Don’t skip headline levels. Always start with `<h1>`, `<h2>`, and so on
-- There can only be one `<h1>` tag per page
+- Don’t skip headline levels. Always start with `<h1>`, `<h2>`, and so on. In other words, you cannot use an `<h3>` unless preceded by an `<h2>`.
+- There can **only be one `<h1>` tag** per page.
 - Always use sentence case when writing headings, for more information read the [product style guide](/foundations/content/product-style-guide/#sentence-case)
 
 #### Accessibility
@@ -166,6 +166,37 @@ It is important to not skip one or more heading levels as it is common for scree
 </LivePreview>
 
 ## Composition Notes
+
+### Difference between the as and variant props
+
+Visual hierarchy doesn't always follow <em>document hierarchy</em>. For
+this reason, we've decoupled the visual appearance (the `variant` prop)
+from the semantic hierarchy (the `as` prop) of the element.
+
+For accessibility reasons we want to create a nice clean document hierarchy where:
+
+- We only have one h1
+- We don't skip levels as we travel the DOM:
+
+```
+h1
+  h2
+    h3
+    h3
+  h2
+  h2
+    h3
+      h4
+    h3
+      h4
+```
+
+Sometimes, the appropriate document level doesn't match the visual design,
+because, for example, the third section of content is less important than
+the previous two, but at the same logical level of document hierarchy.
+
+By decoupling visual appearance from hierarchy, we enable designers
+and engineers to create visual and semantic hierarchy correctly for all users.
 
 ### When to use Heading
 

--- a/packages/paste-website/src/pages/introduction/for-engineers/manual-installation/index.mdx
+++ b/packages/paste-website/src/pages/introduction/for-engineers/manual-installation/index.mdx
@@ -162,7 +162,7 @@ The **best and most performant way** to load the fonts is to include the followi
 
 ```
 <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
-<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css">
+<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css">
 ```
 
 <Callout variant="neutral" marginY="space70">

--- a/packages/paste-website/src/pages/theme/changing-theme.mdx
+++ b/packages/paste-website/src/pages/theme/changing-theme.mdx
@@ -49,7 +49,7 @@ To change the theme, simply change the value of the `theme` prop on the `Theme.P
 
 ```html
 <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
-<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css" />
+<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
 ```
 
 Alternatively, Paste will automatically load the default theme's font via JavaScript. **Note:** this will result in slower download times than including the fonts in the `<head />`.


### PR DESCRIPTION
- [x] Fixes https://github.com/twilio-labs/paste/discussions/3323
- [x] Adds internal-docs on where to find information on updating fonts in the future
- [x] (scope creep) added some clarity to Heading docs differentiating between `variant` and `as` props 