### PR TITLE
feat(combobox): make the title collapsible

### DIFF
--- a/.changeset/cyan-pots-happen.md
+++ b/.changeset/cyan-pots-happen.md
@@ -1,0 +1,5 @@
+---
+"@twilio-paste/combobox": major
+---
+
+Make group title collapsible in combobox

--- a/packages/paste-core/components/combobox/src/ComboboxItems.tsx
+++ b/packages/paste-core/components/combobox/src/ComboboxItems.tsx
@@ -22,6 +22,7 @@ const ComboboxItems: React.FC<
         disabledItems,
         optionTemplate,
         groupLabelTemplate,
+        canCollapseGroupLabel,
         groupItemsBy,
         totalSize,
         virtualItems,
@@ -126,6 +127,7 @@ const ComboboxItems: React.FC<
                 element={element}
                 key={groupKey}
                 groupName={isUncategorized ? undefined : groupKey}
+                canCollapseGroupLabel={canCollapseGroupLabel}
                 groupLabelTemplate={groupLabelTemplate}
               >
                 {groupedItems[groupedItemKey].map(({ index, ...item }: Record<string, unknown>) => {

--- a/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
@@ -60,6 +60,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       selectedItem,
       groupItemsBy,
       groupLabelTemplate,
+      canCollapseGroupLabel,
       variant = "default",
       emptyState,
       getA11yStatusMessage,
@@ -196,6 +197,7 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
                 totalSize={rowVirtualizer.totalSize}
                 virtualItems={rowVirtualizer.virtualItems}
                 emptyState={emptyState}
+                canCollapseGroupLabel={canCollapseGroupLabel}
               />
             </ComboboxListbox>
           </ListBoxPositioner>

--- a/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
+++ b/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
@@ -1,11 +1,14 @@
 import { Box, type BoxProps } from "@twilio-paste/box";
 import { Text } from "@twilio-paste/text";
+import { Button } from "@twilio-paste/button";
 import type { HTMLPasteProps } from "@twilio-paste/types";
+import { ChevronDownIcon } from '@twilio-paste/icons/esm/ChevronDownIcon'
+import { ChevronRightIcon } from '@twilio-paste/icons/esm/ChevronRightIcon'
 import * as React from "react";
 
 import type { ComboboxProps } from "../types";
 
-export interface ComboboxListboxGroupProps extends Pick<ComboboxProps, "groupLabelTemplate">, HTMLPasteProps<"ul"> {
+export interface ComboboxListboxGroupProps extends Pick<ComboboxProps, "groupLabelTemplate" | "canCollapseGroupLabel">, HTMLPasteProps<"ul"> {
   children: NonNullable<React.ReactNode>;
   /**
    * Overrides the default element name to apply unique styles with the Customization Provider
@@ -22,17 +25,36 @@ export interface ComboboxListboxGroupProps extends Pick<ComboboxProps, "groupLab
    * @memberof ComboboxListboxGroupProps
    */
   element?: BoxProps["element"];
+
+  /**
+   * canCollapseGroupLabel, default to false if undefined. If it's true, clicking on the group label will collapse/expand items under the group.
+   * @type {boolean}
+   * @memberof ComboboxListboxGroupProps
+   */
+  canCollapseGroupLabel?: boolean;
 }
 
 const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxGroupProps>(
-  ({ children, element = "COMBOBOX", groupName, groupLabelTemplate }, ref) => {
-    return (
+  ({ children, element = "COMBOBOX", groupName, groupLabelTemplate, canCollapseGroupLabel = false }, ref) => {
+    const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set())
+    const onClickLabel = (): void => {
+      if (!groupName) {
+        return;
+      }
+      if (collapsedGroups.has(groupName)) {
+        collapsedGroups.delete(groupName);
+      } else {
+        collapsedGroups.add(groupName);
+      }
+      setCollapsedGroups(new Set(collapsedGroups));
+    }
+    if (!groupName) {
+      return (
       <Box
         as="ul"
         ref={ref}
         element={`${element}_LIST`}
-        role={!groupName ? "presentation" : "group"}
-        aria-label={groupName}
+        role="presentation"
         margin="space0"
         padding="space0"
         listStyleType="none"
@@ -41,9 +63,28 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
         borderBottomColor="colorBorderWeaker"
         _last={{
           borderWidth: "borderWidth0",
-        }}
-      >
-        {groupName ? (
+        }}>
+        {children}
+      </Box>);
+    }
+    const groupLabel = groupLabelTemplate ? groupLabelTemplate(groupName) : groupName
+    if (!canCollapseGroupLabel) {
+      return (
+        <Box
+          as="ul"
+          ref={ref}
+          element={`${element}_LIST`}
+          role="group"
+          aria-label={groupName}
+          margin="space0"
+          padding="space0"
+          listStyleType="none"
+          borderBottomStyle="solid"
+          borderBottomWidth="borderWidth10"
+          borderBottomColor="colorBorderWeaker"
+          _last={{
+            borderWidth: "borderWidth0",
+          }}>
           <Box
             as="li"
             backgroundColor="colorBackgroundWeak"
@@ -64,11 +105,61 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
               color="colorText"
               element={`${element}_GROUPNAME_TEXT`}
             >
-              {groupLabelTemplate ? groupLabelTemplate(groupName) : groupName}
+              {groupLabel}
             </Text>
           </Box>
-        ) : null}
-        {children}
+          {children}
+        </Box>);
+    }
+    return (
+      <Box
+        as="ul"
+        ref={ref}
+        element={`${element}_LIST`}
+        role="group"
+        aria-label={groupName}
+        margin="space0"
+        padding="space0"
+        listStyleType="none"
+        borderBottomStyle="solid"
+        borderBottomWidth="borderWidth10"
+        borderBottomColor="colorBorderWeaker"
+        _last={{
+          borderWidth: "borderWidth0",
+        }}
+      >
+        <Box
+          as="li"
+          backgroundColor="colorBackgroundWeak"
+          borderBottomStyle="solid"
+          borderBottomWidth="borderWidth10"
+          borderBottomColor="colorBorderWeaker"
+          role="presentation"
+          paddingY="space30"
+          paddingLeft="space50"
+          paddingRight="space50"
+          element={`${element}_GROUPNAME`}
+        >
+          <Button variant="secondary_icon" element={`${element}_GROUPNAME_BUTTON`} onClick={onClickLabel}>
+            {collapsedGroups.has(groupName) ? (
+              <ChevronRightIcon element={`${element}_GROUPNAME_ARROW`} decorative={false} title={groupName} />
+            ) : (
+              <ChevronDownIcon element={`${element}_GROUPNAME_ARROW`} decorative={false} title={groupName} />
+            )}
+            <Text
+              as="span"
+              variant="secondary_icon"
+              fontSize="fontSize20"
+              lineHeight="lineHeight20"
+              fontWeight="fontWeightSemibold"
+              color="colorText"
+              element={`${element}_GROUPNAME_TEXT`}
+              >
+                {groupLabel}
+              </Text>
+          </Button>
+        </Box>
+        {!collapsedGroups.has(groupName) && children}
       </Box>
     );
   },

--- a/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
+++ b/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
@@ -50,22 +50,23 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
     }
     if (!groupName) {
       return (
-      <Box
-        as="ul"
-        ref={ref}
-        element={`${element}_LIST`}
-        role="presentation"
-        margin="space0"
-        padding="space0"
-        listStyleType="none"
-        borderBottomStyle="solid"
-        borderBottomWidth="borderWidth10"
-        borderBottomColor="colorBorderWeaker"
-        _last={{
-          borderWidth: "borderWidth0",
-        }}>
-        {children}
-      </Box>);
+        <Box
+          as="ul"
+          ref={ref}
+          element={`${element}_LIST`}
+          role="presentation"
+          margin="space0"
+          padding="space0"
+          listStyleType="none"
+          borderBottomStyle="solid"
+          borderBottomWidth="borderWidth10"
+          borderBottomColor="colorBorderWeaker"
+          _last={{
+            borderWidth: "borderWidth0",
+          }}>
+          {children}
+        </Box>
+      );
     }
     const groupLabel = groupLabelTemplate ? groupLabelTemplate(groupName) : groupName
     if (!canCollapseGroupLabel) {
@@ -109,7 +110,8 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
             </Text>
           </Box>
           {children}
-        </Box>);
+        </Box>
+      );
     }
     return (
       <Box

--- a/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
+++ b/packages/paste-core/components/combobox/src/styles/ComboboxListboxGroup.tsx
@@ -36,17 +36,12 @@ export interface ComboboxListboxGroupProps extends Pick<ComboboxProps, "groupLab
 
 const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxGroupProps>(
   ({ children, element = "COMBOBOX", groupName, groupLabelTemplate, canCollapseGroupLabel = false }, ref) => {
-    const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set())
+    const [isCollapsed, setCollapsed] = React.useState<boolean>(false)
     const onClickLabel = (): void => {
       if (!groupName) {
         return;
       }
-      if (collapsedGroups.has(groupName)) {
-        collapsedGroups.delete(groupName);
-      } else {
-        collapsedGroups.add(groupName);
-      }
-      setCollapsedGroups(new Set(collapsedGroups));
+      setCollapsed(!isCollapsed);
     }
     if (!groupName) {
       return (
@@ -113,6 +108,11 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
         </Box>
       );
     }
+    const iconProps = {
+      element: `${element}_GROUPNAME_ARROW`,
+      decorative: false,
+      title: groupName
+    }
     return (
       <Box
         as="ul"
@@ -143,11 +143,7 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
           element={`${element}_GROUPNAME`}
         >
           <Button variant="secondary_icon" element={`${element}_GROUPNAME_BUTTON`} onClick={onClickLabel}>
-            {collapsedGroups.has(groupName) ? (
-              <ChevronRightIcon element={`${element}_GROUPNAME_ARROW`} decorative={false} title={groupName} />
-            ) : (
-              <ChevronDownIcon element={`${element}_GROUPNAME_ARROW`} decorative={false} title={groupName} />
-            )}
+            {isCollapsed ? (<ChevronRightIcon {...iconProps}/>) : (<ChevronDownIcon {...iconProps} />)}
             <Text
               as="span"
               variant="secondary_icon"
@@ -161,7 +157,7 @@ const ComboboxListboxGroup = React.forwardRef<HTMLUListElement, ComboboxListboxG
               </Text>
           </Button>
         </Box>
-        {!collapsedGroups.has(groupName) && children}
+        {!isCollapsed && children}
       </Box>
     );
   },

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -221,6 +221,13 @@ export interface ComboboxProps extends Omit<InputProps, "id" | "type" | "value" 
    * @memberof ComboboxProps
    */
   onInput?: never;
+
+  /**
+   * canCollapseGroupLabel, default to false if undefined. If it's true, clicking on the group label will collapse/expand items under the group.
+   * @type {boolean}
+   * @memberof ComboboxProps
+   */
+  canCollapseGroupLabel?: boolean;
 }
 
 export interface MultiselectComboboxProps
