### PR TITLE
feat(Intput): increment/decrement reset buttons focus stylings

### DIFF
--- a/.changeset/wise-suns-serve.md
+++ b/.changeset/wise-suns-serve.md
@@ -1,0 +1,5 @@
+---
+"@twilio-paste/input": patch
+---
+
+[Input] updated focus stylings on increment/decrement buttons for number input type on both default and inverse variants

--- a/packages/paste-core/components/input/src/DecrementButton.tsx
+++ b/packages/paste-core/components/input/src/DecrementButton.tsx
@@ -3,12 +3,14 @@ import { Button, type ButtonProps } from "@twilio-paste/button";
 import { ChevronDownIcon } from "@twilio-paste/icons/esm/ChevronDownIcon";
 import type { HTMLPasteProps } from "@twilio-paste/types";
 import * as React from "react";
+import { InputVariants } from "./Input";
 
 export interface DecrementButtonProps extends HTMLPasteProps<"button"> {
   i18nStepDownLabel?: string;
   element?: BoxProps["element"];
   // Button component restricts tabIndex values
   tabIndex?: ButtonProps["tabIndex"];
+  variant?: InputVariants;
 }
 
 export const DecrementButton = React.forwardRef<HTMLButtonElement, DecrementButtonProps>(
@@ -22,8 +24,17 @@ export const DecrementButton = React.forwardRef<HTMLButtonElement, DecrementButt
         size="reset"
         type="button"
         borderRadius="borderRadius20"
-        backgroundColor="colorBackground"
+        backgroundColor={props.variant === "inverse" ? "colorBackgroundInverseStrong" : "colorBackground"}
         marginRight="space30"
+        _focus={{
+          borderRadius: "borderRadius20",
+          borderWidth: "borderWidth10",
+          borderStyle: "solid",
+          borderColor: props.variant === "inverse" ? "colorBorderInverseStrong" : "colorBorderPrimary",
+        }}
+        borderWidth="borderWidth10"
+        borderStyle="solid"
+        borderColor="transparent"
       >
         <ChevronDownIcon
           decorative={false}

--- a/packages/paste-core/components/input/src/IncrementButton.tsx
+++ b/packages/paste-core/components/input/src/IncrementButton.tsx
@@ -3,12 +3,14 @@ import { Button, type ButtonProps } from "@twilio-paste/button";
 import { ChevronUpIcon } from "@twilio-paste/icons/esm/ChevronUpIcon";
 import type { HTMLPasteProps } from "@twilio-paste/types";
 import * as React from "react";
+import { InputVariants } from "./Input";
 
 export interface IncrementButtonProps extends HTMLPasteProps<"button"> {
   i18nStepUpLabel?: string;
   element?: BoxProps["element"];
   // Button component restricts tabIndex values
   tabIndex?: ButtonProps["tabIndex"];
+  variant?: InputVariants;
 }
 
 export const IncrementButton = React.forwardRef<HTMLButtonElement, IncrementButtonProps>(
@@ -22,8 +24,17 @@ export const IncrementButton = React.forwardRef<HTMLButtonElement, IncrementButt
         size="reset"
         type="button"
         borderRadius="borderRadius20"
-        backgroundColor="colorBackground"
+        backgroundColor={props.variant === "inverse" ? "colorBackgroundInverseStrong" : "colorBackground"}
         marginRight="space30"
+        _focus={{
+          borderRadius: "borderRadius20",
+          borderWidth: "borderWidth10",
+          borderStyle: "solid",
+          borderColor: props.variant === "inverse" ? "colorBorderInverseStrong" : "colorBorderPrimary",
+        }}
+        borderWidth="borderWidth10"
+        borderStyle="solid"
+        borderColor="transparent"
       >
         <ChevronUpIcon
           decorative={false}

--- a/packages/paste-core/components/input/src/Input.tsx
+++ b/packages/paste-core/components/input/src/Input.tsx
@@ -333,6 +333,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   internalRef.current?.focus();
                 }}
                 i18nStepUpLabel={i18nStepUpLabel}
+                variant={variant}
               />
             ) : (
               <Box height="12px" width="12px" element={`${element}_INCREMENT_PLACEHOLDER`} />
@@ -347,6 +348,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   internalRef.current?.focus();
                 }}
                 i18nStepDownLabel={i18nStepDownLabel}
+                variant={variant}
               />
             ) : (
               <Box height="12px" width="12px" element={`${element}_DECREMENT_PLACEHOLDER`} />

--- a/packages/paste-core/components/input/stories/input.stories.tsx
+++ b/packages/paste-core/components/input/stories/input.stories.tsx
@@ -713,6 +713,32 @@ export const DefaultNumberInput = (): React.ReactNode => {
 
 DefaultNumberInput.storyName = "Number Input - Controlled";
 
+export const DefaultNumberInverseInput = (): React.ReactNode => {
+  const uid = useUID();
+  const [value, setValue] = React.useState("0");
+  return (
+    <Box backgroundColor="colorBackgroundBodyInverse" padding="space60">
+      <Label htmlFor={uid} variant="inverse">
+        Label
+      </Label>
+      <Input
+        id={uid}
+        type="number"
+        max="50"
+        min="-50"
+        step={5}
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value);
+        }}
+        variant="inverse"
+      />
+    </Box>
+  );
+};
+
+DefaultNumberInverseInput.storyName = "Number Input - Inverse Controlled";
+
 export const TestNumberInput = (): React.ReactNode => {
   const uid = useUID();
   const [value, setValue] = React.useState("5");


### PR DESCRIPTION
Adds correct focus stylings onto the Increment/Decrement buttons inside of Input component.

Accounts for inverse stylings of the buttons too.

Before:
<img width="861" alt="image" src="https://github.com/twilio-labs/paste/assets/55083528/d1aa7687-f7db-4b53-a5e1-de9051cdfe1c">

After:
<img width="978" alt="image" src="https://github.com/twilio-labs/paste/assets/55083528/0a61d4f4-3d85-4f7e-b1eb-19280cdb3559">

- [ X ] I acknowledge that all my contributions will be made under the project's license.
