### PR TITLE
chore: remove description list vertical margin

### DIFF
--- a/.changeset/thirty-dots-reply.md
+++ b/.changeset/thirty-dots-reply.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/description-list": minor
+"@twilio-paste/core": minor
+---
+
+[Description List] Adjust spacing on Description List component. Description List was previously inheriting 14px of top and bottom margin from the HTML element. This change removes that spacing, so the component now has 0px of top/bottom margin. The same amount of spacing remains between DescriptionListTerms and DescriptionListDetails. In order to maintain designs with Description Lists, you may have to replace the removed spacing to your layout.

--- a/packages/paste-core/components/description-list/src/DescriptionList.tsx
+++ b/packages/paste-core/components/description-list/src/DescriptionList.tsx
@@ -18,7 +18,7 @@ export interface DescriptionListProps extends HTMLPasteProps<"dl"> {
 const DescriptionList = React.forwardRef<HTMLDListElement, DescriptionListProps>(
   ({ element = "DESCRIPTION_LIST", children, ...props }, ref) => {
     return (
-      <Box {...safelySpreadBoxProps(props)} as="dl" ref={ref} element={element}>
+      <Box {...safelySpreadBoxProps(props)} as="dl" marginY="space0" ref={ref} element={element}>
         {children}
       </Box>
     );

--- a/packages/paste-core/components/description-list/src/DescriptionListSet.tsx
+++ b/packages/paste-core/components/description-list/src/DescriptionListSet.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 
 export const StyledDescriptionListSet = styled.div(
   css({
-    "& > dd:last-of-type": {
+    ":not(:last-of-type)": {
       marginBottom: "space60",
     },
     "& > dd:not(:last-of-type)": {


### PR DESCRIPTION
Possible visual breaking change so it's marked as a minor with clear instructions. Removes top and bottom margin from `<dl>` and replaces the `<dd>` last of type bottom margin with a bottom margin on the `DescriptionListSet` as long as it's not the last one in the `<dl>`.