### PR TITLE
chore(meter): add docs, update designs

### DIFF
--- a/.changeset/blue-phones-battle.md
+++ b/.changeset/blue-phones-battle.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/meter': patch
+'@twilio-paste/core': patch
+---
+
+[Meter] Finalize designs of Meter component, bump to Production status, and add documentation.

--- a/.changeset/olive-lizards-enjoy.md
+++ b/.changeset/olive-lizards-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@twilio-paste/codemods': patch
+---
+
+[Codemods] New export from Meter package: MeterLabel

--- a/cypress/integration/sitemap-vrt/constants.ts
+++ b/cypress/integration/sitemap-vrt/constants.ts
@@ -60,6 +60,7 @@ export const SITEMAP = [
   '/components/list/',
   '/components/minimizable-dialog/',
   '/components/media-object/',
+  '/components/meter',
   '/components/pagination/',
   '/components/modal/',
   '/components/menu/',

--- a/packages/paste-core/components/meter/__tests__/index.spec.tsx
+++ b/packages/paste-core/components/meter/__tests__/index.spec.tsx
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react';
 import {Theme} from '@twilio-paste/theme';
 import type {RenderOptions} from '@testing-library/react';
 
-import {Default, HiddenValueLabelAriaLabel, Customized} from '../stories/index.stories';
+import {Default, AriaLabel, Customized} from '../stories/index.stories';
 
 const ThemeWrapper: RenderOptions['wrapper'] = ({children}) => (
   <Theme.Provider theme="default">{children}</Theme.Provider>
@@ -21,14 +21,14 @@ describe('Meter', () => {
       expect(meter).toHaveAttribute('aria-valuemax', '100');
       expect(meter).toHaveAttribute('aria-valuenow', '75');
       expect(meter).toHaveAttribute('aria-valuetext', '75%');
-      expect(meter).toHaveAttribute('id', 'meter');
-      expect(meter).toHaveAttribute('aria-labelledby', 'meterMETER_LABEL');
+      expect(meter).toHaveAttribute('id');
+      expect(meter).toHaveAttribute('aria-labelledby');
     });
 
     it('should apply aria-label correctly', () => {
-      render(<HiddenValueLabelAriaLabel />, {wrapper: ThemeWrapper});
+      render(<AriaLabel />, {wrapper: ThemeWrapper});
       const meter = screen.getByRole('meter');
-      expect(meter).toHaveAttribute('aria-label', 'Fuel level');
+      expect(meter).toHaveAttribute('aria-label', 'Storage space');
       expect(meter).not.toHaveAttribute('aria-labelledby');
     });
   });
@@ -36,18 +36,32 @@ describe('Meter', () => {
   describe('Customization', () => {
     it('should set default data-paste-element attribute on meter', () => {
       render(<Customized />);
-      const meterOne = screen.getByTestId('meter_one');
-      expect(meterOne).toHaveAttribute(elementAttr, 'METER');
       const meterLabelOne = screen.getByTestId('meter_label_one');
       expect(meterLabelOne).toHaveAttribute(elementAttr, 'METER_LABEL');
+      expect(meterLabelOne.parentElement).toHaveAttribute(elementAttr, 'METER_LABEL_WRAPPER');
+      expect(meterLabelOne.nextElementSibling).toHaveAttribute(elementAttr, 'METER_LABEL_VALUE_LABEL');
+      const meterOne = screen.getByTestId('meter_one');
+      expect(meterOne).toHaveAttribute(elementAttr, 'METER');
+      expect(meterOne.firstElementChild).toHaveAttribute(elementAttr, 'METER_BAR');
+      expect(meterOne.firstElementChild?.firstElementChild).toHaveAttribute(elementAttr, 'METER_FILL');
+      expect(meterOne.lastElementChild).toHaveAttribute(elementAttr, 'METER_MIN_MAX_WRAPPER');
+      expect(meterOne.lastElementChild?.firstElementChild).toHaveAttribute(elementAttr, 'METER_MIN');
+      expect(meterOne.lastElementChild?.lastElementChild).toHaveAttribute(elementAttr, 'METER_MAX');
     });
 
     it('should set custom data-paste-element attribute on meter', () => {
       render(<Customized />);
-      const meterTwo = screen.getByTestId('meter_two');
-      expect(meterTwo).toHaveAttribute(elementAttr, 'FOO');
       const meterLabelTwo = screen.getByTestId('meter_label_two');
       expect(meterLabelTwo).toHaveAttribute(elementAttr, 'FOO_LABEL');
+      expect(meterLabelTwo.parentElement).toHaveAttribute(elementAttr, 'FOO_LABEL_WRAPPER');
+      expect(meterLabelTwo.nextElementSibling).toHaveAttribute(elementAttr, 'FOO_LABEL_VALUE_LABEL');
+      const meterTwo = screen.getByTestId('meter_two');
+      expect(meterTwo).toHaveAttribute(elementAttr, 'FOO');
+      expect(meterTwo.firstElementChild).toHaveAttribute(elementAttr, 'FOO_BAR');
+      expect(meterTwo.firstElementChild?.firstElementChild).toHaveAttribute(elementAttr, 'FOO_FILL');
+      expect(meterTwo.lastElementChild).toHaveAttribute(elementAttr, 'FOO_MIN_MAX_WRAPPER');
+      expect(meterTwo.lastElementChild?.firstElementChild).toHaveAttribute(elementAttr, 'FOO_MIN');
+      expect(meterTwo.lastElementChild?.lastElementChild).toHaveAttribute(elementAttr, 'FOO_MAX');
     });
   });
 });

