### PR TITLE
chore: prevent auto-formatting package.json files

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,21 +6,21 @@
     font-family: Colfax;
     font-style: normal;
     font-weight: 300;
-    src: url(/fonts/colfax-light.woff2) format('woff2'), url(/fonts/colfax-light.woff) format('woff');
+    src: url(/fonts/colfax-light.woff2) format("woff2"), url(/fonts/colfax-light.woff) format("woff");
   }
 
   @font-face {
     font-family: Colfax;
     font-style: normal;
     font-weight: 400;
-    src: url(/fonts/colfax-regular.woff2) format('woff2'), url(/fonts/colfax-regular.woff) format('woff');
+    src: url(/fonts/colfax-regular.woff2) format("woff2"), url(/fonts/colfax-regular.woff) format("woff");
   }
 
   @font-face {
     font-family: Colfax;
     font-style: normal;
     font-weight: 600;
-    src: url(/fonts/colfax-medium.woff2) format('woff2'), url(/fonts/colfax-medium.woff) format('woff');
+    src: url(/fonts/colfax-medium.woff2) format("woff2"), url(/fonts/colfax-medium.woff) format("woff");
   }
 </style>
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,16 +13,13 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[json]": {
-    "editor.defaultFormatter": "biomejs.biome"
-  },
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[jsonc]": {
+  "[json]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[typescriptreact]": {
+  "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
   "search.exclude": {

--- a/biome.json
+++ b/biome.json
@@ -25,10 +25,10 @@
       "packages/**/dist/*",
       "tsconfig.build.tsbuildinfo",
       "**/*.d.ts",
+      "**/package.json",
       ".codesandbox/ci.json",
       "build.icon-list.js",
       "**/*.hbs",
-      "docs",
       "apps/backend/supabase/schema.gen.ts"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "author": "Twilio Inc.",
   "license": "MIT",
   "workspaces": {
-    "packages": ["apps/**/*", "packages/**/*", "templates/**/*", "!packages/paste-core/core-bundle/**/*"]
+    "packages": [
+      "apps/**/*",
+      "packages/**/*",
+      "templates/**/*",
+      "!packages/paste-core/core-bundle/**/*"
+    ]
   },
   "types": "./types/index.d.ts",
   "engines": {
@@ -73,7 +78,7 @@
     "lint:vscode-intellisense": "eslint -c ./apps/vs-code-intellisense/.eslintrc.json --ext .tsx,.ts ./apps/vs-code-intellisense",
     "lint:repo": "eslint -c .eslintrc.repo.js --ext .tsx,.ts .",
     "format": "biome format ./ && prettier --list-different ./packages/",
-    "format:write": "biome format ./ --write",
+    "format:write": "biome format ./ --write && prettier ./ --write",
     "format:ci": "biome ci ./ --linter-enabled=false && prettier --list-different ./packages/",
     "type-check": "yarn prebuild && yarn nx run-many --target=tsc",
     "tsc": "echo 'Did you mean to run yarn type-check?'",
@@ -228,5 +233,9 @@
     }
   },
   "packageManager": "yarn@3.6.3",
-  "browserslist": ["last 2 versions", "not dead", "not IE 11"]
+  "browserslist": [
+    "last 2 versions",
+    "not dead",
+    "not IE 11"
+  ]
 }

--- a/packages/paste-core/components/alert/tsconfig.json
+++ b/packages/paste-core/components/alert/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/anchor/tsconfig.json
+++ b/packages/paste-core/components/anchor/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/avatar/tsconfig.json
+++ b/packages/paste-core/components/avatar/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/base-radio-checkbox/tsconfig.json
+++ b/packages/paste-core/components/base-radio-checkbox/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/breadcrumb/tsconfig.json
+++ b/packages/paste-core/components/breadcrumb/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/button/tsconfig.json
+++ b/packages/paste-core/components/button/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/card/tsconfig.json
+++ b/packages/paste-core/components/card/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/checkbox/tsconfig.json
+++ b/packages/paste-core/components/checkbox/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/combobox/tsconfig.json
+++ b/packages/paste-core/components/combobox/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/description-list/tsconfig.json
+++ b/packages/paste-core/components/description-list/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/disclosure/tsconfig.json
+++ b/packages/paste-core/components/disclosure/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/heading/tsconfig.json
+++ b/packages/paste-core/components/heading/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/help-text/tsconfig.json
+++ b/packages/paste-core/components/help-text/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/inline-control-group/tsconfig.json
+++ b/packages/paste-core/components/inline-control-group/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/input-box/tsconfig.json
+++ b/packages/paste-core/components/input-box/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/input/tsconfig.json
+++ b/packages/paste-core/components/input/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/label/tsconfig.json
+++ b/packages/paste-core/components/label/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/list/tsconfig.json
+++ b/packages/paste-core/components/list/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/modal/tsconfig.json
+++ b/packages/paste-core/components/modal/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/paragraph/tsconfig.json
+++ b/packages/paste-core/components/paragraph/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/popover/tsconfig.json
+++ b/packages/paste-core/components/popover/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/progress-bar/package.json
+++ b/packages/paste-core/components/progress-bar/package.json
@@ -14,7 +14,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "yarn clean && NODE_ENV=production node build.js && tsc",
     "build:js": "NODE_ENV=development node build.js",

