### PR TITLE
fix: disable a11y test for theme provider in style test

### DIFF
--- a/packages/paste-theme/stories/themeProvider.stories.tsx
+++ b/packages/paste-theme/stories/themeProvider.stories.tsx
@@ -81,3 +81,9 @@ export const StylingThemeProviderElement = (): React.ReactNode => (
     </Paragraph>
   </ThemeProvider>
 );
+StylingThemeProviderElement.parameters = {
+  a11y: {
+    // no need to a11y this story
+    disable: true,
+  },
+};


### PR DESCRIPTION
Description and useful links to discussions / issues / tickets

## Changes in this PR:

### Disable theme provider style a11y test

It fails on dark themes because the story has to reset a theme provider to the default theme. This is not a real use case and it's not worth fixing it.

## Checklist

- [ ] Work in a "Draft" branch whilst you are getting feedback to reduce Chromatic costs. Once you are ready for approval, convert the PR to "Ready to review"
- [ ] Ensure all `required` checks have passed
- [ ] Icon changes must have a product design review
- [ ] Website content changes must have a product design review
- [ ] At least two engineers have reviewed any code changes
- [ ] At least one engineering lead has reviewed any core package changes or repository infrastructure
- [ ] Website visual regression testing is run by adding `🕵🏻‍♀️ Run website visual regression` label