@@ -292,7 +299,7 @@ export interface MultiselectComboboxProps
 export interface ComboboxItemsProps
   extends Pick<
     ComboboxProps,
-    "groupItemsBy" | "optionTemplate" | "groupLabelTemplate" | "element" | "emptyState" | "state"
+    "groupItemsBy" | "optionTemplate" | "groupLabelTemplate" | "element" | "emptyState" | "state" | "canCollapseGroupLabel"
   > {
   items: Item[];
   selectedItems?: Item[];

--- a/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
@@ -701,6 +701,24 @@ export const ComboboxOptionGroups: StoryFn = () => {
 
 ComboboxOptionGroups.storyName = "Combobox - Option groups";
 
+
+export const ComboboxCollapsibleGroups: StoryFn = () => {
+  return (
+    <Combobox
+      groupItemsBy="group"
+      items={groupedItems}
+      labelText="Choose a component:"
+      helpText="This is collapsible group"
+      groupLabelTemplate={(groupName: string) => <Box fontStyle="italic">{groupName}</Box>}
+      optionTemplate={(item: GroupedItem) => <div>{item.label}</div>}
+      itemToString={(item: GroupedItem) => (item ? item.label : "")}
+      canCollapseGroupLabel={true}
+    />
+  );
+};
+
+ComboboxCollapsibleGroups.storyName = "Combobox - Collapsible groups";
+
 export const ComboboxOptionGroupsOpen: StoryFn = () => {
   return (
     <Combobox

--- a/packages/paste-website/src/component-examples/ComboboxExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxExamples.ts
@@ -283,6 +283,51 @@ render(
 )
 `.trim();
 
+export const collapsiableGroupedLabelComboboxExample = `
+const groupedItems = [
+  {type: 'Components', label: 'Alert'},
+  {type: 'Components', label: 'Anchor'},
+  {type: 'Components', label: 'Button'},
+  {type: 'Components', label: 'Card'},
+  {type: 'Components', label: 'Heading'},
+  {type: 'Components', label: 'List'},
+  {type: 'Components', label: 'Modal'},
+  {type: 'Components', label: 'Paragraph'},
+  {type: 'Primitives', label: 'Box'},
+  {type: 'Primitives', label: 'Text'},
+  {type: 'Primitives', label: 'Non-modal Dialog'},
+  {type: 'Layout', label: 'Grid'},
+  {label: 'Design tokens'},
+];
+
+const GroupedCombobox = () => {
+  const [inputItems, setInputItems] = React.useState(groupedItems);
+  return (
+    <Combobox
+      autocomplete
+      groupItemsBy="type"
+      items={inputItems}
+      canCollapseGroupLabel={true}
+      labelText="Choose a component:"
+      helpText="This is the help text"
+      optionTemplate={(item) => <div>{item.label}</div>}
+      onInputValueChange={({inputValue}) => {
+        if (inputValue !== undefined) {
+          setInputItems(
+            filter(groupedItems, (item) => item.label.toLowerCase().startsWith(inputValue.toLowerCase()))
+          );
+        }
+      }}
+      itemToString={item => (item ? item.label : null)}
+    />
+  );
+};
+
+render(
+  <GroupedCombobox />
+)
+`.trim();
+
 export const errorExample = `
 const products = ['SMS', 'Phone Numbers', 'Video'];
 

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -192,6 +192,31 @@ it based on the name.
   {groupedLabelComboboxExample}
 </LivePreview>
 
+### Combobox with collapsible group label
+
+The `canCollapseGroupLabel` prop accepts a boolean. If true, the group label is collapsiable. 
+The default value is false.
+
+In the example below, you may click on the group label to collapse or expand the group label.
+
+<LivePreview
+  scope={{
+    Combobox,
+    ProductInsightsIcon,
+    ProductAutopilotIcon,
+    ProductStudioIcon,
+    MediaObject,
+    MediaFigure,
+    MediaBody,
+    filter,
+  }}
+  noInline
+  language="jsx"
+  showOverflow
+>
+  {collapsiableGroupedLabelComboboxExample}
+</LivePreview>
+
 ### Combobox using Option Template
 
 Use the option template to display more complex options in a listbox.


### PR DESCRIPTION
Hi, I want to add a feature to combox, specifically making the group label collapsible. We are not able to use groupLabelTemplate to simply add an interactive button. Because we are not able to "hide" the children items under the group.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
