### PR TITLE
fix(select): background color in dark mode on windows

### DIFF
--- a/.changeset/strange-spoons-hear.md
+++ b/.changeset/strange-spoons-hear.md
@@ -1,0 +1,6 @@
+---
+'@twilio-paste/select': patch
+'@twilio-paste/core': patch
+---
+
+[Select] Fixed a bug in dark mode on Windows where the options list was still white and the options were unreadable

--- a/packages/paste-core/components/select/src/Select.tsx
+++ b/packages/paste-core/components/select/src/Select.tsx
@@ -30,7 +30,8 @@ export const SelectElement = React.forwardRef<HTMLSelectElement, SelectProps>(
         // We want the size attribute on the HTML element to set the height, not the css
         height={undefined}
         appearance="none"
-        backgroundColor="transparent"
+        // must set a solid color to inherit in options for Windows
+        backgroundColor={variant === 'inverse' ? 'colorBackgroundInverse' : 'colorBackgroundBody'}
         border="none"
         borderRadius="borderRadius20"
         boxShadow="none"


### PR DESCRIPTION
New PR to patch v15

Addresses https://github.com/twilio-labs/paste/discussions/2909

Changes in this PR:
Control background color of options
In windows we need to explicitly set the background color of options, otherwise in dark mode its white on white bg

(cherry picked from commit ac5a84407c1305ebb60fa317dd98fb8c99332d81)


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
