### PR TITLE
feat(badge): add notification variant

### DIFF
--- a/.changeset/smooth-gorillas-care.md
+++ b/.changeset/smooth-gorillas-care.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/badge": minor
+"@twilio-paste/core": minor
+---
+
+[Badge] Added a new notification variant

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ module.exports = {
           "icon_small",
           "error_counter",
           "neutral_counter",
+          "notification_counter",
           // unstable props are allowed
           "^unstable_",
           // this is a temporary prop, if the console patch is removed from components this can be removed too

--- a/packages/paste-core/components/badge/src/constants.ts
+++ b/packages/paste-core/components/badge/src/constants.ts
@@ -15,6 +15,7 @@ export const BadgeVariants = [
   "neutral_counter",
   "error_counter",
   "default",
+  "notification_counter",
   // the following variants are outdated but still supported to prevent breaking changes
   "info",
 ] as const;

--- a/packages/paste-core/components/badge/src/styles.ts
+++ b/packages/paste-core/components/badge/src/styles.ts
@@ -110,6 +110,12 @@ export const badgeVariantStyles: {
     color: "colorText",
     boxShadow: "shadowBorderWeaker",
   },
+  notification_counter: {
+    borderRadius: "borderRadiusPill",
+    color: "colorTextInverse",
+    backgroundColor: "colorBackgroundErrorStrongest",
+    boxShadow: "shadowBorderErrorWeaker",
+  },
   /*
    * the following variants are outdated but still supported to prevent breaking changes
    */

--- a/packages/paste-core/components/badge/src/styles.ts
+++ b/packages/paste-core/components/badge/src/styles.ts
@@ -112,9 +112,9 @@ export const badgeVariantStyles: {
   },
   notification_counter: {
     borderRadius: "borderRadiusPill",
-    backgroundColor: "colorBackgroundDecorative40Weakest",
-    color: "colorTextDecorative40",
-    boxShadow: "shadowBorderDecorative40Weaker",
+    backgroundColor: "colorBackgroundNotification",
+    color: "colorTextInverse",
+    boxShadow: "shadowBorderNotification",
   },
   /*
    * the following variants are outdated but still supported to prevent breaking changes
@@ -177,7 +177,7 @@ export const badgeButtonStyles: {
     boxShadow: "shadowBorderBottomErrorWeaker",
   },
   notification_counter: {
-    boxShadow: "shadowBorderBottomDecorative40Weaker",
+    boxShadow: "shadowBorderBottomNotificationStronger",
   },
   // the following variants are outdated but still supported to prevent breaking changes
   default: {

--- a/packages/paste-core/components/badge/src/styles.ts
+++ b/packages/paste-core/components/badge/src/styles.ts
@@ -112,9 +112,9 @@ export const badgeVariantStyles: {
   },
   notification_counter: {
     borderRadius: "borderRadiusPill",
-    color: "colorTextInverse",
-    backgroundColor: "colorBackgroundErrorStrongest",
-    boxShadow: "shadowBorderErrorWeaker",
+    backgroundColor: "colorBackgroundDecorative40Weakest",
+    color: "colorTextDecorative40",
+    boxShadow: "shadowBorderDecorative40Weaker",
   },
   /*
    * the following variants are outdated but still supported to prevent breaking changes
@@ -175,6 +175,9 @@ export const badgeButtonStyles: {
   },
   error_counter: {
     boxShadow: "shadowBorderBottomErrorWeaker",
+  },
+  notification_counter: {
+    boxShadow: "shadowBorderBottomDecorative40Weaker",
   },
   // the following variants are outdated but still supported to prevent breaking changes
   default: {

--- a/packages/paste-core/components/badge/stories/index.stories.tsx
+++ b/packages/paste-core/components/badge/stories/index.stories.tsx
@@ -77,6 +77,9 @@ export const AllBadges = (): JSX.Element => (
     <Badge as="span" variant="error_counter">
       1
     </Badge>
+    <Badge as="span" variant="notification_counter">
+      100
+    </Badge>
   </Wrapper>
 );
 export const SmallBadges = (): JSX.Element => (
@@ -125,6 +128,9 @@ export const SmallBadges = (): JSX.Element => (
     </Badge>
     <Badge as="span" size="small" variant="error_counter">
       1
+    </Badge>
+    <Badge as="span" size="small" variant="notification_counter">
+      100
     </Badge>
   </Wrapper>
 );
@@ -1031,3 +1037,52 @@ export const LongTextBadge = (): JSX.Element => (
     </Badge>
   </Wrapper>
 );
+
+export const NotificationCounterBadge = (): JSX.Element => (
+  <>
+    <Heading as="h2" variant="heading40">
+      Span
+    </Heading>
+    <Wrapper>
+      <Badge as="span" variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="span" variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="span" variant="notification_counter">
+        100
+      </Badge>
+    </Wrapper>
+    <Heading as="h2" variant="heading40">
+      Anchor
+    </Heading>
+    <Wrapper>
+      <Badge as="a" href="#" variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="a" href="#" variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="a" href="#" variant="notification_counter">
+        100
+      </Badge>
+    </Wrapper>
+    <Heading as="h2" variant="heading40">
+      Button
+    </Heading>
+    <Wrapper>
+      <Badge as="button" onClick={() => {}} variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="button" onClick={() => {}} variant="notification_counter">
+        100
+      </Badge>
+      <Badge as="button" onClick={() => {}} variant="notification_counter">
+        100
+      </Badge>
+    </Wrapper>
+  </>
+);
+
+NotificationCounterBadge.storyName = "Notification Counter Badge";

--- a/packages/paste-core/components/badge/type-docs.json
+++ b/packages/paste-core/components/badge/type-docs.json
@@ -1,7 +1,7 @@
 {
   "BadgeBase": {
     "variant": {
-      "type": "| \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"default\"\n  | \"info\"",
+      "type": "| \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"default\"\n  | \"notification_counter\"\n  | \"info\"",
       "defaultValue": "null",
       "required": true,
       "externalProp": false
@@ -29,7 +29,7 @@
       "description": "Underlying HTML element to render. Can be \"span\", \"button\", or \"a\"."
     },
     "variant": {
-      "type": "| \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"default\"\n  | \"info\"",
+      "type": "| \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"default\"\n  | \"notification_counter\"\n  | \"info\"",
       "defaultValue": "null",
       "required": true,
       "externalProp": false

--- a/packages/paste-core/components/menu/type-docs.json
+++ b/packages/paste-core/components/menu/type-docs.json
@@ -2477,7 +2477,7 @@
       "description": "Toggles the `visible` state"
     },
     "variant": {
-      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"info\"",
+      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"notification_counter\"\n  | \"info\"",
       "defaultValue": "null",
       "required": true,
       "externalProp": false

--- a/packages/paste-core/components/popover/type-docs.json
+++ b/packages/paste-core/components/popover/type-docs.json
@@ -3560,7 +3560,7 @@
   },
   "PopoverBadgeButton": {
     "variant": {
-      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"info\"",
+      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"notification_counter\"\n  | \"info\"",
       "defaultValue": "null",
       "required": true,
       "externalProp": false

--- a/packages/paste-core/components/side-panel/type-docs.json
+++ b/packages/paste-core/components/side-panel/type-docs.json
@@ -1712,7 +1712,7 @@
   },
   "SidePanelBadgeButton": {
     "variant": {
-      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"info\"",
+      "type": "| \"default\"\n  | \"neutral\"\n  | \"warning\"\n  | \"error\"\n  | \"success\"\n  | \"new\"\n  | \"subaccount\"\n  | \"decorative10\"\n  | \"decorative20\"\n  | \"decorative30\"\n  | \"decorative40\"\n  | \"brand10\"\n  | \"brand20\"\n  | \"brand30\"\n  | \"neutral_counter\"\n  | \"error_counter\"\n  | \"notification_counter\"\n  | \"info\"",
       "defaultValue": "null",
       "required": true,
       "externalProp": false

--- a/packages/paste-website/src/pages/components/badge/index.mdx
+++ b/packages/paste-website/src/pages/components/badge/index.mdx
@@ -1,68 +1,68 @@
 export const meta = {
-  title: 'Badge - Components',
-  package: '@twilio-paste/badge',
-  description: 'A badge is a visually highlighted text label that describes an attribute of an object.',
-  slug: '/components/badge/',
+  title: "Badge - Components",
+  package: "@twilio-paste/badge",
+  description: "A badge is a visually highlighted text label that describes an attribute of an object.",
+  slug: "/components/badge/",
 };
 
-import Changelog from '@twilio-paste/badge/CHANGELOG.md';
+import Changelog from "@twilio-paste/badge/CHANGELOG.md";
 
-import {Badge} from '@twilio-paste/badge';
-import {Card} from '@twilio-paste/card';
-import {Text} from '@twilio-paste/text';
-import {Heading} from '@twilio-paste/heading';
-import {Button} from '@twilio-paste/button';
-import {Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading} from '@twilio-paste/modal';
-import {Radio, RadioGroup} from '@twilio-paste/radio-group';
-import {InformationIcon} from '@twilio-paste/icons/esm/InformationIcon';
-import {WarningIcon} from '@twilio-paste/icons/esm/WarningIcon';
-import {SuccessIcon} from '@twilio-paste/icons/esm/SuccessIcon';
-import {ErrorIcon} from '@twilio-paste/icons/esm/ErrorIcon';
-import {NewIcon} from '@twilio-paste/icons/esm/NewIcon';
-import {UsersIcon} from '@twilio-paste/icons/esm/UsersIcon';
-import {ProductVoiceIcon} from '@twilio-paste/icons/esm/ProductVoiceIcon';
-import {ProductElasticSIPTrunkingIcon} from '@twilio-paste/icons/esm/ProductElasticSIPTrunkingIcon';
-import {SMSCapableIcon} from '@twilio-paste/icons/esm/SMSCapableIcon';
-import {MMSCapableIcon} from '@twilio-paste/icons/esm/MMSCapableIcon';
-import {VoiceCapableIcon} from '@twilio-paste/icons/esm/VoiceCapableIcon';
-import {FaxCapableIcon} from '@twilio-paste/icons/esm/FaxCapableIcon';
-import {LinkExternalIcon} from '@twilio-paste/icons/esm/LinkExternalIcon';
+import { Badge } from "@twilio-paste/badge";
+import { Card } from "@twilio-paste/card";
+import { Text } from "@twilio-paste/text";
+import { Heading } from "@twilio-paste/heading";
+import { Button } from "@twilio-paste/button";
+import { Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading } from "@twilio-paste/modal";
+import { Radio, RadioGroup } from "@twilio-paste/radio-group";
+import { InformationIcon } from "@twilio-paste/icons/esm/InformationIcon";
+import { WarningIcon } from "@twilio-paste/icons/esm/WarningIcon";
+import { SuccessIcon } from "@twilio-paste/icons/esm/SuccessIcon";
+import { ErrorIcon } from "@twilio-paste/icons/esm/ErrorIcon";
+import { NewIcon } from "@twilio-paste/icons/esm/NewIcon";
+import { UsersIcon } from "@twilio-paste/icons/esm/UsersIcon";
+import { ProductVoiceIcon } from "@twilio-paste/icons/esm/ProductVoiceIcon";
+import { ProductElasticSIPTrunkingIcon } from "@twilio-paste/icons/esm/ProductElasticSIPTrunkingIcon";
+import { SMSCapableIcon } from "@twilio-paste/icons/esm/SMSCapableIcon";
+import { MMSCapableIcon } from "@twilio-paste/icons/esm/MMSCapableIcon";
+import { VoiceCapableIcon } from "@twilio-paste/icons/esm/VoiceCapableIcon";
+import { FaxCapableIcon } from "@twilio-paste/icons/esm/FaxCapableIcon";
+import { LinkExternalIcon } from "@twilio-paste/icons/esm/LinkExternalIcon";
 import { ProductCommsIcon } from "@twilio-paste/icons/esm/ProductCommsIcon";
 import { ProductSendGridIcon } from "@twilio-paste/icons/esm/ProductSendGridIcon";
 import { ProductSegmentIcon } from "@twilio-paste/icons/esm/ProductSegmentIcon";
-import {Grid, Column} from '@twilio-paste/grid';
-import {Tabs, Tab, TabList, TabPanel, TabPanels} from '@twilio-paste/tabs';
-import {DisplayPill} from '@twilio-paste/display-pill-group';
+import { Grid, Column } from "@twilio-paste/grid";
+import { Tabs, Tab, TabList, TabPanel, TabPanels } from "@twilio-paste/tabs";
+import { DisplayPill } from "@twilio-paste/display-pill-group";
 
-import {Truncate} from '@twilio-paste/truncate';
-import {styled, css} from '@twilio-paste/styling-library';
+import { Truncate } from "@twilio-paste/truncate";
+import { styled, css } from "@twilio-paste/styling-library";
 
-import {Box} from '@twilio-paste/box';
-import {UnorderedList, ListItem} from '@twilio-paste/list';
-import {Stack} from '@twilio-paste/stack';
-import {Paragraph} from '@twilio-paste/paragraph';
-import {PopoverContainer, PopoverBadgeButton, Popover} from '@twilio-paste/popover';
-import {Table, THead, TBody, Td, Th, Tr} from '@twilio-paste/table';
-import {useUID} from '@twilio-paste/uid-library';
+import { Box } from "@twilio-paste/box";
+import { UnorderedList, ListItem } from "@twilio-paste/list";
+import { Stack } from "@twilio-paste/stack";
+import { Paragraph } from "@twilio-paste/paragraph";
+import { PopoverContainer, PopoverBadgeButton, Popover } from "@twilio-paste/popover";
+import { Table, THead, TBody, Td, Th, Tr } from "@twilio-paste/table";
+import { useUID } from "@twilio-paste/uid-library";
 
-import {SidebarCategoryRoutes} from '../../../constants';
-import {DoDont, Do, Dont} from '../../../components/DoDont';
+import { SidebarCategoryRoutes } from "../../../constants";
+import { DoDont, Do, Dont } from "../../../components/DoDont";
 import {
   tableExample,
   betaFeatureExample,
   settingsAndProducts,
   badgeModalExample,
   counterExample,
-} from '../../../component-examples/BadgeExamples';
-import packageJson from '@twilio-paste/badge/package.json';
-import ComponentPageLayout from '../../../layouts/ComponentPageLayout';
-import {getFeature, getNavigationData} from '../../../utils/api';
+} from "../../../component-examples/BadgeExamples";
+import packageJson from "@twilio-paste/badge/package.json";
+import ComponentPageLayout from "../../../layouts/ComponentPageLayout";
+import { getFeature, getNavigationData } from "../../../utils/api";
 
 export default ComponentPageLayout;
 
 export const getStaticProps = async () => {
   const navigationData = await getNavigationData();
-  const feature = await getFeature('Badge');
+  const feature = await getFeature("Badge");
   return {
     props: {
       data: {
@@ -73,14 +73,14 @@ export const getStaticProps = async () => {
       mdxHeadings,
       pageHeaderData: {
         categoryRoute: SidebarCategoryRoutes.COMPONENTS,
-        githubUrl: 'https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/badge',
-        storybookUrl: '/?path=/story/components-badge--all-badges',
+        githubUrl: "https://github.com/twilio-labs/paste/tree/main/packages/paste-core/components/badge",
+        storybookUrl: "/?path=/story/components-badge--all-badges",
       },
     },
   };
 };
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space40" rowGap="space60" flexWrap="wrap">
   <Badge as="span" variant="neutral">
     Neutral
@@ -127,6 +127,9 @@ export const getStaticProps = async () => {
   <Badge as="span" variant="error_counter">
     1
   </Badge>
+  <Badge as="span" variant="notification_counter">
+    100
+  </Badge>
 </Box>
 `.trim()}
 </LivePreview>
@@ -160,7 +163,7 @@ should be prefixed before the text.
 
 Use the neutral Badge to highlight neutral attributes of an object. An information icon is optional.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="neutral">
     Neutral
@@ -177,7 +180,7 @@ Use the neutral Badge to highlight neutral attributes of an object. An informati
 
 Use the warning Badge to highlight attributes of an object that the user must be made aware of to avoid incurring an error. A warning icon is recommended.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="warning">
     Warning
@@ -198,7 +201,7 @@ Do not use an error Badge unless there is additional guidance elsewhere on the p
 
 For additional guidance on how to compose error messages, refer to the [error state pattern](/patterns/error-state).
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="error">
     Error
@@ -216,7 +219,7 @@ For additional guidance on how to compose error messages, refer to the [error st
 Use the success Badge to highlight attributes of an object that were completed or are considered to be in a good
 state. A success icon is recommended.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="success">
     Success
@@ -233,7 +236,7 @@ state. A success icon is recommended.
 
 Use the new Badge to highlight an object that is new, beta, pilot, or experimental. A new icon is recommended.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="new">
     New
@@ -251,7 +254,7 @@ Use the new Badge to highlight an object that is new, beta, pilot, or experiment
 The subaccount Badge is reserved for specific use cases only. Consult with the Console team before implementing this variant.
 A users icon is recommended.
 
-<LivePreview scope={{Box, Badge, UsersIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, UsersIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="subaccount">
     Subaccount
@@ -269,7 +272,7 @@ A users icon is recommended.
 Use the decorative Badge to highlight attributes that do not have a strictly semantic meaning (like warning, error, or success)
 but would benefit from the visual affordance of differently-colored Badges. Icons are optional, and should appear before the text.
 
-<LivePreview scope={{Box, Badge, SMSCapableIcon, MMSCapableIcon, VoiceCapableIcon, FaxCapableIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, SMSCapableIcon, MMSCapableIcon, VoiceCapableIcon, FaxCapableIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="decorative10">
     <VoiceCapableIcon decorative />
@@ -295,7 +298,10 @@ but would benefit from the visual affordance of differently-colored Badges. Icon
 
 Use the brand Badge for cross-selling opportunities across platforms (e.g., Segment, SendGrid, Communications, Flex) and pricing plans. Use these sparingly.
 
-<LivePreview scope={{Box, Badge, ProductSendGridIcon, ProductSegmentIcon, ProductCommsIcon, FaxCapableIcon}} language="jsx">
+<LivePreview
+  scope={{ Box, Badge, ProductSendGridIcon, ProductSegmentIcon, ProductCommsIcon, FaxCapableIcon }}
+  language="jsx"
+>
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="brand10">
     <ProductCommsIcon decorative />
@@ -319,7 +325,7 @@ Use the counter Badge to visually highlight a count in a UI, like the number of 
 
 Counter Badges have neutral, error, and notification variants. The error variant should always include an error icon. The notification variant informs users of new or unread items, such as messages, notifications, or updates.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space80">
   <Badge as="span" variant="neutral_counter">
     100
@@ -327,7 +333,7 @@ Counter Badges have neutral, error, and notification variants. The error variant
   <Badge as="span" variant="error_counter">
     100
   </Badge>
-    <Badge as="span" variant="notification_counter">
+  <Badge as="span" variant="notification_counter">
     100
   </Badge>
 </Box>
@@ -339,7 +345,7 @@ Counter Badges have neutral, error, and notification variants. The error variant
 A badge can link to other pages.
 To do so, add an `href` prop and set `as="a"` on the Badge.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space40" rowGap="space60" flexWrap="wrap">
   <Badge as="a" href="https://www.twilio.com/docs" variant="neutral">
     <InformationIcon decorative/>
@@ -384,7 +390,7 @@ of the Popover docs to add a Popover to a Badge.
 
 Use a small Badge only when vertical density is a concern. The guidelines for using variants in a small Badge are the same as in their default size.
 
-<LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
+<LivePreview scope={{ Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon }} language="jsx">
   {`<Box display="flex" columnGap="space40" rowGap="space60" flexWrap="wrap">
   <Badge as="span" size="small" variant="neutral">
     Neutral
@@ -666,7 +672,7 @@ yarn add @twilio-paste/badge - or - yarn add @twilio-paste/core
 #### Usage
 
 ```jsx
-import {Badge} from '@twilio-paste/core/badge';
+import { Badge } from "@twilio-paste/core/badge";
 
 const BadgeExample = () => (
   <Badge as="span" variant="neutral">

--- a/packages/paste-website/src/pages/components/badge/index.mdx
+++ b/packages/paste-website/src/pages/components/badge/index.mdx
@@ -315,9 +315,9 @@ Use the brand Badge for cross-selling opportunities across platforms (e.g., Segm
 
 ### Counter
 
-Use the counter Badge should be used to visually highlight a count in a UI.
-For example, the number of pending invitations or the number of errors.
-Counter Badges are limited to Neutral and Error variants, and the error variant should always include an error icon.
+Use the counter Badge to visually highlight a count in a UI, like the number of pending invitations or the number of errors.
+
+Counter Badges have neutral, error, and notification variants. The error variant should always include an error icon. The notification variant informs users of new or unread items, such as messages, notifications, or updates.
 
 <LivePreview scope={{Box, Badge, InformationIcon, ErrorIcon, WarningIcon, SuccessIcon, NewIcon}} language="jsx">
   {`<Box display="flex" columnGap="space80">
@@ -325,6 +325,9 @@ Counter Badges are limited to Neutral and Error variants, and the error variant 
     100
   </Badge>
   <Badge as="span" variant="error_counter">
+    100
+  </Badge>
+    <Badge as="span" variant="notification_counter">
     100
   </Badge>
 </Box>
@@ -400,19 +403,6 @@ Use a small Badge only when vertical density is a concern. The guidelines for us
   </Badge>
   <Badge as="span" size="small" variant="subaccount">
     Subaccount
-  </Badge>
-</Box>
-`.trim()}
-</LivePreview>
-
-### Notification Counter
-
-Use a notification counter as a visual indicator to inform users of new or unread items, such as messages, notifications, or updates. 
-
-<LivePreview scope={{Box, Badge, InformationIcon}} language="jsx">
-  {`<Box display="flex" columnGap="space80">
-  <Badge as="span" variant="notification_counter">
-    100
   </Badge>
 </Box>
 `.trim()}

--- a/packages/paste-website/src/pages/components/badge/index.mdx
+++ b/packages/paste-website/src/pages/components/badge/index.mdx
@@ -405,6 +405,19 @@ Use a small Badge only when vertical density is a concern. The guidelines for us
 `.trim()}
 </LivePreview>
 
+### Notification Counter
+
+Use a notification counter as a visual indicator to inform users of new or unread items, such as messages, notifications, or updates. 
+
+<LivePreview scope={{Box, Badge, InformationIcon}} language="jsx">
+  {`<Box display="flex" columnGap="space80">
+  <Badge as="span" variant="notification_counter">
+    100
+  </Badge>
+</Box>
+`.trim()}
+</LivePreview>
+
 ---
 
 ## Composition notes


### PR DESCRIPTION
This pull request primarily introduces a new badge variant, `notification_counter`, to the badge component in `packages/paste-core/components/badge`. 

It uses the new design tokens for notifications