--- a/packages/paste-core/components/radio-group/tsconfig.json
+++ b/packages/paste-core/components/radio-group/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/screen-reader-only/tsconfig.json
+++ b/packages/paste-core/components/screen-reader-only/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/select/tsconfig.json
+++ b/packages/paste-core/components/select/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/separator/tsconfig.json
+++ b/packages/paste-core/components/separator/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/spinner/tsconfig.json
+++ b/packages/paste-core/components/spinner/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/table/tsconfig.json
+++ b/packages/paste-core/components/table/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/tabs/tsconfig.json
+++ b/packages/paste-core/components/tabs/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/textarea/tsconfig.json
+++ b/packages/paste-core/components/textarea/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/toast/tsconfig.json
+++ b/packages/paste-core/components/toast/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/tooltip/tsconfig.json
+++ b/packages/paste-core/components/tooltip/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/components/truncate/tsconfig.json
+++ b/packages/paste-core/components/truncate/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/layout/aspect-ratio/tsconfig.json
+++ b/packages/paste-core/layout/aspect-ratio/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/layout/flex/tsconfig.json
+++ b/packages/paste-core/layout/flex/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/layout/grid/tsconfig.json
+++ b/packages/paste-core/layout/grid/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/layout/media-object/tsconfig.json
+++ b/packages/paste-core/layout/media-object/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/layout/stack/tsconfig.json
+++ b/packages/paste-core/layout/stack/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/box/tsconfig.json
+++ b/packages/paste-core/primitives/box/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/combobox/tsconfig.json
+++ b/packages/paste-core/primitives/combobox/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/disclosure/tsconfig.json
+++ b/packages/paste-core/primitives/disclosure/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/listbox/tsconfig.json
+++ b/packages/paste-core/primitives/listbox/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/menu/tsconfig.json
+++ b/packages/paste-core/primitives/menu/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/modal-dialog/tsconfig.json
+++ b/packages/paste-core/primitives/modal-dialog/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/non-modal-dialog/tsconfig.json
+++ b/packages/paste-core/primitives/non-modal-dialog/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/sibling-box/tsconfig.json
+++ b/packages/paste-core/primitives/sibling-box/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/tabs/tsconfig.json
+++ b/packages/paste-core/primitives/tabs/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/text/tsconfig.json
+++ b/packages/paste-core/primitives/text/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-core/primitives/tooltip/tsconfig.json
+++ b/packages/paste-core/primitives/tooltip/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-customization/tsconfig.json
+++ b/packages/paste-customization/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-icons/tsconfig.json
+++ b/packages/paste-icons/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./types",
+    "outDir": "./types"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/paste-libraries/animation/tsconfig.json
+++ b/packages/paste-libraries/animation/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/packages/paste-libraries/dropdown/tsconfig.json
+++ b/packages/paste-libraries/dropdown/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/packages/paste-libraries/reakit/tsconfig.json
+++ b/packages/paste-libraries/reakit/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/packages/paste-libraries/styling/tsconfig.json
+++ b/packages/paste-libraries/styling/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/packages/paste-libraries/uid/tsconfig.json
+++ b/packages/paste-libraries/uid/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/packages/paste-theme/tsconfig.json
+++ b/packages/paste-theme/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
-  "include": [
-    "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "__tests__"]
 }


### PR DESCRIPTION
Because the `yarn install` command formats the package.json file in a way that differs from both biomejs and prettierjs, I've disabled auto formatting of package.json files.

This will fix the annoying issue where yarn install causes formatting errors in CI.