### PR TITLE
feat(tabs): make non-fitted tabs responsive

### DIFF
--- a/.changeset/grumpy-dryers-remain.md
+++ b/.changeset/grumpy-dryers-remain.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/code-block": patch
+"@twilio-paste/core": patch
+---
+
+[CodeBlock] make tabs responsive

--- a/.changeset/strong-eagles-complain.md
+++ b/.changeset/strong-eagles-complain.md
@@ -3,4 +3,4 @@
 "@twilio-paste/core": patch
 ---
 
-[Tabs] make the non-fitted variant Tabs responsive
+[Tabs] make the non-fitted variant Tabs responsive. Export the context provider `TabsContext`.

--- a/.changeset/strong-eagles-complain.md
+++ b/.changeset/strong-eagles-complain.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/tabs": patch
+"@twilio-paste/core": patch
+---
+
+[Tabs] make the non-fitted variant Tabs responsive

--- a/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
+++ b/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
@@ -1,8 +1,68 @@
-import { Box } from "@twilio-paste/box";
+import { Box, safelySpreadBoxProps } from "@twilio-paste/box";
 import type { BoxProps } from "@twilio-paste/box";
-import { TabList } from "@twilio-paste/tabs";
+import { css, styled } from "@twilio-paste/styling-library";
 import type { TabListProps } from "@twilio-paste/tabs";
+import type { ThemeShape } from "@twilio-paste/theme";
 import * as React from "react";
