### PR TITLE
chore: update the install guides to mention types peer deps

### DIFF
--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -158,6 +158,7 @@
     "react-visibility-sensor": "5.1.1",
     "remark-gfm": "^3.0.1",
     "rollbar": "^2.25.0",
+    "sharp": "^0.32.5",
     "typescript": "^4.9.4",
     "unist-util-visit-esm": "npm:unist-util-visit@^4.1.2",
     "use-resize-observer": "^9.1.0",

--- a/packages/paste-website/src/pages/components/anchor/index.mdx
+++ b/packages/paste-website/src/pages/components/anchor/index.mdx
@@ -127,6 +127,7 @@ When placing an Anchor within a sentence, don't link the whole sentence. Instead
 When the link is at the end of a paragraph or block of text, avoid punctuation except for a question mark.
 
 ## Dos and don'ts
+
 <DoDont>
   <Do title="Do" body="Anchors should only be used to link to another page, app, or another website." center>
     <Anchor href="https://paste.twilio.design">Go to API documentation</Anchor>
@@ -173,7 +174,7 @@ yarn add @twilio-paste/anchor - or - yarn add @twilio-paste/core
 
 #### Usage
 
-```js
+```jsx
 import {Anchor} from '@twilio-paste/core/anchor';
 
 const Component = () => <Anchor href="https://paste.twilio.design">Go to Paste</Anchor>;

--- a/packages/paste-website/src/pages/components/aspect-ratio/index.mdx
+++ b/packages/paste-website/src/pages/components/aspect-ratio/index.mdx
@@ -172,7 +172,7 @@ yarn add @twilio-paste/aspect-ratio - or - yarn add @twilio-paste/core
 
 #### Usage
 
-```js
+```jsx
 import {AspectRatio} from '@twilio-paste/core/aspect-ratio';
 import {Box} from '@twilio-paste/core/box';
 

--- a/packages/paste-website/src/pages/core/libraries/codemods/index.mdx
+++ b/packages/paste-website/src/pages/core/libraries/codemods/index.mdx
@@ -72,7 +72,7 @@ This will start an interactive wizard, and then run the specified transform.
 
 Converts old-style core imports to the new unbarreled style. (i.e.: `import {Button} from '@twilio-paste/core'` becomes `import {Button} from '@twilio-paste/core/button'`)
 
-```sh
+```bash
 npx @twilio-paste/codemods barreled-to-unbarreled <path>
 ```
 
@@ -80,7 +80,7 @@ npx @twilio-paste/codemods barreled-to-unbarreled <path>
 
 To pass more options directly to jscodeshift, use `--jscodeshift="..."`. For example:
 
-```sh
+```bash
 npx @twilio-paste/codemods --jscodeshift="--run-in-band --verbose=2"
 ```
 
