### PR TITLE
chore: ignore generated storybook docs from format and format generated core bundle files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[json]": {
     "editor.defaultFormatter": "biomejs.biome"
   },

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
       "**/*.d.ts",
       ".codesandbox/ci.json",
       "build.icon-list.js",
-      "**/*.hbs"
+      "**/*.hbs",
+      "docs"
     ]
   },
   "organizeImports": {

--- a/packages/paste-core/core-bundle/tools/utils.ts
+++ b/packages/paste-core/core-bundle/tools/utils.ts
@@ -18,7 +18,7 @@ import type { PackageList, PackageShape } from "./types";
 function generateIndexFromPackageList(packageList: PackageList): string {
   let output = "";
   packageList.forEach((item) => {
-    output = `${output}export * from '${item.name}';\n`;
+    output = `${output}export * from "${item.name}";\n`;
   });
   return output;
 }
@@ -26,7 +26,7 @@ function generateIndexFromPackageList(packageList: PackageList): string {
 // See: https://stackoverflow.com/questions/58527907/barrel-file-and-tree-shaking
 function generateUnbarreledExports(packageList: PackageList): void {
   packageList.forEach((item) => {
-    writeToFile(getUnbarreledFileFullPath(item), `export * from '${item.name}';\n`, {
+    writeToFile(getUnbarreledFileFullPath(item), `export * from "${item.name}";\n`, {
       errorMessage: `[@twilio-paste/core] ${item.name} export file was not generated.`,
     });
   });


### PR DESCRIPTION
Description and useful links to discussions / issues / tickets

## Changes in this PR:

### Ignore storybook build

Formatter tries to format compiled storybook source

### Generate core files correctly formatted

If you build core, it'll tell you the generated files are incorrect.

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
