### PR TITLE
fix: chromatic flakes

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -261,4 +261,6 @@ export const parameters = {
   viewport: {
     viewports: INITIAL_VIEWPORTS,
   },
+  // Notifies Chromatic to pause the animations when they finish for all stories.
+  chromatic: {pauseAnimationAtEnd: true},
 };

--- a/packages/paste-core/components/spinner/stories/index.stories.tsx
+++ b/packages/paste-core/components/spinner/stories/index.stories.tsx
@@ -2,12 +2,9 @@ import * as React from 'react';
 import type {StoryFn} from '@storybook/react';
 import {Box} from '@twilio-paste/box';
 import {Card} from '@twilio-paste/card';
-import {Button} from '@twilio-paste/button';
 import {useTheme, DefaultTheme} from '@twilio-paste/theme';
 import {CustomizationProvider} from '@twilio-paste/customization';
-import {ScreenReaderOnly} from '@twilio-paste/screen-reader-only';
 import type {IconSize, TextColorOptions} from '@twilio-paste/style-props';
-import {styled} from '@twilio-paste/styling-library';
 
 import {Spinner} from '../src';
 
@@ -15,7 +12,6 @@ import {Spinner} from '../src';
 export default {
   title: 'Components/Spinner',
   component: Spinner,
-  excludeStories: ['LoadingOverlay', 'StyledLoadingOverlay', 'StyledLoadingOverlayContent'],
 };
 
 const {textColors: defaultThemeTextColors, iconSizes} = DefaultTheme;
@@ -69,96 +65,13 @@ export const InverseColors = (): React.ReactNode => (
   </Box>
 );
 