@@ -91,7 +91,7 @@ See [all available jscodeshift options](https://github.com/facebook/jscodeshift#
 Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through jscodeshift's `printOptions` command line argument
 
-```sh
+```bash
 npx @twilio-paste/codemods <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
 ```
 

--- a/packages/paste-website/src/pages/introduction/for-designers/design-guidelines/index.mdx
+++ b/packages/paste-website/src/pages/introduction/for-designers/design-guidelines/index.mdx
@@ -31,7 +31,7 @@ export const getStaticProps = async () => {
 
 <h1>{meta.title}</h1>
 
-<Paragraph>{meta.description}</Paragraph>
+<p>{meta.description}</p>
 
 </content>
 

--- a/packages/paste-website/src/pages/introduction/for-engineers/manual-installation/index.mdx
+++ b/packages/paste-website/src/pages/introduction/for-engineers/manual-installation/index.mdx
@@ -56,15 +56,23 @@ To start using Paste, you must first install the following third party dependenc
     <TBody>
       <Tr>
         <Td>react</Td>
-        <Td>{Package.dependencies['react']}</Td>
+        <Td>{CorePkgJson.peerDependencies['react']}</Td>
       </Tr>
       <Tr>
         <Td>react-dom</Td>
-        <Td>{Package.dependencies['react-dom']}</Td>
+        <Td>{CorePkgJson.peerDependencies['react-dom']}</Td>
+      </Tr>
+      <Tr>
+        <Td>@types/react</Td>
+        <Td>{CorePkgJson.peerDependencies['@types/react']}</Td>
+      </Tr>
+      <Tr>
+        <Td>@types/react-dom</Td>
+        <Td>{CorePkgJson.peerDependencies['@types/react-dom']}</Td>
       </Tr>
       <Tr>
         <Td>prop-types</Td>
-        <Td>{Package.dependencies['prop-types']}</Td>
+        <Td>{CorePkgJson.peerDependencies['prop-types']}</Td>
       </Tr>
     </TBody>
   </Table>
@@ -72,21 +80,13 @@ To start using Paste, you must first install the following third party dependenc
 
 Install them in your project folder using either of these terminal commands:
 
-```shell
+```bash
 # yarn
 yarn add react react-dom prop-types
 
 # npm
 npm install react react-dom prop-types
 ```
-
-<Callout variant="warning" marginY="space70">
-  <CalloutHeading as="h2">A special callout on @types/react</CalloutHeading>
-  <CalloutText>
-    @types/react is bundled with Paste Core. To ensure you are using the correct version of @types/react, please do not
-    install it in your project. If you have already installed it, please remove it.
-  </CalloutText>
-</Callout>
 
 ## Paste Packages
 
@@ -116,7 +116,7 @@ A key distinction with Paste Core is that we _include_ - not _bundle_ - all of P
   </Table>
 </Box>
 
-```shell
+```bash
 # yarn
 yarn add @twilio-paste/core @twilio-paste/icons
 
@@ -160,9 +160,9 @@ Fonts for our out of the box themes are available via the Twilio CDN and publish
 
 The **best and most performant way** to load the fonts is to include the following snippet in the `<head />` of your web page.
 
-```
+```html
 <link rel="preconnect" href="https://assets.twilio.com" crossorigin />
-<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css">
+<link rel="stylesheet" href="https://assets.twilio.com/public_assets/paste-fonts/1.5.1/fonts.css" />
 ```
 
 <Callout variant="neutral" marginY="space70">
@@ -206,7 +206,7 @@ It can sometimes be helpful to test Paste components without animation. To disab
 
 Jest will often complain about using the esModules versions (`/esm/`) of Paste Icons, since it perfers the commonJS version. You'll often see an error similar to:
 
-```
+```bash
 Test suite failed to run
   unknown: Unexpected token (1:660)
     This usually means that you are trying to import a file which
@@ -219,7 +219,7 @@ In order to fix these Jest errors, you'll need to configure Jest to correctly ha
 You can use the `transformIgnorePatterns` option to tell Jest to not transform Paste Icons, which allows Jest to transpile these files. More
 information about `transformIgnorePatterns` can be found by [reading the Jest documentation](https://jestjs.io/docs/en/configuration#transformignorepatterns-arraystring).
 
-```js
+```javascript
 // jest.config.js
 {
   "transformIgnorePatterns": [

--- a/packages/paste-website/src/pages/introduction/for-engineers/quickstart/index.mdx
+++ b/packages/paste-website/src/pages/introduction/for-engineers/quickstart/index.mdx
@@ -50,7 +50,7 @@ Paste has a pre-made template for `create-next-app` that comes with `@twilio-pas
 
 To create a new `create-next-app` app using the Paste template execute the following commands:
 
-```shell
+```bash
 yarn create next-app --example https://github.com/twilio-labs/paste/tree/main/packages/paste-nextjs-template my-paste-app
 cd my-paste-app
 yarn dev
@@ -79,7 +79,7 @@ Paste has a pre-made template for `create-react-app` that comes with `@twilio-pa
 
 To create a new `create-react-app` app using the Paste template execute the following command:
 
-```shell
+```bash
 yarn create react-app --template @twilio-paste my-paste-app
 cd my-paste-app
 yarn start

--- a/packages/paste-website/src/pages/theme/index.mdx
+++ b/packages/paste-website/src/pages/theme/index.mdx
@@ -67,7 +67,7 @@ the theme object to any descendant components in the tree. For that reason, we r
 application at the root level with the Paste `ThemeProvider`. This allows all sub-components to retrieve
 the correct token value for the supplied theme.
 
-```js
+```javascript
 import {Theme} from '@twilio-paste/theme';
 
 <Theme.Provider theme="default">
@@ -104,7 +104,7 @@ By using the `Theme.Provider`, when you create a custom component using Styling-
 
 This is the preferred method.
 
-```js
+```javascript
 import {styled, css} from '@twilio-paste/styling-library';
 
 const custom = styled.div(
@@ -131,7 +131,7 @@ If you are not using Styled Components or want to access the values of tokens in
 
 Paste Theme provides `Theme.Consumer` - a React Context Consumer for the theme. It takes a function as a child, which provides the theme object as an argument.
 
-```js
+```javascript
 import {Theme} from '@twilio-paste/theme';
 
 <Theme.Consumer>
@@ -145,7 +145,7 @@ import {Theme} from '@twilio-paste/theme';
 
 Paste Theme provides a React Hook called `useTheme` which returns the theme object from the React Context via the Theme Provider.
 
-```js
+```javascript
 import React from 'react';
 import {useTheme} from '@twilio-paste/theme';
 
@@ -159,7 +159,7 @@ const HookExampleComponent = (): React.ReactElement => {
 
 Paste also provides a HoC to be able to access the theme object.
 
-```js
+```javascript
 import React from 'react';
 import {withTheme} from '@twilio-paste/theme';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16989,6 +16989,7 @@ __metadata:
     react-visibility-sensor: 5.1.1
     remark-gfm: ^3.0.1
     rollbar: ^2.25.0
+    sharp: ^0.32.5
     typescript: ^4.9.4
     unist-util-visit-esm: "npm:unist-util-visit@^4.1.2"
     use-resize-observer: ^9.1.0
@@ -20611,6 +20612,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"b4a@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "b4a@npm:1.6.4"
+  checksum: 81b086f9af1f8845fbef4476307236bda3d660c158c201db976f19cdce05f41f93110ab6b12fd7a2696602a490cc43d5410ee36a56d6eef93afb0d6ca69ac3b2
+  languageName: node
+  linkType: hard
+
 "babel-core@npm:^7.0.0-bridge.0":
   version: 7.0.0-bridge.0
   resolution: "babel-core@npm:7.0.0-bridge.0"
@@ -22649,6 +22657,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
 "color-support@npm:^1.1.2, color-support@npm:^1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
@@ -22675,6 +22693,16 @@ __metadata:
     color-convert: ^1.9.1
     color-string: ^1.5.4
   checksum: d52a77ae239e1cdb55d9920e73d730df69a05cec9cb5d9b83a3e311b23009fd4053f4a88e7f6152207db498838f10e3ba4b1661a64a3acb41a50b14944214f26
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -24450,6 +24478,13 @@ __metadata:
   version: 2.0.1
   resolution: "detect-libc@npm:2.0.1"
   checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "detect-libc@npm:2.0.2"
+  checksum: 2b2cd3649b83d576f4be7cc37eb3b1815c79969c8b1a03a40a4d55d83bc74d010753485753448eacb98784abf22f7dbd3911fd3b60e29fda28fed2d1a997944d
   languageName: node
   linkType: hard
 
@@ -27165,6 +27200,13 @@ __metadata:
   version: 1.2.0
   resolution: "fast-diff@npm:1.2.0"
   checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
+  languageName: node
+  linkType: hard
+
+"fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
   languageName: node
   linkType: hard
 
@@ -36240,6 +36282,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "node-addon-api@npm:6.1.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 3a539510e677cfa3a833aca5397300e36141aca064cdc487554f2017110709a03a95da937e98c2a14ec3c626af7b2d1b6dabe629a481f9883143d0d5bff07bf2
+  languageName: node
+  linkType: hard
+
 "node-cleanup@npm:^2.1.2":
   version: 2.1.2
   resolution: "node-cleanup@npm:2.1.2"
@@ -39311,7 +39362,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.0.1":
+"prebuild-install@npm:^7.0.1, prebuild-install@npm:^7.1.1":
   version: 7.1.1
   resolution: "prebuild-install@npm:7.1.1"
   dependencies:
@@ -39911,6 +39962,13 @@ fsevents@^1.2.7:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"queue-tick@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "queue-tick@npm:1.0.1"
+  checksum: 57c3292814b297f87f792fbeb99ce982813e4e54d7a8bdff65cf53d5c084113913289d4a48ec8bbc964927a74b847554f9f4579df43c969a6c8e0f026457ad01
   languageName: node
   linkType: hard
 
@@ -42279,7 +42337,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.3":
+"semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -42536,6 +42594,23 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"sharp@npm:^0.32.5":
+  version: 0.32.5
+  resolution: "sharp@npm:0.32.5"
+  dependencies:
+    color: ^4.2.3
+    detect-libc: ^2.0.2
+    node-addon-api: ^6.1.0
+    node-gyp: latest
+    prebuild-install: ^7.1.1
+    semver: ^7.5.4
+    simple-get: ^4.0.1
+    tar-fs: ^3.0.4
+    tunnel-agent: ^0.6.0
+  checksum: 3cd6dc037c9ba126a30af90ac94043c4418bbb4228e15fd446638ff43fc9b14eabb553037988e484162c318f7baff21d896a5bef7dcc453f608e247d468f41e0
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^1.2.0":
   version: 1.2.0
   resolution: "shebang-command@npm:1.2.0"
@@ -42658,7 +42733,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"simple-get@npm:^4.0.0":
+"simple-get@npm:^4.0.0, simple-get@npm:^4.0.1":
   version: 4.0.1
   resolution: "simple-get@npm:4.0.1"
   dependencies:
@@ -43545,6 +43620,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"streamx@npm:^2.15.0":
+  version: 2.15.1
+  resolution: "streamx@npm:2.15.1"
+  dependencies:
+    fast-fifo: ^1.1.0
+    queue-tick: ^1.0.1
+  checksum: 6f2b4fed68caacd28efbd44d4264f5d3c2b81b0a5de14419333dac57f2075c49ae648df8d03db632a33587a6c8ab7cb9cdb4f9a2f8305be0c2cd79af35742b15
+  languageName: node
+  linkType: hard
+
 "strict-uri-encode@npm:^2.0.0":
   version: 2.0.0
   resolution: "strict-uri-encode@npm:2.0.0"
@@ -44127,6 +44212,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "tar-fs@npm:3.0.4"
+  dependencies:
+    mkdirp-classic: ^0.5.2
+    pump: ^3.0.0
+    tar-stream: ^3.1.5
+  checksum: dcf4054f9e92ca0efe61c2b3f612914fb259a47900aa908a63106513a6d006c899b426ada53eb88d9dbbf089b5724c8e90b96a2c4ca6171845fa14203d734e30
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:^2.0.1, tar-stream@npm:^2.1.4, tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -44137,6 +44233,17 @@ resolve@^2.0.0-next.3:
     inherits: ^2.0.3
     readable-stream: ^3.1.1
   checksum: 699831a8b97666ef50021c767f84924cfee21c142c2eb0e79c63254e140e6408d6d55a065a2992548e72b06de39237ef2b802b99e3ece93ca3904a37622a66f3
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^3.1.5":
+  version: 3.1.6
+  resolution: "tar-stream@npm:3.1.6"
+  dependencies:
+    b4a: ^1.6.4
+    fast-fifo: ^1.2.0
+    streamx: ^2.15.0
+  checksum: f3627f918581976e954ff03cb8d370551053796b82564f8c7ca8fac84c48e4d042026d0854fc222171a34ff9c682b72fae91be9c9b0a112d4c54f9e4f443e9c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Description and useful links to discussions / issues / tickets

## Changes in this PR:

### Update install guide on deps

We moved to types being a peer dep but didn't update the install guide.

### Add sharp for image optimization

I feel like I removed it by accident, but maybe that was another website

### Fix a bunch of prop type warnings

For codeblocks, we only allow certain syntax, and prop types was doing what it should and telling us we did it wrong

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
