### PR TITLE
fix: site search indexing by Algolia

### DIFF
--- a/packages/paste-website/src/components/site-wrapper/SiteMain.tsx
+++ b/packages/paste-website/src/components/site-wrapper/SiteMain.tsx
@@ -4,7 +4,7 @@ import type {HTMLPasteProps} from '@twilio-paste/types';
 
 export const SiteMain: React.FC<React.PropsWithChildren<HTMLPasteProps<'div'>>> = ({children, ...props}) => {
   return (
-    <Box backgroundColor="colorBackgroundBody" position="relative" {...props}>
+    <Box as="main" backgroundColor="colorBackgroundBody" position="relative" {...props}>
       {children}
     </Box>
   );


### PR DESCRIPTION
Description and useful links to discussions / issues / tickets

## Changes in this PR:

### Bring back the main element

In the switch to the new nav UI kit, the main element that was wrapping the main content was dropped by accident. This broke the Algolia indexing as the selector is dependent on the main element being there. It's also just good practice to have one.


## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