-export const Sizes: React.ReactNode = () => (
+export const Sizes: React.FC = () => (
   <Box display="flex" marginX="space80" paddingY="space80" alignItems="center" justifyContent="space-between">
     {Object.keys(iconSizes).map((iconSize) => (
       <Spinner decorative={false} title={iconSize} size={iconSize as IconSize} key={`dark-${iconSize}`} />
     ))}
   </Box>
 );
-
-const StyledLoadingOverlay = styled.div({
-  position: 'fixed',
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  background: 'rgba(0, 0, 0, 0.7)',
-});
-const StyledLoadingOverlayContent = styled.div({
-  position: 'fixed',
-  top: '50%',
-  display: 'flex',
-});
-interface LoadingOverlayProps {
-  isOpen: boolean;
-}
-
-export const LoadingOverlay: React.FC<React.PropsWithChildren<LoadingOverlayProps>> = ({isOpen, children}) => {
-  if (isOpen) {
-    return (
-      <StyledLoadingOverlay>
-        <StyledLoadingOverlayContent>
-          <Box display="flex" flexDirection="column">
-            {children}
-          </Box>
-        </StyledLoadingOverlayContent>
-      </StyledLoadingOverlay>
-    );
-  }
-
-  return null;
-};
-
-export const InFullscreenOverlay: React.ReactNode = () => {
-  const countdown = 7;
-  const timeoutTime = countdown * 1000;
-  const [isOpen, setIsOpen] = React.useState(true);
-  const handleOpenOnClick = (): void => setIsOpen(true);
-
-  const [seconds, updateSeconds] = React.useState(countdown);
-
-  const decrementSeconds = (): void => {
-    updateSeconds((state: number) => state - 1);
-  };
-
-  React.useEffect(() => {
-    let timeout: NodeJS.Timeout;
-    let interval: NodeJS.Timeout;
-
-    if (isOpen) {
-      timeout = setTimeout((): void => setIsOpen(false), timeoutTime);
-      interval = setInterval(decrementSeconds, 1000);
-    }
-
-    return () => {
-      if (timeout) {
-        clearTimeout(timeout);
-        clearInterval(interval);
-      }
-    };
-  }, [isOpen, setIsOpen]);
-
-  return (
-    <Box>
-      <Button variant="secondary" onClick={handleOpenOnClick}>
-        Open loading overlay
-      </Button>
-
-      {isOpen ? (
-        <StyledLoadingOverlay>
-          <StyledLoadingOverlayContent>
-            <ScreenReaderOnly>Spinner example with full page overlay, {seconds} seconds remain.</ScreenReaderOnly>
-            <Spinner size="sizeIcon80" decorative={false} title="Loading logs..." color="colorTextInverse" />
-          </StyledLoadingOverlayContent>
-        </StyledLoadingOverlay>
-      ) : null}
-    </Box>
-  );
-};
 
 export const CustomizedSpinner: StoryFn = (_args, {parameters: {isTestEnvironment}}) => {
   const currentTheme = useTheme();

--- a/packages/paste-core/components/status/stories/StatusMenu.stories.tsx
+++ b/packages/paste-core/components/status/stories/StatusMenu.stories.tsx
@@ -306,7 +306,7 @@ export default {
   subcomponents: {StatusMenuBadge, StatusMenuItemChild},
   parameters: {
     // Sets a delay for the component's stories
-    chromatic: {delay: 3000},
+    chromatic: {delay: 3000, diffThreshold: 0.2},
   },
 };
 export const Process: StoryFn = () => (

--- a/packages/paste-core/components/status/stories/StatusMenuCustomization.stories.tsx
+++ b/packages/paste-core/components/status/stories/StatusMenuCustomization.stories.tsx
@@ -76,7 +76,7 @@ export default {
   component: StatusMenu,
   parameters: {
     // Sets a delay for the component's stories
-    chromatic: {delay: 3000},
+    chromatic: {delay: 3000, diffThreshold: 0.2},
     a11y: {
       // no need to a11y check customization
       disable: true,

--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -207,8 +207,7 @@ export const CustomizedTooltip: StoryFn = (_args, {parameters: {isTestEnvironmen
 CustomizedTooltip.storyName = 'Customized Tooltip';
 CustomizedTooltip.parameters = {
   parameters: {
-    // default diffThreshold is 0.063
-    chromatic: {delay: 3000, diffThreshold: 0.2},
+    chromatic: {disableSnapshot: true},
   },
   a11y: {
     // no need to a11y check customization

--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -40,7 +40,6 @@ export default {
   excludeStories: ['StateHookExample'],
   component: Tooltip,
   parameters: {
-    // default diffThreshold is 0.063
     chromatic: {delay: 3000, diffThreshold: 0.2},
   },
 };

--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -206,6 +206,10 @@ export const CustomizedTooltip: StoryFn = (_args, {parameters: {isTestEnvironmen
 
 CustomizedTooltip.storyName = 'Customized Tooltip';
 CustomizedTooltip.parameters = {
+  parameters: {
+    // default diffThreshold is 0.063
+    chromatic: {delay: 3000, diffThreshold: 0.2},
+  },
   a11y: {
     // no need to a11y check customization
     disable: true,

--- a/packages/paste-core/components/tooltip/stories/index.stories.tsx
+++ b/packages/paste-core/components/tooltip/stories/index.stories.tsx
@@ -40,8 +40,8 @@ export default {
   excludeStories: ['StateHookExample'],
   component: Tooltip,
   parameters: {
-    // Sets a delay for the component's stories
-    chromatic: {delay: 3000, diffThreshold: 0.3},
+    // default diffThreshold is 0.063
+    chromatic: {delay: 3000, diffThreshold: 0.2},
   },
 };
 

--- a/packages/paste-libraries/data-visualization/stories/index.stories.tsx
+++ b/packages/paste-libraries/data-visualization/stories/index.stories.tsx
@@ -18,7 +18,8 @@ import {pieChartOptions} from './options/pieChartOptions';
 export default {
   title: 'Libraries/data-visualization',
   parameters: {
-    chromatic: {delay: 1000},
+    // default diffThreshold is 0.063
+    chromatic: {delay: 3000, diffThreshold: 0.2},
   },
 } as Meta;
 

--- a/packages/paste-libraries/data-visualization/stories/index.stories.tsx
+++ b/packages/paste-libraries/data-visualization/stories/index.stories.tsx
@@ -4,6 +4,7 @@ import {Stack} from '@twilio-paste/stack';
 /* eslint-disable import/no-extraneous-dependencies */
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import merge from 'deepmerge';
 /* eslint-enable */
 
 import {usePasteHighchartsTheme} from '../src';
@@ -23,68 +24,88 @@ export default {
   },
 } as Meta;
 
+const disableAnimationOptions = {
+  chart: {
+    animation: false,
+  },
+  plotOptions: {
+    series: {
+      animation: false,
+    },
+  },
+  drilldown: {
+    animation: false,
+  },
+};
+
 export const LineChart: StoryFn = () => {
-  const themedLineChartOptions = usePasteHighchartsTheme(lineChartOptions);
+  const disabledAnimationOptions = merge(lineChartOptions, disableAnimationOptions);
+  const themedLineChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedLineChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={lineChartOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };
 
 export const LineChartWithAnnotations: StoryFn = () => {
-  const themedLineChartWithAnnotationsOptions = usePasteHighchartsTheme(lineChartWithAnnotationsOptions);
+  const disabledAnimationOptions = merge(lineChartWithAnnotationsOptions, disableAnimationOptions);
+  const themedLineChartWithAnnotationsOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedLineChartWithAnnotationsOptions} />
-      <HighchartsReact highcharts={Highcharts} options={lineChartWithAnnotationsOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };
 
 export const TimeSeries: StoryFn = () => {
-  const themedTimeSeriesChartOptions = usePasteHighchartsTheme(timeSeriesOptions);
+  const disabledAnimationOptions = merge(timeSeriesOptions, disableAnimationOptions);
+  const themedTimeSeriesChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedTimeSeriesChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={timeSeriesOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };
 
 export const ColumnChart: StoryFn = () => {
-  const themedColumnChartOptions = usePasteHighchartsTheme(columnChartOptions);
+  const disabledAnimationOptions = merge(columnChartOptions, disableAnimationOptions);
+  const themedColumnChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedColumnChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={columnChartOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };
 
 export const BasicAreaChart: StoryFn = () => {
-  const themedBasicAreaChartOptions = usePasteHighchartsTheme(basicAreaChartOptions);
+  const disabledAnimationOptions = merge(basicAreaChartOptions, disableAnimationOptions);
+  const themedBasicAreaChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedBasicAreaChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={basicAreaChartOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };
 
 export const PieChart: StoryFn = () => {
-  const themedPieChartOptions = usePasteHighchartsTheme(pieChartOptions);
+  const disabledAnimationOptions = merge(pieChartOptions, disableAnimationOptions);
+  const themedPieChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedPieChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={pieChartOptions} />
+      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
     </Stack>
   );
 };

--- a/packages/paste-libraries/data-visualization/stories/index.stories.tsx
+++ b/packages/paste-libraries/data-visualization/stories/index.stories.tsx
@@ -4,7 +4,6 @@ import {Stack} from '@twilio-paste/stack';
 /* eslint-disable import/no-extraneous-dependencies */
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
-import merge from 'deepmerge';
 /* eslint-enable */
 
 import {usePasteHighchartsTheme} from '../src';
@@ -19,92 +18,72 @@ import {pieChartOptions} from './options/pieChartOptions';
 export default {
   title: 'Libraries/data-visualization',
   parameters: {
-    chromatic: {delay: 3000, diffThreshold: 0.2},
+    chromatic: {disableSnapshot: true},
   },
 } as Meta;
 
-const disableAnimationOptions = {
-  chart: {
-    animation: false,
-  },
-  plotOptions: {
-    series: {
-      animation: false,
-    },
-  },
-  drilldown: {
-    animation: false,
-  },
-};
-
 export const LineChart: StoryFn = () => {
-  const disabledAnimationOptions = merge(lineChartOptions, disableAnimationOptions);
-  const themedLineChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedLineChartOptions = usePasteHighchartsTheme(lineChartOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedLineChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={lineChartOptions} />
     </Stack>
   );
 };
 
 export const LineChartWithAnnotations: StoryFn = () => {
-  const disabledAnimationOptions = merge(lineChartWithAnnotationsOptions, disableAnimationOptions);
-  const themedLineChartWithAnnotationsOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedLineChartWithAnnotationsOptions = usePasteHighchartsTheme(lineChartWithAnnotationsOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedLineChartWithAnnotationsOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={lineChartWithAnnotationsOptions} />
     </Stack>
   );
 };
 
 export const TimeSeries: StoryFn = () => {
-  const disabledAnimationOptions = merge(timeSeriesOptions, disableAnimationOptions);
-  const themedTimeSeriesChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedTimeSeriesChartOptions = usePasteHighchartsTheme(timeSeriesOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedTimeSeriesChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={timeSeriesOptions} />
     </Stack>
   );
 };
 
 export const ColumnChart: StoryFn = () => {
-  const disabledAnimationOptions = merge(columnChartOptions, disableAnimationOptions);
-  const themedColumnChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedColumnChartOptions = usePasteHighchartsTheme(columnChartOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedColumnChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={columnChartOptions} />
     </Stack>
   );
 };
 
 export const BasicAreaChart: StoryFn = () => {
-  const disabledAnimationOptions = merge(basicAreaChartOptions, disableAnimationOptions);
-  const themedBasicAreaChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedBasicAreaChartOptions = usePasteHighchartsTheme(basicAreaChartOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedBasicAreaChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={basicAreaChartOptions} />
     </Stack>
   );
 };
 
 export const PieChart: StoryFn = () => {
-  const disabledAnimationOptions = merge(pieChartOptions, disableAnimationOptions);
-  const themedPieChartOptions = usePasteHighchartsTheme(disabledAnimationOptions);
+  const themedPieChartOptions = usePasteHighchartsTheme(pieChartOptions);
 
   return (
     <Stack orientation="vertical" spacing="space100">
       <HighchartsReact highcharts={Highcharts} options={themedPieChartOptions} />
-      <HighchartsReact highcharts={Highcharts} options={disabledAnimationOptions} />
+      <HighchartsReact highcharts={Highcharts} options={pieChartOptions} />
     </Stack>
   );
 };

--- a/packages/paste-libraries/data-visualization/stories/index.stories.tsx
+++ b/packages/paste-libraries/data-visualization/stories/index.stories.tsx
@@ -19,7 +19,6 @@ import {pieChartOptions} from './options/pieChartOptions';
 export default {
   title: 'Libraries/data-visualization',
   parameters: {
-    // default diffThreshold is 0.063
     chromatic: {delay: 3000, diffThreshold: 0.2},
   },
 } as Meta;


### PR DESCRIPTION
Fixes common chromatic flakes.

I had to disable some story tests, it was the only way. DataVis tokens are snapshot tested, so no point VRTing the renders. Highcharts shouldnt break unless we update it, and if we update it we surely will have the clarity of mind to review the examples on storybook.

Some customization stories flaked. I just removed them since they still have customization jest tests. Basically any popover that appears is at risk of flaking due to sub-pixel positioning issues. The flakes are much too noisy, worth losing those tests.