+
+const StyledTabListWrapper = styled.div(({ theme }: { theme: ThemeShape }) => {
+  return css({
+    paddingLeft: "space70",
+    position: "relative",
+    borderBottomStyle: "solid",
+    borderBottomWidth: "borderWidth10",
+    borderBottomColor: "colorBorderInverseWeaker",
+
+    "::after": {
+      content: "' '",
+      position: "absolute",
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: "50px",
+      pointerEvents: "none",
+      background: `linear-gradient(to right, rgba(0, 0, 0, 0), ${theme.backgroundColors.colorBackgroundInverseStrong})}`,
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "100% 15px, 100% 15px, 100% 5px, 100% 5px",
+      backgroundAttachment: `local, local, scroll, scroll`,
+    },
+  });
+});
+/**
+ * This wrapper applies styles that customize the scrollbar and its track.
+ */
+const StyledTabList = styled.div(({ theme }: { theme: ThemeShape }) => {
+  const { colorBackgroundStronger, colorBackgroundInverseStronger } = theme.backgroundColors;
+
+  return css({
+    paddingRight: "space70",
+    position: "relative",
+    bottom: "-1px",
+    overflowX: "auto",
+    overflowY: "hidden",
+    overflowScrolling: "touch",
+    /* Firefox scrollbar */
+    "@supports (-moz-appearance:none)": {
+      paddingBottom: "0px",
+      scrollbarColor: `${colorBackgroundStronger} transparent`,
+      scrollbarWidth: "thin",
+    },
+    /* Chrome + Safari scrollbar */
+    "::-webkit-scrollbar": {
+      height: 4,
+    },
+    "::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "::-webkit-scrollbar-thumb": {
+      background: colorBackgroundStronger,
+      borderRadius: "5px",
+    },
+    "::-webkit-scrollbar-thumb:hover": {
+      background: colorBackgroundInverseStronger,
+    },
+  });
+});
 
 export interface CodeBlockTabListProps extends Omit<TabListProps, "aria-label"> {
   /**
@@ -18,10 +78,21 @@ export interface CodeBlockTabListProps extends Omit<TabListProps, "aria-label"> 
 export const CodeBlockTabList = React.forwardRef<HTMLDivElement, CodeBlockTabListProps>(
   ({ children, element = "CODE_BLOCK_TAB_LIST", ...props }, ref) => {
     return (
-      <Box paddingX="space70">
-        <TabList {...props} aria-label="label" ref={ref} element={element}>
+      <Box as={StyledTabListWrapper as any} element={`${element}_WRAPPER`}>
+        <Box
+          {...safelySpreadBoxProps(props)}
+          as={StyledTabList as any}
+          ref={ref}
+          display="flex"
+          flexWrap="nowrap"
+          flexShrink={0}
+          aria-label="label"
+          element={element}
+          overflowX="auto"
+          overflowY="hidden"
+        >
           {children}
-        </TabList>
+        </Box>
       </Box>
     );
   },

--- a/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
+++ b/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
@@ -1,7 +1,8 @@
 import { Box, safelySpreadBoxProps } from "@twilio-paste/box";
 import type { BoxProps } from "@twilio-paste/box";
 import { css, styled } from "@twilio-paste/styling-library";
-import type { TabListProps } from "@twilio-paste/tabs";
+import { type TabListProps, TabsContext } from "@twilio-paste/tabs";
+import { TabPrimitiveList } from "@twilio-paste/tabs-primitive";
 import { type ThemeShape, useTheme } from "@twilio-paste/theme";
 import * as React from "react";
 
@@ -80,6 +81,7 @@ export interface CodeBlockTabListProps extends Omit<TabListProps, "aria-label"> 
 
 export const CodeBlockTabList = React.forwardRef<HTMLDivElement, CodeBlockTabListProps>(
   ({ children, element = "CODE_BLOCK_TAB_LIST", ...props }, fwdRef) => {
+    const tab = React.useContext(TabsContext);
     const theme = useTheme();
     // Create a fallback ref to the scrollable element
     const scrollableRef = React.useRef<HTMLDivElement>(null);
@@ -112,36 +114,38 @@ export const CodeBlockTabList = React.forwardRef<HTMLDivElement, CodeBlockTabLis
     };
 
     return (
-      <Box
-        element={`${element}_WRAPPER`}
-        paddingLeft="space70"
-        position="relative"
-        borderBottomStyle="solid"
-        borderBottomWidth="borderWidth10"
-        borderBottomColor="colorBorderInverseWeaker"
-      >
+      <TabPrimitiveList {...(tab as any)} as={Box} {...props} element={element} ref={ref}>
         <Box
-          {...safelySpreadBoxProps(props)}
-          as={StyledTabList as any}
-          ref={ref}
-          display="flex"
-          flexWrap="nowrap"
-          flexShrink={0}
-          aria-label="label"
-          element={element}
-          overflowX="auto"
-          overflowY="hidden"
-          onScroll={handleScroll}
+          element={`${element}_CHILD_WRAPPER`}
+          paddingLeft="space70"
+          position="relative"
+          borderBottomStyle="solid"
+          borderBottomWidth="borderWidth10"
+          borderBottomColor="colorBorderInverseWeaker"
         >
-          {children}
+          <Box
+            {...safelySpreadBoxProps(props)}
+            as={StyledTabList as any}
+            ref={ref}
+            display="flex"
+            flexWrap="nowrap"
+            flexShrink={0}
+            aria-label="label"
+            element={`${element}_CHILD`}
+            overflowX="auto"
+            overflowY="hidden"
+            onScroll={handleScroll}
+          >
+            {children}
+          </Box>
+          {scrollShadow === "left" || scrollShadow === "both" ? (
+            <ShadowLeft bgColor={theme.backgroundColors.colorBackgroundInverseStrong} />
+          ) : null}
+          {scrollShadow === "right" || scrollShadow === "both" ? (
+            <ShadowRight bgColor={theme.backgroundColors.colorBackgroundInverseStrong} />
+          ) : null}
         </Box>
-        {scrollShadow === "left" || scrollShadow === "both" ? (
-          <ShadowLeft bgColor={theme.backgroundColors.colorBackgroundInverseStrong} />
-        ) : null}
-        {scrollShadow === "right" || scrollShadow === "both" ? (
-          <ShadowRight bgColor={theme.backgroundColors.colorBackgroundInverseStrong} />
-        ) : null}
-      </Box>
+      </TabPrimitiveList>
     );
   },
 );

--- a/packages/paste-core/components/code-block/stories/index.stories.tsx
+++ b/packages/paste-core/components/code-block/stories/index.stories.tsx
@@ -125,6 +125,22 @@ export const CodeBlockTabs: StoryFn = () => (
     <CodeBlockTabList>
       <CodeBlockTab>Ruby</CodeBlockTab>
       <CodeBlockTab>PHP</CodeBlockTab>
+      <CodeBlockTab>Python</CodeBlockTab>
+      <CodeBlockTab>Curl</CodeBlockTab>
+      <CodeBlockTab>JavaScript</CodeBlockTab>
+      <CodeBlockTab>Java</CodeBlockTab>
+      <CodeBlockTab>C++</CodeBlockTab>
+      <CodeBlockTab>C#</CodeBlockTab>
+      <CodeBlockTab>C</CodeBlockTab>
+      <CodeBlockTab>Perl</CodeBlockTab>
+      <CodeBlockTab>Lisp</CodeBlockTab>
+      <CodeBlockTab>Rust</CodeBlockTab>
+      <CodeBlockTab>Cobol</CodeBlockTab>
+      <CodeBlockTab>Shell</CodeBlockTab>
+      <CodeBlockTab>Bash</CodeBlockTab>
+      <CodeBlockTab>Golang</CodeBlockTab>
+      <CodeBlockTab>Erlang</CodeBlockTab>
+      <CodeBlockTab>Haskell</CodeBlockTab>
     </CodeBlockTabList>
     <CodeBlockTabPanel>
       <CodeBlock externalLink="#" code={rubyCode} language="ruby" />

--- a/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/paste-core/components/tabs/__tests__/tabs.test.tsx
@@ -1,13 +1,45 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CustomizationProvider } from "@twilio-paste/customization";
+import { Theme } from "@twilio-paste/theme";
 import * as React from "react";
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "../src";
 import { getElementName } from "../src/utils";
-import { HorizontalTabs, StateHookTabs } from "../stories/index.stories";
+import { StateHookTabs } from "../stories/index.stories";
 
 describe("Tabs", () => {
+  window.HTMLElement.prototype.scrollIntoView = function () {};
+
+  const [tabOneId, tabTwoId, tabThreeId, panelOneId, panelTwoId, panelThreeId] = [...new Array(6)].map(
+    (_, i) => `${i}`,
+  );
+
+  const ManualIdExample = (): JSX.Element => {
+    return (
+      <Theme.Provider theme="default">
+        <Tabs orientation="horizontal" selectedId={tabOneId} baseId="">
+          <TabList aria-label="My tabs">
+            <Tab id={tabOneId}>Tab 1 is a long tab name because the server sent a long tab name</Tab>
+            <Tab id={tabTwoId}>Tab 2</Tab>
+            <Tab id={tabThreeId}>Tab 3</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel tabId={tabOneId} id={panelOneId}>
+              Tab 1
+            </TabPanel>
+            <TabPanel tabId={tabTwoId} id={panelTwoId}>
+              Tab 1
+            </TabPanel>
+            <TabPanel tabId={tabThreeId} id={panelThreeId}>
+              Tab 1
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </Theme.Provider>
+    );
+  };
+
   describe("Utils", () => {
     describe("getElementName", () => {
       const mockFallbackName = "TEST_ELEMENT_FALLBACK";
@@ -31,33 +63,6 @@ describe("Tabs", () => {
   describe("Render", () => {
     // eslint-disable-next-line consistent-return
     it("relevant html and aria attributes", async () => {
-      const [tabOneId, tabTwoId, tabThreeId, panelOneId, panelTwoId, panelThreeId] = [...new Array(6)].map(
-        (_, i) => `${i}`,
-      );
-
-      const ManualIdExample = (): JSX.Element => {
-        return (
-          <Tabs orientation="horizontal" selectedId={tabOneId} baseId="">
-            <TabList aria-label="My tabs">
-              <Tab id={tabOneId}>Tab 1 is a long tab name because the server sent a long tab name</Tab>
-              <Tab id={tabTwoId}>Tab 2</Tab>
-              <Tab id={tabThreeId}>Tab 3</Tab>
-            </TabList>
-            <TabPanels>
-              <TabPanel tabId={tabOneId} id={panelOneId}>
-                Tab 1
-              </TabPanel>
-              <TabPanel tabId={tabTwoId} id={panelTwoId}>
-                Tab 1
-              </TabPanel>
-              <TabPanel tabId={tabThreeId} id={panelThreeId}>
-                Tab 1
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
-        );
-      };
-
       render(<ManualIdExample />);
 
       const renderedTabList = screen.getByRole("tablist");
@@ -98,7 +103,11 @@ describe("Tabs", () => {
 
     // eslint-disable-next-line consistent-return
     it("should render tabs using the state prop and go to the next tab on button click", async () => {
-      render(<StateHookTabs />);
+      render(
+        <Theme.Provider theme="default">
+          <StateHookTabs />
+        </Theme.Provider>,
+      );
 
       const [ButtonOne] = screen.queryAllByRole("button");
 
@@ -120,18 +129,20 @@ describe("Tabs", () => {
   describe("HTML Attribute", () => {
     it("should set an element data attribute for Horizontal Tabs (default)", () => {
       render(
-        <Tabs orientation="horizontal" baseId="">
-          <TabList data-testid="tab-list" aria-label="My tabs">
-            <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
-            <Tab data-testid="tab-2">Tab 2</Tab>
-            <Tab data-testid="tab-3">Tab 3</Tab>
-          </TabList>
-          <TabPanels data-testid="tab-panels">
-            <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
-            <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
-            <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
-          </TabPanels>
-        </Tabs>,
+        <Theme.Provider theme="default">
+          <Tabs orientation="horizontal" baseId="">
+            <TabList data-testid="tab-list" aria-label="My tabs">
+              <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
+              <Tab data-testid="tab-2">Tab 2</Tab>
+              <Tab data-testid="tab-3">Tab 3</Tab>
+            </TabList>
+            <TabPanels data-testid="tab-panels">
+              <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
+              <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
+              <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Theme.Provider>,
       );
 
       const outerDiv = screen.getByTestId("tab-list").parentElement as HTMLElement;
@@ -139,8 +150,16 @@ describe("Tabs", () => {
       expect(outerDiv.getAttribute("data-paste-element")).toEqual("HORIZONTAL_TABS");
       expect(screen.getByTestId("tab-list").getAttribute("data-paste-element")).toEqual("HORIZONTAL_TAB_LIST");
       expect((screen.getByTestId("tab-list").firstChild as HTMLElement).getAttribute("data-paste-element")).toEqual(
-        "HORIZONTAL_TAB_LIST_CHILD",
+        "HORIZONTAL_TAB_LIST_CHILD_SCROLL_WRAPPER",
       );
+      expect(
+        (screen.getByTestId("tab-list").firstChild?.firstChild as HTMLElement).getAttribute("data-paste-element"),
+      ).toEqual("HORIZONTAL_TAB_LIST_CHILD_CONTAINER");
+      expect(
+        (screen.getByTestId("tab-list").firstChild?.firstChild?.firstChild as HTMLElement).getAttribute(
+          "data-paste-element",
+        ),
+      ).toEqual("HORIZONTAL_TAB_LIST_CHILD");
       expect(screen.getByTestId("tab-1").getAttribute("data-paste-element")).toEqual("HORIZONTAL_TAB");
       expect(screen.getByTestId("tab-2").getAttribute("data-paste-element")).toEqual("HORIZONTAL_TAB");
       expect(screen.getByTestId("tab-3").getAttribute("data-paste-element")).toEqual("HORIZONTAL_TAB");
@@ -152,18 +171,20 @@ describe("Tabs", () => {
 
     it("should set an element data attribute for Vertical Tabs (default)", () => {
       render(
-        <Tabs orientation="vertical" baseId="">
-          <TabList data-testid="tab-list" aria-label="My tabs">
-            <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
-            <Tab data-testid="tab-2">Tab 2</Tab>
-            <Tab data-testid="tab-3">Tab 3</Tab>
-          </TabList>
-          <TabPanels data-testid="tab-panels">
-            <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
-            <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
-            <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
-          </TabPanels>
-        </Tabs>,
+        <Theme.Provider theme="default">
+          <Tabs orientation="vertical" baseId="">
+            <TabList data-testid="tab-list" aria-label="My tabs">
+              <Tab data-testid="tab-1">Tab 1 is a long tab name because the server sent a long tab name</Tab>
+              <Tab data-testid="tab-2">Tab 2</Tab>
+              <Tab data-testid="tab-3">Tab 3</Tab>
+            </TabList>
+            <TabPanels data-testid="tab-panels">
+              <TabPanel data-testid="tab-panel-1">Tab 1</TabPanel>
+              <TabPanel data-testid="tab-panel-2">Tab 2</TabPanel>
+              <TabPanel data-testid="tab-panel-3">Tab 3</TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Theme.Provider>,
       );
 
       const outerDiv = screen.getByTestId("tab-list").parentElement as HTMLElement;
@@ -184,30 +205,32 @@ describe("Tabs", () => {
 
     it("should set an element data attribute Horizontal Tabs", () => {
       render(
-        <Tabs element="HORSE" orientation="horizontal" baseId="">
-          <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
-            <Tab element="TIGER" data-testid="tab-1">
-              Tab 1 is a long tab name because the server sent a long tab name
-            </Tab>
-            <Tab element="PANTHER" data-testid="tab-2">
-              Tab 2
-            </Tab>
-            <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
-              Tab 3
-            </Tab>
-          </TabList>
-          <TabPanels element="DOG" data-testid="tab-panels">
-            <TabPanel element="CORGI" data-testid="tab-panel-1">
-              Tab 1
-            </TabPanel>
-            <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
-              Tab 2
-            </TabPanel>
-            <TabPanel element="PUG" data-testid="tab-panel-3">
-              Tab 3
-            </TabPanel>
-          </TabPanels>
-        </Tabs>,
+        <Theme.Provider theme="default">
+          <Tabs element="HORSE" orientation="horizontal" baseId="">
+            <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
+              <Tab element="TIGER" data-testid="tab-1">
+                Tab 1 is a long tab name because the server sent a long tab name
+              </Tab>
+              <Tab element="PANTHER" data-testid="tab-2">
+                Tab 2
+              </Tab>
+              <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
+                Tab 3
+              </Tab>
+            </TabList>
+            <TabPanels element="DOG" data-testid="tab-panels">
+              <TabPanel element="CORGI" data-testid="tab-panel-1">
+                Tab 1
+              </TabPanel>
+              <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
+                Tab 2
+              </TabPanel>
+              <TabPanel element="PUG" data-testid="tab-panel-3">
+                Tab 3
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Theme.Provider>,
       );
 
       const outerDiv = screen.getByTestId("tab-list").parentElement as HTMLElement;
@@ -215,7 +238,7 @@ describe("Tabs", () => {
       expect(outerDiv.getAttribute("data-paste-element")).toEqual("HORSE");
       expect(screen.getByTestId("tab-list").getAttribute("data-paste-element")).toEqual("CAT");
       expect((screen.getByTestId("tab-list").firstChild as HTMLElement).getAttribute("data-paste-element")).toEqual(
-        "CAT_CHILD",
+        "CAT_CHILD_SCROLL_WRAPPER",
       );
       expect(screen.getByTestId("tab-1").getAttribute("data-paste-element")).toEqual("TIGER");
       expect(screen.getByTestId("tab-2").getAttribute("data-paste-element")).toEqual("PANTHER");
@@ -228,30 +251,32 @@ describe("Tabs", () => {
 
     it("should set an element data attribute for Vertical Tabs", () => {
       render(
-        <Tabs element="HORSE" orientation="vertical" baseId="">
-          <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
-            <Tab element="TIGER" data-testid="tab-1">
-              Tab 1 is a long tab name because the server sent a long tab name
-            </Tab>
-            <Tab element="PANTHER" data-testid="tab-2">
-              Tab 2
-            </Tab>
-            <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
-              Tab 3
-            </Tab>
-          </TabList>
-          <TabPanels element="DOG" data-testid="tab-panels">
-            <TabPanel element="CORGI" data-testid="tab-panel-1">
-              Tab 1
-            </TabPanel>
-            <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
-              Tab 2
-            </TabPanel>
-            <TabPanel element="PUG" data-testid="tab-panel-3">
-              Tab 3
-            </TabPanel>
-          </TabPanels>
-        </Tabs>,
+        <Theme.Provider theme="default">
+          <Tabs element="HORSE" orientation="vertical" baseId="">
+            <TabList element="CAT" data-testid="tab-list" aria-label="My tabs">
+              <Tab element="TIGER" data-testid="tab-1">
+                Tab 1 is a long tab name because the server sent a long tab name
+              </Tab>
+              <Tab element="PANTHER" data-testid="tab-2">
+                Tab 2
+              </Tab>
+              <Tab element="SCOTTISH_FOLD" data-testid="tab-3">
+                Tab 3
+              </Tab>
+            </TabList>
+            <TabPanels element="DOG" data-testid="tab-panels">
+              <TabPanel element="CORGI" data-testid="tab-panel-1">
+                Tab 1
+              </TabPanel>
+              <TabPanel element="GOLDEN_DOODLE" data-testid="tab-panel-2">
+                Tab 2
+              </TabPanel>
+              <TabPanel element="PUG" data-testid="tab-panel-3">
+                Tab 3
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Theme.Provider>,
       );
 
       const outerDiv = screen.getByTestId("tab-list").parentElement as HTMLElement;
@@ -289,7 +314,7 @@ describe("Tabs", () => {
               borderColor: "colorBorderDestructive",
               marginY: "space100",
             },
-            HORIZONTAL_TAB_LIST_CHILD: { borderColor: "colorBorderDestructive" },
+            HORIZONTAL_TAB_LIST_CHILD_CONTAINER: { height: "50px" },
             HORIZONTAL_TAB: {
               fontFamily: "fontFamilyCode",
             },
@@ -325,7 +350,7 @@ describe("Tabs", () => {
       expect(screen.getByTestId("tab-list")).toHaveStyleRule("margin-top", "2.25rem");
       expect(screen.getByTestId("tab-list")).toHaveStyleRule("margin-bottom", "2.25rem");
 
-      expect(screen.getByTestId("tab-list").firstChild).toHaveStyleRule("border-color", "rgb(214, 31, 31)");
+      expect(screen.getByTestId("tab-list").firstChild?.firstChild).toHaveStyleRule("height", "50px");
 
       expect(screen.getByTestId("tab-1")).toHaveStyleRule("font-family", "'TwilioSansMono',Courier,monospace");
       expect(screen.getByTestId("tab-2")).toHaveStyleRule("font-family", "'TwilioSansMono',Courier,monospace");
@@ -415,7 +440,10 @@ describe("Tabs", () => {
       expect(screen.getByTestId("tab-list")).toHaveStyleRule("margin-top", "2.25rem");
       expect(screen.getByTestId("tab-list")).toHaveStyleRule("margin-bottom", "2.25rem");
 
-      expect(screen.getByTestId("tab-list").firstChild).toHaveStyleRule("border-color", "rgb(214, 31, 31)");
+      expect(screen.getByTestId("tab-list").firstChild?.firstChild?.firstChild).toHaveStyleRule(
+        "border-color",
+        "rgb(214, 31, 31)",
+      );
 
       expect(screen.getByTestId("tab-1")).toHaveStyleRule("font-family", "'TwilioSansMono',Courier,monospace");
       expect(screen.getByTestId("tab-2")).toHaveStyleRule("font-family", "'TwilioSansMono',Courier,monospace");

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -202,7 +202,7 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({ children, element, ...
   const tab = React.useContext(TabsContext);
   const boxStyles = React.useMemo(() => getTabBoxStyles(tab.orientation, tab.variant), [tab.orientation, tab.variant]);
 
-  const { orientation } = tab;
+  const { orientation, variant } = tab;
   const elementName = getElementName(orientation, "TAB", element);
 
   return (
@@ -229,6 +229,7 @@ const Tab = React.forwardRef<HTMLDivElement, TabProps>(({ children, element, ...
             textOverflow={orientation !== "vertical" ? "ellipsis" : undefined}
             transition="border-color 100ms ease, color 100ms ease"
             whiteSpace={orientation !== "vertical" ? "nowrap" : undefined}
+            minWidth={variant === "fitted" || variant === "inverse_fitted" ? "auto" : "fit-content"}
           >
             {children}
           </Box>

--- a/packages/paste-core/components/tabs/src/Tab.tsx
+++ b/packages/paste-core/components/tabs/src/Tab.tsx
@@ -108,6 +108,7 @@ const getTabBoxStyles = (orientation: Orientation, variant: Variants): BoxStyleP
         borderColor: "transparent",
         borderStyle: "solid",
         borderWidth: "borderWidth10",
+        borderBottomWidth: "borderWidth20",
         borderTopLeftRadius: "borderRadius30",
         borderTopRightRadius: "borderRadius30",
         display: "inline-block",
@@ -150,7 +151,6 @@ const getTabBoxStyles = (orientation: Orientation, variant: Variants): BoxStyleP
         },
         _selected_focus: {
           borderStyle: "solid",
-          borderWidth: "borderWidth10",
           boxShadow: "shadowFocusInset",
           color: isInverse ? "colorTextInverse" : "colorTextPrimary",
           borderColor: "colorBorderPrimary",

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -13,7 +13,7 @@ import { getElementName } from "./utils";
 /**
  * This wrapper applies styles that customize the scrollbar and its track.
  */
-const SidebarNavigationWrapper = styled.div(({ theme }: { theme: ThemeShape }) => {
+const StyledTabList = styled.div(({ theme }: { theme: ThemeShape }) => {
   const { colorBackgroundStronger, colorBackgroundInverseStronger } = theme.backgroundColors;
 
   return css({
@@ -90,7 +90,7 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
   const isFitted = variant === "fitted" || variant === "inverse_fitted";
 
   return (
-    <Box as={SidebarNavigationWrapper as any} element={`${element}_SCROLL_WRAPPER`}>
+    <Box as={StyledTabList as any} element={`${element}_SCROLL_WRAPPER`}>
       <Box
         element={`${element}_CONTAINER`}
         borderBottomStyle="solid"

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -1,12 +1,48 @@
 import { Box } from "@twilio-paste/box";
 import type { BoxProps } from "@twilio-paste/box";
+import { css, styled } from "@twilio-paste/styling-library";
 import { TabPrimitiveList } from "@twilio-paste/tabs-primitive";
+import type { ThemeShape } from "@twilio-paste/theme";
 import type { HTMLPasteProps } from "@twilio-paste/types";
 import * as React from "react";
 
 import { TabsContext } from "./TabsContext";
 import type { Variants } from "./types";
 import { getElementName } from "./utils";
+
+/**
+ * This wrapper applies styles that customize the scrollbar and its track.
+ */
+const SidebarNavigationWrapper = styled.div(({ theme }: { theme: ThemeShape }) => {
+  const { colorBackgroundStronger, colorBackgroundInverseStronger } = theme.backgroundColors;
+
+  return css({
+    paddingBottom: "4px",
+    overflowX: "auto",
+    overflowY: "hidden",
+    overflowScrolling: "touch",
+    /* Firefox scrollbar */
+    "@supports (-moz-appearance:none)": {
+      paddingBottom: "10px",
+      scrollbarColor: `${colorBackgroundStronger} transparent`,
+      scrollbarWidth: "thin",
+    },
+    /* Chrome + Safari scrollbar */
+    "::-webkit-scrollbar": {
+      height: 4,
+    },
+    "::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "::-webkit-scrollbar-thumb": {
+      background: colorBackgroundStronger,
+      borderRadius: "5px",
+    },
+    "::-webkit-scrollbar-thumb:hover": {
+      background: colorBackgroundInverseStronger,
+    },
+  });
+});
 
 export interface TabListProps extends HTMLPasteProps<"div"> {
   /**
@@ -39,18 +75,32 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
   variant,
   element,
 }) => {
+  const ref = React.useRef<HTMLElement>(null);
   const isInverse = variant === "inverse" || variant === "inverse_fitted";
+  const isFitted = variant === "fitted" || variant === "inverse_fitted";
 
   return (
-    <Box
-      display="flex"
-      borderBottomStyle="solid"
-      borderBottomWidth="borderWidth10"
-      borderBottomColor={isInverse ? "colorBorderInverseWeaker" : "colorBorderWeak"}
-      columnGap="space20"
-      element={element}
-    >
-      {children}
+    <Box as={SidebarNavigationWrapper as any} element={`${element}_SCROLL_WRAPPER`}>
+      <Box
+        element={`${element}_CONTAINER`}
+        borderBottomStyle="solid"
+        borderBottomWidth={!ref?.current ? "borderWidth0" : "borderWidth10"}
+        borderBottomColor={isInverse ? "colorBorderInverseWeaker" : "colorBorderWeak"}
+        width={ref?.current?.scrollWidth}
+        height={isFitted ? ref?.current?.scrollHeight : (ref?.current?.offsetHeight || 40) - 4}
+      >
+        <Box
+          ref={ref}
+          as="nav"
+          display={isFitted ? "flex" : "block"}
+          columnGap="space20"
+          element={element}
+          overflow="visible"
+          whiteSpace="nowrap"
+        >
+          {!ref.current ? null : children}
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -50,7 +50,6 @@ const StyledNav = styled.nav(
     columnGap: "space20",
     overflow: "visible",
     whiteSpace: "nowrap",
-    marginBottom: "-5px",
   }),
 );
 
@@ -98,7 +97,13 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
         borderBottomColor={isInverse ? "colorBorderInverseWeaker" : "colorBorderWeak"}
         width={ref?.current?.scrollWidth}
       >
-        <Box as={StyledNav as any} ref={ref} display={isFitted ? "flex" : "block"} element={element}>
+        <Box
+          as={StyledNav as any}
+          ref={ref}
+          display={isFitted ? "flex" : "block"}
+          element={element}
+          marginBottom={isFitted ? "space0" : "-5px"}
+        >
           {children}
         </Box>
       </Box>

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -18,6 +18,7 @@ const SidebarNavigationWrapper = styled.div(({ theme }: { theme: ThemeShape }) =
 
   return css({
     paddingBottom: "4px",
+    marginBottom: "4px",
     overflowX: "auto",
     overflowY: "hidden",
     overflowScrolling: "touch",

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -45,13 +45,15 @@ const StyledTabList = styled.div(({ theme }: { theme: ThemeShape }) => {
   });
 });
 
-const StyledNav = styled.nav(
-  css({
+const StyledNav = styled(Box)(({ isFitted }: { isFitted: boolean }) => {
+  return css({
     columnGap: "space20",
     overflow: "visible",
     whiteSpace: "nowrap",
-  }),
-);
+    display: isFitted ? "flex" : "block",
+    marginBottom: isFitted ? "space0" : "-5px",
+  });
+});
 
 export interface TabListProps extends HTMLPasteProps<"div"> {
   /**
@@ -97,15 +99,9 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
         borderBottomColor={isInverse ? "colorBorderInverseWeaker" : "colorBorderWeak"}
         width={ref?.current?.scrollWidth}
       >
-        <Box
-          as={StyledNav as any}
-          ref={ref}
-          display={isFitted ? "flex" : "block"}
-          element={element}
-          marginBottom={isFitted ? "space0" : "-5px"}
-        >
+        <StyledNav ref={ref} isFitted={isFitted} element={element} as="nav">
           {children}
-        </Box>
+        </StyledNav>
       </Box>
     </Box>
   );

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -44,6 +44,15 @@ const SidebarNavigationWrapper = styled.div(({ theme }: { theme: ThemeShape }) =
   });
 });
 
+const StyledNav = styled.nav(
+  css({
+    columnGap: "space20",
+    overflow: "visible",
+    whiteSpace: "nowrap",
+    marginBottom: "-5px",
+  }),
+);
+
 export interface TabListProps extends HTMLPasteProps<"div"> {
   /**
    * Required label for this Tabs component. Titles the entire Tabbing context for screen readers.
@@ -84,21 +93,12 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
       <Box
         element={`${element}_CONTAINER`}
         borderBottomStyle="solid"
-        borderBottomWidth={!ref?.current ? "borderWidth0" : "borderWidth10"}
+        borderBottomWidth="borderWidth10"
         borderBottomColor={isInverse ? "colorBorderInverseWeaker" : "colorBorderWeak"}
         width={ref?.current?.scrollWidth}
-        height={isFitted ? ref?.current?.scrollHeight : (ref?.current?.offsetHeight || 40) - 4}
       >
-        <Box
-          ref={ref}
-          as="nav"
-          display={isFitted ? "flex" : "block"}
-          columnGap="space20"
-          element={element}
-          overflow="visible"
-          whiteSpace="nowrap"
-        >
-          {!ref.current ? null : children}
+        <Box as={StyledNav as any} ref={ref} display={isFitted ? "flex" : "block"} element={element}>
+          {children}
         </Box>
       </Box>
     </Box>

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -65,6 +65,8 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
           document
             // eslint-disable-next-line unicorn/prefer-query-selector
             .getElementById(selectedId)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore - behavior is typed incorrectly in Typescript v4, fixed in v5+
             ?.scrollIntoView({ behavior: prevSelectedTab === undefined ? "instant" : "smooth" });
 
           setPrevSelectedTab(selectedId);

--- a/packages/paste-core/components/tabs/src/Tabs.tsx
+++ b/packages/paste-core/components/tabs/src/Tabs.tsx
@@ -48,13 +48,30 @@ export interface TabsProps extends TabPrimitiveInitialState {
 const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   ({ children, element, orientation = "horizontal", state, variant, ...initialState }, ref) => {
     // If returned state from primitive has orientation set to undefined, use the default "horizontal"
+    const [prevSelectedTab, setPrevSelectedTab] = React.useState<string | undefined>(undefined);
     const { orientation: tabOrientation = orientation, ...tab } =
       state || useTabPrimitiveState({ orientation, ...initialState });
     const elementName = getElementName(tabOrientation, "TABS", element);
     const value = React.useMemo(
       () => ({ ...tab, orientation: tabOrientation, variant }),
-      [...Object.values(tab), tabOrientation, variant],
+      [tab, tabOrientation, variant],
     );
+
+    const { selectedId } = tab;
+    // Scroll to the selected tab if it exists on mount
+    React.useEffect(() => {
+      if (typeof selectedId === "string") {
+        setTimeout(() => {
+          document
+            // eslint-disable-next-line unicorn/prefer-query-selector
+            .getElementById(selectedId)
+            ?.scrollIntoView({ behavior: prevSelectedTab === undefined ? "instant" : "smooth" });
+
+          setPrevSelectedTab(selectedId);
+        }, 1);
+      }
+    }, [prevSelectedTab, selectedId]);
+
     const returnValue = <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
 
     if (tabOrientation === "vertical") {

--- a/packages/paste-core/components/tabs/src/index.tsx
+++ b/packages/paste-core/components/tabs/src/index.tsx
@@ -2,6 +2,7 @@ import type { TabStateReturn } from "./Tabs";
 
 export { Tabs, useTabState } from "./Tabs";
 export type { TabsProps } from "./Tabs";
+export { TabsContext } from "./TabsContext";
 export { TabList } from "./TabList";
 export type { TabListProps } from "./TabList";
 export { Tab } from "./Tab";


### PR DESCRIPTION
I went to great lengths to use a native scrollbar solution and style it such that I wouldn't need a pure JS built scrollbar.

In order to achieve this, I needed to add two wrapper divs to the TabList component. One for the outer scrollbar, and one for the bottom border. I still need some JS to fetch the total width of the TabList in order to position the bottom border correctly cross-browser, and to offset the scrollbar position by 4px on the outside of the element visually.

I also made the Tabs component scroll to the selected tab on mount, if it is off-screen. This initial scroll happens instantly to avoid screen noise. Subsequent tab navigation will smoothly scroll to the selected tab to provide a more refined experience.

Fitted tabs do not receive any significant changes, as by definition they shouldn't overflow or scroll.
Vertical tabs have similarly remained untouched.

I tested these changes thoroughly on Safari, Firefox, and Chrome, and checked the browser support tables for the features I'm using to verify they pass our requirements.



### Chrome

<img width="891" alt="image" src="https://github.com/twilio-labs/paste/assets/1592327/ecd81dbc-15f4-44b2-a575-0876a0ff80bd">

### Firefox

<img width="585" alt="image" src="https://github.com/twilio-labs/paste/assets/1592327/b266cff3-e86b-4cc3-a8f5-4c561f30cbf6">

### Safari

<img width="788" alt="image" src="https://github.com/twilio-labs/paste/assets/1592327/82aa026f-1a5c-4056-a210-87f8b2ca3ed2">
