### PR TITLE
feat(alert-dialog): add disableDestructive prop

### DIFF
--- a/.changeset/little-beans-laugh.md
+++ b/.changeset/little-beans-laugh.md
@@ -3,4 +3,4 @@
 '@twilio-paste/core': minor
 ---
 
-[Alert Dialog] Add prop `disableDestructive` to allow for the confirm button on destructive Alert Dialogs to be conditionally disabled. This interaction is primarily for use in the High Severity Delete Pattern.
+[Alert Dialog] Add prop `onConfirmDisabled` to allow for the confirm button on destructive Alert Dialogs to be conditionally disabled. This interaction is primarily for use in the High Severity Delete Pattern.

--- a/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/alert-dialog/__tests__/index.spec.tsx
@@ -33,8 +33,8 @@ describe('Alert Dialog', () => {
     expect(button).toHaveStyleRule('background-color', 'rgb(214, 31, 31)');
   });
 
-  it('Should have a disabled destructive button style when the disableDestructive prop is included', () => {
-    render(<DisabledButtonDestructiveAlertDialog />, {wrapper: ThemeWrapper});
+  it('Should have a disabled destructive button style when the onConfirmDisabled prop is included', () => {
+    render(<DisabledButtonDestructiveAlertDialog dialogIsOpen />, {wrapper: ThemeWrapper});
     const button = screen.getByRole('button', {name: 'Delete'});
     expect(button).toHaveStyleRule('background-color', 'rgb(225, 227, 234)');
   });
@@ -59,7 +59,7 @@ describe('Alert Dialog', () => {
   });
 
   it('Should have correct attributes when button is disabled', () => {
-    render(<DisabledButtonDestructiveAlertDialog />);
+    render(<DisabledButtonDestructiveAlertDialog dialogIsOpen />, {wrapper: ThemeWrapper});
     expect(screen.getByRole('button', {name: 'Delete'})).toHaveAttribute('disabled');
   });
 

--- a/packages/paste-core/components/alert-dialog/src/AlertDialogFooter.tsx
+++ b/packages/paste-core/components/alert-dialog/src/AlertDialogFooter.tsx
@@ -12,7 +12,7 @@ export interface AlertDialogFooterProps extends HTMLPasteProps<'div'>, Pick<BoxP
   onConfirmLabel: string;
   onDismiss: () => void;
   onDismissLabel: string;
-  disableDestructive?: boolean;
+  onConfirmDisabled?: boolean;
 }
 
 export const AlertDialogFooter = React.forwardRef<HTMLDivElement, AlertDialogFooterProps>(
@@ -24,7 +24,7 @@ export const AlertDialogFooter = React.forwardRef<HTMLDivElement, AlertDialogFoo
       onConfirmLabel,
       onDismiss,
       onDismissLabel,
-      disableDestructive = false,
+      onConfirmDisabled = false,
       ...props
     },
     ref
@@ -48,7 +48,7 @@ export const AlertDialogFooter = React.forwardRef<HTMLDivElement, AlertDialogFoo
           <Button variant="secondary" onClick={onDismiss}>
             {onDismissLabel}
           </Button>
-          <Button variant={primaryVariant} onClick={onConfirm} disabled={destructive && disableDestructive}>
+          <Button variant={primaryVariant} onClick={onConfirm} disabled={destructive && onConfirmDisabled}>
             {onConfirmLabel}
           </Button>
         </Stack>

--- a/packages/paste-core/components/alert-dialog/src/index.tsx
+++ b/packages/paste-core/components/alert-dialog/src/index.tsx
@@ -34,7 +34,7 @@ export interface AlertDialogProps extends HTMLPasteProps<'div'>, Pick<BoxProps, 
   onConfirmLabel: string;
   onDismiss: () => void;
   onDismissLabel: string;
-  disableDestructive?: boolean;
+  onConfirmDisabled?: boolean;
 }
 
 export const AlertDialog = React.forwardRef<HTMLDivElement, AlertDialogProps>(
@@ -49,7 +49,7 @@ export const AlertDialog = React.forwardRef<HTMLDivElement, AlertDialogProps>(
       onConfirmLabel,
       onDismiss,
       onDismissLabel,
-      disableDestructive,
+      onConfirmDisabled,
       ...props
     },
     ref
@@ -88,7 +88,7 @@ export const AlertDialog = React.forwardRef<HTMLDivElement, AlertDialogProps>(
                     onDismissLabel={onDismissLabel}
                     onConfirm={onConfirm}
                     onConfirmLabel={onConfirmLabel}
-                    disableDestructive={disableDestructive}
+                    onConfirmDisabled={onConfirmDisabled}
                   />
                 </Box>
               </ModalDialogOverlay>

--- a/packages/paste-core/components/alert-dialog/stories/index.stories.tsx
+++ b/packages/paste-core/components/alert-dialog/stories/index.stories.tsx
@@ -87,40 +87,72 @@ DestructiveAlertDialogStory.parameters = {
   },
 };
 
-export const DisabledButtonDestructiveAlertDialog = (): JSX.Element => {
+export const DisabledButtonDestructiveAlertDialog = ({dialogIsOpen = false}): JSX.Element => {
+  const [isOpen, setIsOpen] = React.useState(dialogIsOpen);
+  const [inputString, setInputString] = React.useState('');
+  const [inputHasError, setInputHasError] = React.useState(false);
   const [isDisabled, setIsDisabled] = React.useState(true);
+  const handleOpen = (): void => {
+    if (inputString !== '') setIsDisabled(false);
+    setIsOpen(true);
+  };
+  const handleDismiss = (): void => {
+    setIsDisabled(true);
+    setIsOpen(false);
+    setInputHasError(false);
+  };
+  const handleConfirm = (): void => {
+    if (inputString === 'Toyota TCB Automobile (Gevelsberg)') {
+      setIsOpen(false);
+      setInputString('');
+      setInputHasError(false);
+      setIsDisabled(true);
+    } else {
+      setInputHasError(true);
+    }
+  };
   const handleChange = (e): void => {
-    if (e.target.value === 'Toyota TCB Automobile (Gevelsberg)') setIsDisabled(false);
+    setInputString(e.target.value);
+    if (e.target.value !== '') setIsDisabled(false);
     else setIsDisabled(true);
   };
   return (
-    <AlertDialog
-      heading="Delete regulatory bundle"
-      isOpen
-      destructive
-      onConfirm={() => {}}
-      onConfirmLabel="Delete"
-      onDismiss={() => {}}
-      onDismissLabel="Cancel"
-      disableDestructive={isDisabled}
-    >
-      You&apos;re about to delete &quot;Toyota TCB Automobile (Gevelsberg)&quot; and all data associated with it. This
-      regulatory bundle will be deleted immediately. You can&apos;t undo this action.
-      <Box display="flex" flexDirection="column" rowGap="space30" marginY="space50">
-        <Label htmlFor="delete-input" required>
-          Regulatory bundle name
-        </Label>
-        <Input type="text" required aria-describedby="delete-help-text" onChange={(e) => handleChange(e)} />
-        <HelpText id="delete-help-text">
-          To confirm this deletion, please input the name of this regulatory bundle.
-        </HelpText>
-      </Box>
-    </AlertDialog>
+    <>
+      <Button variant="destructive" onClick={handleOpen}>
+        Delete object
+      </Button>
+      <AlertDialog
+        heading="Delete regulatory bundle"
+        isOpen={isOpen}
+        onConfirm={handleConfirm}
+        onConfirmLabel="Delete"
+        onDismiss={handleDismiss}
+        onDismissLabel="Cancel"
+        destructive
+        onConfirmDisabled={isDisabled}
+      >
+        You&apos;re about to delete &ldquo;Toyota TCB Automobile (Gevelsberg)&ldquo; and all data associated with it.
+        This regulatory bundle will be deleted immediately. You can&apos;t undo this action.
+        <Box display="flex" flexDirection="column" rowGap="space30" marginY="space50">
+          <Label htmlFor="delete-input" required>
+            Regulatory bundle name
+          </Label>
+          <Input
+            type="text"
+            required
+            id="delete-input"
+            aria-describedby="delete-help-text"
+            onChange={(e) => handleChange(e)}
+            hasError={inputHasError}
+            value={inputString}
+          />
+          <HelpText id="delete-help-text" variant={inputHasError ? 'error' : 'default'}>
+            To confirm this deletion, please input the name of this regulatory bundle.
+          </HelpText>
+        </Box>
+      </AlertDialog>
+    </>
   );
-};
-
-export const DisabledButtonDestructiveAlertDialogStory = (): React.ReactNode => {
-  return <DisabledButtonDestructiveAlertDialog />;
 };
 
 export const OpenAlertDialogFromButton = (): JSX.Element => {

--- a/packages/paste-website/src/component-examples/DeletePatternExamples.ts
+++ b/packages/paste-website/src/component-examples/DeletePatternExamples.ts
@@ -1,0 +1,139 @@
+export const LowSeverityExample = `
+  const LowSeverityDelete = () => {
+    return (
+      <Button variant="destructive_link">Remove</Button>
+    )
+  }
+  
+  render(
+    <LowSeverityDelete />
+  )
+`.trim();
+
+export const MediumSeverityExample = `
+  const MediumSeverityDelete = () => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const handleOpen = () => setIsOpen(true);
+    const handleClose = () => setIsOpen(false);
+    return (
+      <>
+        <Button variant="destructive" onClick={handleOpen}>Delete</Button>
+        <AlertDialog
+          heading="Delete from regulatory bundle?"
+          isOpen={isOpen}
+          onConfirm={handleClose}
+          onConfirmLabel="Delete"
+          onDismiss={handleClose}
+          onDismissLabel="Cancel"
+          destructive
+        >
+          You're about to delete "Plan A Productions, LLC" from this regulatory bundle. This does not impact any other regulatory bundles.
+        </AlertDialog>
+      </>
+    )
+  }
+  render(
+    <MediumSeverityDelete />
+  )
+`.trim();
+
+export const HighSeverityExample = `
+  const HighSeverityDelete = () => {
+    const [isDisabled, setIsDisabled] = React.useState(true);
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [inputString, setInputString] = React.useState('');
+    const [inputHasError, setInputHasError] = React.useState(false);
+    const handleOpen = () => {
+        if (inputString !== '') setIsDisabled(false);
+        setIsOpen(true);
+      };
+    const handleDismiss = () => {
+        setIsDisabled(true)
+        setIsOpen(false)
+    };
+    const handleConfirm = () => {
+        if (inputString === 'Toyota TCB Automobile (Gevelsberg)') {
+            setIsOpen(false)
+            setInputString('')
+            setInputHasError(false)
+        }
+        else {
+            setInputHasError(true)
+        }
+    };
+    const handleChange = (e) => {
+        setInputString(e.target.value)
+        if (e.target.value !== '') setIsDisabled(false);
+        else setIsDisabled(true);
+    };
+
+  return (
+    <>
+      <Button variant="destructive" onClick={handleOpen}>Delete</Button>
+      <AlertDialog
+        heading="Delete regulatory bundle?"
+        isOpen={isOpen}
+        onConfirm={handleConfirm}
+        onConfirmLabel="Delete"
+        onDismiss={handleDismiss}
+        onDismissLabel="Cancel"
+        destructive
+        onConfirmDisabled={isDisabled}
+      >
+        You're about to delete "Toyota TCB Automobile (Gevelsberg)" and all associated data. The bundle will be deleted immediately. You cannot undo this action.
+        <Box display="flex" flexDirection="column" rowGap="space30" marginY="space50">
+          <Label htmlFor="delete-input" required>
+            Regulatory bundle name
+          </Label>
+          <Input type="text" id="delete-input" required aria-describedby="delete-help-text" onChange={(e) => handleChange(e)} hasError={inputHasError} value={inputString}/>
+          <HelpText id="delete-help-text" variant={inputHasError ? 'error' : 'default'}>
+            Enter the name of the bundle being deleted. Entries are case-sensitive.
+          </HelpText>
+        </Box>
+      </AlertDialog>
+    </>
+  )
+}
+
+render(
+<HighSeverityDelete />
+)
+`.trim();
+
+export const PostDeletionExample = `
+  const MediumSeverityDelete = () => {
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleOpen = () => setIsOpen(true);
+  const handleDismiss = () => setIsOpen(false);
+  const toaster = useToaster();
+
+  const handleConfirm = () => {
+    setIsOpen(false)
+    toaster.push({
+        message: '"Plan A Productions, LLC" was deleted. To undo deletion, return to the regulatory bundle overview.',
+        variant: 'success',
+      })
+  }
+  return (
+    <>
+      <Button variant="destructive" onClick={handleOpen}>Delete</Button>
+      <AlertDialog
+        heading="Delete from regulatory bundle?"
+        isOpen={isOpen}
+        onConfirm={handleConfirm}
+        onConfirmLabel="Delete"
+        onDismiss={handleDismiss}
+        onDismissLabel="Cancel"
+        destructive
+      >
+        You're about to delete "Plan A Productions, LLC" from this regulatory bundle. This does not impact any other regulatory bundles.
+      </AlertDialog>
+      <Toaster left={['space40', 'unset', 'unset']} {...toaster} />
+    </>
+  )
+}
+render(
+<MediumSeverityDelete />
+)
+`.trim();

--- a/packages/paste-website/src/pages/components/alert-dialog/index.mdx
+++ b/packages/paste-website/src/pages/components/alert-dialog/index.mdx
@@ -158,16 +158,17 @@ const AlertDialogExample = () => {
 
 #### Props
 
-| Prop           | Type                 | Description                                                                               | Default        |
-| -------------- | -------------------- | ----------------------------------------------------------------------------------------- | -------------- |
-| children       | `ReactNode`          |                                                                                           | null           |
-| isOpen         | `boolean`            |                                                                                           | null           |
-| destructive?   | `boolean`            |                                                                                           | null           |
-| onConfirmLabel | `string`             |                                                                                           | null           |
-| onConfirm      | `Function() => void` |                                                                                           | null           |
-| onDismissLabel | `string`             |                                                                                           | null           |
-| onDismiss      | `Function() => void` |                                                                                           | null           |
-| element?       | `string`             | Overrides the default element name to apply unique styles with the Customization Provider | 'ALERT_DIALOG' |
+| Prop               | Type                 | Description                                                                                       | Default        |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
+| children           | `ReactNode`          |                                                                                                   | null           |
+| isOpen             | `boolean`            |                                                                                                   | null           |
+| destructive?       | `boolean`            |                                                                                                   | null           |
+| onConfirmDisabled? | `boolean`            | Disables the confirm button on destructive Alert Dialogs for high severity deletion confirmations | null           |
+| onConfirmLabel     | `string`             |                                                                                                   | null           |
+| onConfirm          | `Function() => void` |                                                                                                   | null           |
+| onDismissLabel     | `string`             |                                                                                                   | null           |
+| onDismiss          | `Function() => void` |                                                                                                   | null           |
+| element?           | `string`             | Overrides the default element name to apply unique styles with the Customization Provider         | 'ALERT_DIALOG' |
 
 <ChangelogRevealer>
   <Changelog />

--- a/packages/paste-website/src/pages/patterns/delete/index.mdx
+++ b/packages/paste-website/src/pages/patterns/delete/index.mdx
@@ -7,6 +7,9 @@ export const meta = {
 
 import {Anchor} from '@twilio-paste/anchor';
 import {Box} from '@twilio-paste/box';
+import {Label} from '@twilio-paste/label';
+import {Input} from '@twilio-paste/input';
+import {HelpText} from '@twilio-paste/help-text';
 import {Card} from '@twilio-paste/card';
 import {Disclosure, DisclosureHeading, DisclosureContent} from '@twilio-paste/disclosure';
 import {Grid, Column} from '@twilio-paste/grid';
@@ -14,11 +17,20 @@ import {Heading} from '@twilio-paste/heading';
 import {Paragraph} from '@twilio-paste/paragraph';
 import {Text} from '@twilio-paste/text';
 import {useUID} from '@twilio-paste/uid-library';
+import {AlertDialog} from '@twilio-paste/alert-dialog';
+import {Button} from '@twilio-paste/button';
+import {Toaster, useToaster} from '@twilio-paste/toast';
 import {ResponsiveImage} from '../../../components/ResponsiveImage';
 import DeleteMediumSeverityImage from '../../../assets/images/patterns/delete-medium-severity.png';
 import DeleteHighSeverityImage from '../../../assets/images/patterns/delete-high-severity.png';
 import DefaultLayout from '../../../layouts/DefaultLayout';
 import {getFeature, getNavigationData} from '../../../utils/api';
+import {
+  LowSeverityExample,
+  MediumSeverityExample,
+  HighSeverityExample,
+  PostDeletionExample,
+} from '../../../component-examples/DeletePatternExamples.ts';
 
 export default DefaultLayout;
 
@@ -62,7 +74,7 @@ export const getStaticProps = async () => {
   <Column>
     <Card>
       <Heading as="h3" variant="heading40" marginBottom="space0">
-        <Anchor href="/components/modal">Modal</Anchor>
+        <Anchor href="/components/alert-dialog">Alert Dialog</Anchor>
       </Heading>
     </Card>
   </Column>
@@ -86,10 +98,10 @@ export const getStaticProps = async () => {
 // import all ingredients for the delete patterns
 
 import {​ Button } from "@twilio-paste/core/button";
-import { Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading } from "@twilio-paste/core/modal";
+import { AlertDialog } from "@twilio-paste/core/alert-dialog";
 import { Input } from "@twilio-paste/core/input";
 import { Label } from "@twilio-paste/core/label";
-import { HelpText } from "@twilio-paste/core/help-text;
+import { HelpText } from "@twilio-paste/core/help-text";
 import { Toast } from "@twilio-paste/core/toast";
 ```
 
@@ -106,6 +118,8 @@ The delete action should:
 - Not usually be the primary action on the page. There are many variants of differing visual prominence to choose from to achieve the correct hierarchy for the delete action trigger.
 - Follow certain guidelines based on the [severity](#variations) of the deletion.
 
+According to the Paste [Word List](/foundations/content/word-list), the word "remove" should be used when the item being deleted is still available and/or the user can undo the action. Use "delete" when the action is permanent and the item is unretrievable.
+
 ## Variations
 
 ### Low-severity
@@ -114,57 +128,75 @@ A deletion is considered low-severity when it is trivial to undo the deletion or
 
 Low-severity deletions can be triggered by a single click and do not require further warning or confirmation.
 
+<LivePreview
+  scope={{
+    AlertDialog,
+    Button,
+  }}
+  noInline
+  showOverflow
+>
+  {LowSeverityExample}
+</LivePreview>
+
 ### Medium-severity
 
 A deletion is considered medium-severity when the action cannot be undone, and the data cannot be recreated easily. This pattern is also useful for bulk deletions of low- or medium-severity.
 
-For medium-severity deletions, show a confirmation modal that explains what is being deleted and the consequences of the deletion.
+For medium-severity deletions, show an [Alert Dialog](/components/alert-dialog) that explains what is being deleted and the consequences of the deletion.
 
-<ResponsiveImage src={DeleteMediumSeverityImage} alt="modal with a destrctive button to confirm deletion" />
-
-<Box marginBottom="space80">
-  <Disclosure variant="contained">
-    <DisclosureHeading as="h5" variant="heading50">
-      Show live example
-    </DisclosureHeading>
-    <DisclosureContent>Coming soon!</DisclosureContent>
-  </Disclosure>
-</Box>
+<LivePreview
+  scope={{
+    AlertDialog,
+    Button,
+  }}
+  noInline
+  showOverflow
+>
+  {MediumSeverityExample}
+</LivePreview>
 
 ### High-severity
 
 A deletion is considered high-severity when the action cannot be undone, and it would be very time-consuming, or perhaps impossible, to recreate the deleted data. An action that deletes a large amount of data or has significant downstream impact would also be considered a high-severity deletion.
 
-For high-severity deletions, show a confirmation modal that explains what is being deleted and the consequences of the deletion, and have the user manually confirm the deletion by typing the name of the object they are deleting.
+For high-severity deletions, show an [Alert Dialog](/components/alert-dialog) that explains what is being deleted and the consequences of the deletion, and have the user manually confirm the deletion by typing the name of the object they are deleting.
 
-<ResponsiveImage src={DeleteHighSeverityImage} alt="modal with an input and a destructive button to confirm deletion" />
-
-<Box marginBottom="space80">
-  <Disclosure variant="contained">
-    <DisclosureHeading as="h5" variant="heading50">
-      Show live example
-    </DisclosureHeading>
-    <DisclosureContent>Coming soon!</DisclosureContent>
-  </Disclosure>
-</Box>
+<LivePreview
+  scope={{
+    AlertDialog,
+    Button,
+    Box,
+    Label,
+    Input,
+    HelpText,
+  }}
+  noInline
+  showOverflow
+>
+  {HighSeverityExample}
+</LivePreview>
 
 ## Post-deletion
 
 After the user has deleted the object, navigate them to the index page, where they can see a list of all remaining objects, and show a success [Toast](/components/toast) informing them that the object has successfully been deleted. If it is possible to undo the deletion, give the user the option to do so, and tell them how long they have to undo the deletion if it is time-bound.
 
-If the delete action fails, keep the modal open and display an error [Toast](/components/toast) that explains what went wrong and how to try again.
+If the delete action fails, keep the Alert Dialog open and display an error [Toast](/components/toast) that explains what went wrong and how to try again.
 
 For more information, check out our [Notifications and Feedback patterns](/patterns/notifications-and-feedback).
 
-## Starter kits
-
-### CodeSandbox
-
-Coming soon
-
-### Figma
-
-Coming soon
+<LivePreview
+  scope={{
+    AlertDialog,
+    Button,
+    Toaster,
+    useToaster,
+  }}
+  noInline
+  showOverflow
+>
+  {PostDeletionExample}
+</LivePreview>
 
 </content>
 


### PR DESCRIPTION
Adds prop `disableDestructive` to Alert Dialog so that the confirm button can be disabled on destructive Alert Dialogs. This functionality allows consumers to accurately implement the [High Severity Delete Pattern](https://paste.twilio.design/patterns/delete#high-severity).

Also updates the delete pattern docs page to use live examples, using Alert Dialog and the new `disableDestructive` prop.