### PR TITLE
fix: error pattern link typo

### DIFF
--- a/packages/paste-website/src/pages/patterns/empty-state/index.mdx
+++ b/packages/paste-website/src/pages/patterns/empty-state/index.mdx
@@ -329,7 +329,7 @@ When data is absent due to a user waiting for data to populate, consider a CTA l
 
 ### Error states
 
-Error empty states can result from problems like a system issue or access issue. The content should explain what went wrong and tell the user how to fix the issue. Consider including an error icon to complement the content. If the error empty state occurs in a small component (a card, for example), prioritize communicating how to fix the problem. For error message guidance, review the [error state pattern](patterns/error-state).
+Error empty states can result from problems like a system issue or access issue. The content should explain what went wrong and tell the user how to fix the issue. Consider including an error icon to complement the content. If the error empty state occurs in a small component (a card, for example), prioritize communicating how to fix the problem. For error message guidance, review the [error state pattern](/patterns/error-state).
 
 #### Examples
 


### PR DESCRIPTION
https://paste-docs-git-fix-error-pattern-link-typo-twilio.vercel.app/patterns/empty-state#error-states