--- a/packages/paste-core/components/meter/package.json
+++ b/packages/paste-core/components/meter/package.json
@@ -2,7 +2,7 @@
   "name": "@twilio-paste/meter",
   "version": "1.0.0",
   "category": "data display",
-  "status": "alpha",
+  "status": "production",
   "description": "Meter is a visual representation of a numerical value within a known range.",
   "author": "Twilio Inc.",
   "license": "MIT",

--- a/packages/paste-core/components/meter/src/MeterLabel.tsx
+++ b/packages/paste-core/components/meter/src/MeterLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import {type BoxProps} from '@twilio-paste/box';
+import {type BoxProps, Box} from '@twilio-paste/box';
 import {Label} from '@twilio-paste/label';
+import {Text} from '@twilio-paste/text';
 import type {HTMLPasteProps} from '@twilio-paste/types';
 
 import {LABEL_SUFFIX} from './constants';
@@ -8,14 +9,36 @@ import {LABEL_SUFFIX} from './constants';
 export interface MeterLabelProps extends HTMLPasteProps<'div'>, Pick<BoxProps, 'element'> {
   children: string;
   htmlFor: string;
+  valueLabel?: string;
 }
 
 const MeterLabel = React.forwardRef<HTMLLabelElement, MeterLabelProps>(
-  ({element = 'METER_LABEL', children, htmlFor, ...labelProps}, ref) => {
+  ({element = 'METER_LABEL', children, htmlFor, valueLabel, ...labelProps}, ref) => {
     return (
-      <Label {...labelProps} as="div" element={element} id={`${htmlFor}${LABEL_SUFFIX}`} ref={ref}>
-        {children}
-      </Label>
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-end"
+        element={`${element}_WRAPPER`}
+      >
+        <Label {...labelProps} as="div" element={element} id={`${htmlFor}${LABEL_SUFFIX}`} ref={ref}>
+          {children}
+        </Label>
+        {valueLabel && (
+          <Text
+            as="span"
+            fontWeight="fontWeightSemibold"
+            textAlign="end"
+            marginBottom="space20"
+            marginLeft="space20"
+            aria-hidden="true"
+            element={`${element}_VALUE_LABEL`}
+          >
+            {valueLabel}
+          </Text>
+        )}
+      </Box>
     );
   }
 );

--- a/packages/paste-core/components/meter/stories/index.stories.tsx
+++ b/packages/paste-core/components/meter/stories/index.stories.tsx
@@ -2,6 +2,7 @@ import {CustomizationProvider} from '@twilio-paste/customization';
 import {useTheme} from '@twilio-paste/theme';
 import {useUID} from '@twilio-paste/uid-library';
 import {HelpText} from '@twilio-paste/help-text';
+import {Box} from '@twilio-paste/box';
 import * as React from 'react';
 
 import {Meter, MeterLabel} from '../src';
@@ -13,38 +14,94 @@ export default {
 };
 
 export const Default = (): React.ReactElement => {
-  const meterId = 'meter';
+  const meterId = useUID();
   return (
-    <>
-      <MeterLabel htmlFor={meterId}>Storage space</MeterLabel>
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="75%">
+        Storage used
+      </MeterLabel>
       <Meter value={75} id={meterId} />
-    </>
+    </Box>
   );
 };
 
-export const HiddenValueLabelAriaLabel = (): React.ReactElement => {
-  const meterId = useUID();
-  return <Meter aria-label="Fuel level" id={meterId} value={33} showValueLabel={false} />;
-};
-
-export const FormattedValueLabel = (): React.ReactElement => {
+export const Full = (): React.ReactElement => {
   const meterId = useUID();
   return (
-    <>
-      <MeterLabel htmlFor={meterId}>Account funds</MeterLabel>
-      <Meter id={meterId} value={80} formatOptions={{style: 'currency', currency: 'USD'}} />
-    </>
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="100%">
+        Storage used
+      </MeterLabel>
+      <Meter value={100} id={meterId} />
+    </Box>
   );
 };
 
-export const CustomValueLabelCustomLabel = (): React.ReactElement => {
+export const Empty = (): React.ReactElement => {
+  const meterId = useUID();
+  return (
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="0%">
+        Storage used
+      </MeterLabel>
+      <Meter value={0} id={meterId} />
+    </Box>
+  );
+};
+
+export const MinMax = (): React.ReactElement => {
+  const meterId = useUID();
+  return (
+    <Box width="size40">
+      <MeterLabel htmlFor={meterId} valueLabel="49GB">
+        Storage space used
+      </MeterLabel>
+      <Meter value={49} minValue={0} maxValue={64} minLabel="0GB" maxLabel="64GB" id={meterId} />
+    </Box>
+  );
+};
+
+export const MinOnly = (): React.ReactElement => {
+  const meterId = useUID();
+  return (
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="75%">
+        Storage space
+      </MeterLabel>
+      <Meter value={75} minValue={0} minLabel="0%" id={meterId} />
+    </Box>
+  );
+};
+
+export const MaxOnly = (): React.ReactElement => {
+  const meterId = useUID();
+  return (
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="75%">
+        Storage space
+      </MeterLabel>
+      <Meter value={75} maxValue={100} maxLabel="100%" id={meterId} />
+    </Box>
+  );
+};
+
+export const AriaLabel = (): React.ReactElement => {
+  const meterId = useUID();
+  return (
+    <Box width="size30">
+      <Meter aria-label="Storage space" id={meterId} value={33} />
+    </Box>
+  );
+};
+
+export const CustomLabel = (): React.ReactElement => {
   const labelId = useUID();
   const meterId = useUID();
   return (
-    <>
+    <Box width="size30" display="flex" flexDirection="column" rowGap="space20">
       <legend id={labelId}>Storage space used</legend>
-      <Meter aria-labelledby={labelId} id={meterId} value={54} minValue={0} maxValue={60} valueLabel="54 of 60GB" />
-    </>
+      <Meter aria-labelledby={labelId} id={meterId} value={54} minValue={0} maxValue={60} />
+    </Box>
   );
 };
 
@@ -52,11 +109,35 @@ export const WithHelpText = (): React.ReactElement => {
   const meterId = useUID();
   const helpTextId = useUID();
   return (
-    <>
-      <MeterLabel htmlFor={meterId}>Storage space used</MeterLabel>
-      <Meter id={meterId} value={54} minValue={0} maxValue={60} valueLabel="54 of 60GB" aria-describedby={helpTextId} />
+    <Box width="size40">
+      <MeterLabel htmlFor={meterId} valueLabel="54GB">
+        Storage space used
+      </MeterLabel>
+      <Meter
+        id={meterId}
+        value={54}
+        minValue={0}
+        maxValue={60}
+        aria-describedby={helpTextId}
+        minLabel="0GB"
+        maxLabel="64GB"
+      />
+      <HelpText id={helpTextId}>Additional storage may be purchased on your account page.</HelpText>
+    </Box>
+  );
+};
+
+export const Wrapped = (): React.ReactElement => {
+  const meterId = useUID();
+  const helpTextId = useUID();
+  return (
+    <Box width="size20">
+      <MeterLabel htmlFor={meterId} valueLabel="54,730 is the current value of this Meter">
+        Storage space used on this account that belongs to you
+      </MeterLabel>
+      <Meter id={meterId} value={54730} minValue={0} maxValue={600000} aria-describedby={helpTextId} />
       <HelpText id={helpTextId}>Helpful text</HelpText>
-    </>
+    </Box>
   );
 };
 
@@ -68,39 +149,70 @@ export const Customized = (): React.ReactElement => {
     <CustomizationProvider
       theme={theme}
       elements={{
-        METER_LABEL: {color: 'colorTextErrorStrongest'},
+        METER_LABEL_WRAPPER: {borderStyle: 'solid', borderWidth: 'borderWidth20'},
+        METER_LABEL: {color: 'colorTextError'},
+        METER_LABEL_VALUE_LABEL: {color: 'colorTextDecorative10'},
         METER: {
           borderStyle: 'solid',
           borderWidth: 'borderWidth30',
           borderColor: 'colorBorderDecorative20Weaker',
-          borderRadius: 'borderRadiusPill',
+          borderRadius: 'borderRadius10',
         },
-        METER_VALUE_LABEL_WRAPPER: {backgroundColor: 'colorBackgroundBrandHighlightWeakest'},
         METER_VALUE_LABEL: {color: 'colorTextDecorative30', fontWeight: 'fontWeightBold'},
-        METER_BAR: {backgroundColor: 'colorBackgroundDestructiveStrongest', borderRadius: 'borderRadiusPill'},
-        METER_FILL: {backgroundColor: 'colorBackgroundDecorative30Weakest', borderRadius: 'borderRadiusPill'},
+        METER_BAR: {backgroundColor: 'colorBackgroundDestructiveStrongest', borderRadius: 'borderRadius10'},
+        METER_FILL: {backgroundColor: 'colorBackgroundDecorative30Weakest', borderRadius: 'borderRadius10'},
+        METER_MIN_MAX_WRAPPER: {backgroundColor: 'colorBackgroundBrandHighlightWeakest'},
+        METER_MIN: {color: 'colorTextBrandHighlight'},
+        METER_MAX: {color: 'colorTextIconAvailable'},
 
-        FOO_LABEL: {color: 'colorTextErrorStrongest'},
+        FOO_LABEL_WRAPPER: {borderStyle: 'solid', borderWidth: 'borderWidth20'},
+        FOO_LABEL: {color: 'colorTextError'},
+        FOO_LABEL_VALUE_LABEL: {color: 'colorTextDecorative10'},
         FOO: {
           borderStyle: 'solid',
           borderWidth: 'borderWidth30',
           borderColor: 'colorBorderDecorative20Weaker',
-          borderRadius: 'borderRadiusPill',
+          borderRadius: 'borderRadius10',
         },
-        FOO_VALUE_LABEL_WRAPPER: {backgroundColor: 'colorBackgroundBrandHighlightWeakest'},
         FOO_VALUE_LABEL: {color: 'colorTextDecorative30', fontWeight: 'fontWeightBold'},
-        FOO_BAR: {backgroundColor: 'colorBackgroundDestructiveStrongest', borderRadius: 'borderRadiusPill'},
-        FOO_FILL: {backgroundColor: 'colorBackgroundDecorative30Weakest', borderRadius: 'borderRadiusPill'},
+        FOO_BAR: {backgroundColor: 'colorBackgroundDestructiveStrongest', borderRadius: 'borderRadius10'},
+        FOO_FILL: {backgroundColor: 'colorBackgroundDecorative30Weakest', borderRadius: 'borderRadius10'},
+        FOO_MIN_MAX_WRAPPER: {backgroundColor: 'colorBackgroundBrandHighlightWeakest'},
+        FOO_MIN: {color: 'colorTextBrandHighlight'},
+        FOO_MAX: {color: 'colorTextIconAvailable'},
       }}
     >
-      <MeterLabel htmlFor={meterOneId} data-testid="meter_label_one">
-        Storage space
-      </MeterLabel>
-      <Meter id={meterOneId} value={70} data-testid="meter_one" />
-      <MeterLabel htmlFor={meterTwoId} data-testid="meter_label_two" element="FOO_LABEL">
-        Storage space
-      </MeterLabel>
-      <Meter id={meterTwoId} value={30} element="FOO" data-testid="meter_two" />
+      <Box width="size30" display="flex" flexDirection="column" rowGap="space60">
+        <Box>
+          <MeterLabel htmlFor={meterOneId} data-testid="meter_label_one" valueLabel="70">
+            Storage space
+          </MeterLabel>
+          <Meter
+            id={meterOneId}
+            value={70}
+            minValue={0}
+            maxValue={100}
+            minLabel="0"
+            maxLabel="100"
+            data-testid="meter_one"
+          />
+        </Box>
+        <Box>
+          <MeterLabel htmlFor={meterTwoId} data-testid="meter_label_two" valueLabel="30" element="FOO_LABEL">
+            Storage space
+          </MeterLabel>
+          <Meter
+            id={meterTwoId}
+            value={30}
+            minValue={0}
+            maxValue={100}
+            minLabel="0"
+            maxLabel="100"
+            element="FOO"
+            data-testid="meter_two"
+          />
+        </Box>
+      </Box>
     </CustomizationProvider>
   );
 };

--- a/packages/paste-website/package.json
+++ b/packages/paste-website/package.json
@@ -83,6 +83,7 @@
     "@twilio-paste/media-object": "^10.0.0",
     "@twilio-paste/menu": "^14.0.1",
     "@twilio-paste/menu-primitive": "^2.0.0",
+    "@twilio-paste/meter": "^1.0.0",
     "@twilio-paste/minimizable-dialog": "^4.0.0",
     "@twilio-paste/modal": "^16.0.0",
     "@twilio-paste/modal-dialog-primitive": "^2.0.0",

--- a/packages/paste-website/src/component-examples/MeterExamples.ts
+++ b/packages/paste-website/src/component-examples/MeterExamples.ts
@@ -1,0 +1,35 @@
+export const defaultMeter = `
+const DefaultMeterExample = () => {
+  const meterId = useUID()
+  const helpTextId = useUID()
+  return (
+    <Box maxWidth="size30">
+      <MeterLabel htmlFor={meterId} valueLabel="89%">Emails delivered</MeterLabel>
+      <Meter value={89} id={meterId} />
+      <HelpText id={helpTextId}>Showing successful deliveries of June email campaign.</HelpText>
+    </Box>
+  );
+};
+
+render(
+  <DefaultMeterExample />
+)
+`.trim();
+
+export const minMaxMeter = `
+const DefaultMeterExample = () => {
+  const meterId = useUID()
+  const helpTextId = useUID()
+  return (
+    <Box maxWidth="size60">
+      <MeterLabel htmlFor={meterId} valueLabel="$4,500.00">Account balance paid</MeterLabel>
+      <Meter minValue={2000} value={4500} maxValue={50000} minLabel="$2,000.00" maxLabel="$50,000.00" id={meterId}/>
+      <HelpText id={helpTextId}>Remaining balance must be paid by the end of the billing period. </HelpText>
+    </Box>
+  );
+};
+
+render(
+  <DefaultMeterExample />
+)
+`.trim();

--- a/packages/paste-website/src/pages/components/meter/index.mdx
+++ b/packages/paste-website/src/pages/components/meter/index.mdx
@@ -1,0 +1,233 @@
+export const meta = {
+  title: 'Meter',
+  package: '@twilio-paste/meter',
+  description: 'Meter is a visual representation of a numerical value within a known range.',
+  slug: '/components/meter/',
+};
+
+import {Box} from '@twilio-paste/box';
+import {Meter, MeterLabel} from '@twilio-paste/meter';
+import {HelpText} from '@twilio-paste/help-text';
+import {useUID} from '@twilio-paste/uid-library';
+import Changelog from '@twilio-paste/meter/CHANGELOG.md';
+import packageJson from '@twilio-paste/meter/package.json';
+
+import DefaultLayout from '../../../layouts/DefaultLayout';
+import {SidebarCategoryRoutes} from '../../../constants';
+import {getFeature, getNavigationData} from '../../../utils/api';
+import {DoDont, Do, Dont} from '../../../components/DoDont';
+import {defaultMeter, minMaxMeter, hiddenValueLabel} from '../../../component-examples/MeterExamples';
+
+export default DefaultLayout;
+
+export const getStaticProps = async () => {
+  const navigationData = await getNavigationData();
+  const feature = await getFeature('Meter');
+  return {
+    props: {
+      data: {
+        ...packageJson,
+        ...feature,
+      },
+      navigationData,
+    },
+  };
+};
+
+<NormalizedComponentHeader
+  categoryRoute={SidebarCategoryRoutes.COMPONENTS}
+  storybookUrl="/?path=/story/components-meter--"
+  githubUrl="https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/meter"
+  data={props.data}
+/>
+
+---
+
+<contentwrapper>
+
+<PageAside data={mdxHeadings} />
+
+<content>
+
+<LivePreview scope={{Meter, MeterLabel, HelpText, useUID, Box}} language="jsx" noInline>
+  {defaultMeter}
+</LivePreview>
+
+## Guidelines
+
+### About Meter
+
+A Meter is a visual representation to indicate how full something is.
+
+### Meter vs. Progress Bar
+
+A Meter represents a bucket that can be empty, full, or somewhere in between. Use a Meter when you need to show capacity. For example, use a Meter to show how much data is being used or how many emails were sent successfully.
+
+A [Progress Bar](/components/progress-bar) represents **only** task completion, like a file upload or filling out a form. If you’re not displaying progress on a particular task, use a Meter.
+
+### Accessibility
+
+A label is required when using Meter. Use one of these options:
+
+- Visible label using `MeterLabel`, with `htmlFor` set equal to the `id` of the Meter (preferred)
+- Visible label that's associated to the Meter with `aria-labelledby`
+- Label directly using `aria-label`
+
+## Examples
+
+### Default
+
+Use a Meter to communicate an amount of something within a range, like number of emails delivered. Use the `valueLabel` prop on the `MeterLabel` component to display the current value being represented by the Meter.
+
+Consider what type of value would be most useful for a user to see (for example, “50%” vs. “5,000 of 10,000”). Avoid using multiple formats to represent the same value (for example, "5,000 of 10,000 (50%)").
+
+<LivePreview scope={{Meter, MeterLabel, HelpText, useUID, Box}} language="jsx" noInline>
+  {defaultMeter}
+</LivePreview>
+
+### Min and max values
+
+Meter has a default value of 0, a default minimum value of 0, and a default maximum value of 100.
+
+Passing `minValue` and `maxValue` to Meter allow you to set a non 0-100 scale. Use `minLabel` and `maxLabel` to display minimum and maximum values below the Meter. If using a non 0-100 scale, displaying min and max labels is required.
+
+<LivePreview scope={{Meter, MeterLabel, HelpText, useUID, Box}} language="jsx" noInline>
+  {minMaxMeter}
+</LivePreview>
+
+## Composition notes
+
+The Meter label should communicate what the Meter is measuring. Where possible, avoid a label that wraps onto two lines.
+
+A Meter almost always will include a numerical value, the value label. When using the `valueLabel` prop, consider what type of value would be most useful for a user to see. For example, choose either “50%” or “5,000 of 10,000”, not both.
+
+Use Help Text to offer additional information to contextualize or help the user understand the Meter.
+
+## When to use a Meter
+
+<DoDont>
+  <Do
+    title="Do"
+    body="Use a Meter when a user needs to understand a measurement within a range (like how much data has been used)."
+    center
+  >
+    <Box width="80%">
+      <MeterLabel htmlFor="do1">Data usage</MeterLabel>
+      <Meter id="do1" value={79} />
+    </Box>
+  </Do>
+  <Dont
+    title="Don't"
+    body="Don't use a Meter to represent a path with a completion point (like uploading a file or filling out a form)."
+    center
+  >
+    <Box width="80%">
+      <MeterLabel htmlFor="dont1">File upload status</MeterLabel>
+      <Meter id="dont1" value={23} />
+    </Box>
+  </Dont>
+</DoDont>
+
+<DoDont>
+  <Do
+    title="Do"
+    body="When using a custom value label, use only the format that is the most useful for a user to know."
+    center
+  >
+    <Box width="80%">
+      <MeterLabel htmlFor="do2" valueLabel="$1,259">
+        Balance
+      </MeterLabel>
+      <Meter
+        id="do2"
+        aria-describedby="help"
+        value={1259}
+        minValue={0}
+        maxValue={1500}
+        minLabel="$0"
+        maxLabel="$1,500"
+      />
+      <HelpText id="help">Complete balance due at the end of the billing cycle.</HelpText>
+    </Box>
+  </Do>
+  <Dont title="Don't" body="Don't show multiple formats of the same value when possible." center>
+    <Box width="80%">
+      <MeterLabel htmlFor="dont2" valueLabel="$1,259 of $1,500 (84%)">
+        Balance
+      </MeterLabel>
+      <Meter
+        id="dont2"
+        aria-describedby="help2"
+        value={1259}
+        minValue={0}
+        maxValue={1500}
+        minLabel="$0"
+        maxLabel="$1,500"
+      />
+      <HelpText id="help2">Complete balance of $1,500 due at the end of the billing cycle.</HelpText>
+    </Box>
+  </Dont>
+</DoDont>
+
+## Usage Guide
+
+### API
+
+#### Installation
+
+```bash
+yarn add @twilio-paste/core - or - yarn add @twilio-paste/meter
+```
+
+#### Usage
+
+```jsx
+import {Meter, MeterLabel} from '@twilio-paste/core/meter';
+import {HelpText} from '@twilio-paste/core/help-text'
+import {useUID} from '@twilio-paste/core/uid-library'
+
+const Component = () => {
+  const meterId = useUID();
+  const helpTextId = useUID(); // Help text is optional
+
+  return (
+    <>
+      <MeterLabel htmlFor={meterId} valueLabel="50%">Label</Label>
+      <Meter id={meterId} value={50} aria-describedby={helpTextId} />
+      <HelpText id={helpTextId}>Help text</HelpText>
+    </>
+  );
+};
+```
+
+#### Meter props
+
+| Prop              | Type     | Description                                                                                        | Default |
+| ----------------- | -------- | -------------------------------------------------------------------------------------------------- | ------- |
+| id                | `string` | Must provide an ID to match with a label                                                           |         |
+| aria-describedby? | `string` | Optional ID to pair the Meter to its help text                                                     |         |
+| aria-labelledby?  | `string` | Optional ID to pair the Meter to its label text (if not using a regular MeterLabel with `htmlFor`) |         |
+| aria-label?       | `string` | Label text of the Meter (if not using a regular MeterLabel with `htmlFor` or `aria-labelledby`)    |         |
+| minValue?         | `number` | Minimum value of the Meter                                                                         | 0       |
+| maxValue?         | `number` | Maximum valuae of the Meter                                                                        | 100     |
+| value?            | `number` | The current value                                                                                  | 0       |
+| minLabel?         | `string` | Label displayed for min value. Only shown when this prop is passed.                                |         |
+| maxLabel?         | `string` | Label displayed for max value. Only shown when this prop is passed.                                |         |
+| element?          | `string` | Overrides the default element name to apply unique styles with the Customization Provider          | 'METER' |
+
+#### MeterLabel props
+
+| Prop        | Type     | Description                                                                               | Default       |
+| ----------- | -------- | ----------------------------------------------------------------------------------------- | ------------- |
+| valueLabel? | `string` | Custom value label of the Meter                                                           |               |
+| children    | `string` | Label text                                                                                |               |
+| htmlFor     | `string` | Pass the id of the associated Meter                                                       |               |
+| element?    | `string` | Overrides the default element name to apply unique styles with the Customization Provider | 'METER_LABEL' |
+
+<ChangelogRevealer>
+  <Changelog />
+</ChangelogRevealer>
+
+</content>
+
+</contentwrapper>

--- a/packages/paste-website/src/pages/components/slider/index.mdx
+++ b/packages/paste-website/src/pages/components/slider/index.mdx
@@ -18,6 +18,7 @@ import {Label} from '@twilio-paste/label';
 import {HelpText} from '@twilio-paste/help-text';
 import {Form, FormControl} from '@twilio-paste/form';
 import {useUID} from '@twilio-paste/uid-library';
+import {Meter, MeterLabel} from '@twilio-paste/meter';
 
 import DefaultLayout from '../../../layouts/DefaultLayout';
 import {SidebarCategoryRoutes} from '../../../constants';
@@ -80,7 +81,7 @@ A Slider allows a user to select a numerical value when:
 
 Slider uses [Adobe's Spectrum React-Aria useSlider](https://react-spectrum.adobe.com/react-aria/useSlider.html) under the hood.
 
-### Slider vs. number Input vs. Meter
+### Slider vs. number Input
 
 Both Sliders and [number Inputs](/components/input#input-with-number-functionality) are form
 fields that take numerical values. Because the mouse and touch interaction on a Slider is less
@@ -90,10 +91,6 @@ selecting image opacity or audio volume.
 If the user needs to select an exact value, use a [number Input](/components/input#input-with-number-functionality)
 instead. If you want to let users select between consecutive values, you can
 also use a [Radio Button Group](/components/radio-button-group).
-
-In cases where visually showing the size of a numerical value is important and
-it’s not enough to show it as text, use a [number Input](/components/input#input-with-number-functionality)
-paired with a Meter (component to come!) instead.
 
 ### Accessibility
 
@@ -137,9 +134,6 @@ For additional guidance on how to compose error messages, refer to the
 ### Disabled
 
 Use a disabled Slider to show users that they can't interact with the Slider.
-
-If you want to show a value that can't be edited, use a Meter (to come) or
-consider another way of showing static information.
 
 <LivePreview scope={{Form, FormControl, Label, Slider, HelpText, useUID}} language="jsx" noInline>
   {disabledSlider}
@@ -214,10 +208,19 @@ Use a Slider with hidden range labels when the range is obvious or the labels ar
 <DoDont>
   <Do
     title="Do"
-    body="Use a Meter (to come!) when you need to visually show the size of a numerical value, but don’t want the bar to be interactive."
+    body="Use a Meter when you need to visually show the size of a numerical value, but don’t want the bar to be interactive."
     center
   >
-    Coming soon!
+    <Box width="80%">
+      <MeterLabel htmlFor="meter">Current balance</MeterLabel>
+      <Meter
+        id="meter"
+        value={8673}
+        minValue={0}
+        maxValue={10000}
+        formatOptions={{style: 'currency', currency: 'JPY'}}
+      />
+    </Box>
   </Do>
   <Dont
     title="Don't"
@@ -225,7 +228,7 @@ Use a Slider with hidden range labels when the range is obvious or the labels ar
     center
   >
     <Box width="80%">
-      <Label>Auto-reload amount</Label>
+      <Label>Current balance</Label>
       <Slider
         disabled
         value={8673}
@@ -233,32 +236,6 @@ Use a Slider with hidden range labels when the range is obvious or the labels ar
         maxValue={10000}
         numberFormatter={new Intl.NumberFormat('ja-JP', {style: 'currency', currency: 'JPY'})}
       />
-    </Box>
-  </Dont>
-</DoDont>
-
-<DoDont>
-  <Do
-    title="Do"
-    body="Pair a Meter and number Input when you need to visually show the size of a numerical value and you need to allow input."
-    center
-  >
-    Coming soon!
-  </Do>
-  <Dont
-    title="Don't"
-    body="Don’t use a Slider when you need to visually show the size of a numerical value and you need to allow input."
-    center
-  >
-    <Box display="grid" width="80%" gridTemplateColumns="1fr 1fr" columnGap="space60">
-      <div>
-        <Label>Branch 1</Label>
-        <Input type="number" value={80} />
-      </div>
-      <div>
-        <Label>Branch 1</Label>
-        <Slider value={80} numberFormatter={new Intl.NumberFormat('en-US')} />
-      </div>
     </Box>
   </Dont>
 </DoDont>
@@ -350,7 +327,7 @@ const Component = () => {
 | id                | `string`                                                                                                                     | Must provide an id to match with a label                                                      | undefined |
 | numberFormatter   | [`Intl.NumberFormatter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) | Used to format the value into i18n formats. Can return localized currencies and percentages   |           |
 | aria-describedby? | `string`                                                                                                                     | Optional id to pair the input to its help text                                                | undefined |
-| aria-labeledby?   | `string`                                                                                                                     | Optional id to pair the input to its label text (if not using a regular label with `htmlFor`) | undefined |
+| aria-labelledby?  | `string`                                                                                                                     | Optional id to pair the input to its label text (if not using a regular label with `htmlFor`) | undefined |
 | disabled?         | `boolean`                                                                                                                    | Disables the slider                                                                           | false     |
 | hasError?         | `boolean`                                                                                                                    | Shows error styling on the Slider                                                             | false     |
 | hideRangeLabels?  | `boolean`                                                                                                                    | Hides the min and max values that appear over the slider                                      | false     |

--- a/yarn.lock
+++ b/yarn.lock
@@ -17010,6 +17010,7 @@ __metadata:
     "@twilio-paste/media-object": ^10.0.0
     "@twilio-paste/menu": ^14.0.1
     "@twilio-paste/menu-primitive": ^2.0.0
+    "@twilio-paste/meter": ^1.0.0
     "@twilio-paste/minimizable-dialog": ^4.0.0
     "@twilio-paste/modal": ^16.0.0
     "@twilio-paste/modal-dialog-primitive": ^2.0.0


### PR DESCRIPTION
# In this PR
- Meter designs
- Meter docs
- Update Slider docs

## Meter API

```
<MeterLabel htmlFor={meterId} valueLabel="49GB">
    Storage space used
</MeterLabel>
<Meter value={49} minValue={0} maxValue={64} minLabel="0GB" maxLabel="64GB" id="meterId" />
```

Design and API are as closely aligned as possible. Any aria values present in the DOM can be displayed on the Meter. The value label is set on the MeterLabel component using the `valueLabel` prop. Min and max value labels are optional and set on the Meter using `minLabel` and `maxLabel` props. This allows the consumer to have full control, using a string rather than a number.