### PR TITLE
chore(collaboration): added script to resolve typedoc issue

### DIFF
--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -98,13 +98,13 @@ DATADOG_CLIENT_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxx
   <tr>
    <td>DATADOG_APPLICATION_ID
    </td>
-   <td>Datadog RUM app ID
+   <td>Datadog RUM app ID. You can get this from the dashbaord chart <a href="https://app.datadoghq.com/dashboard/p79-36e-cxi/paste-monitoring-dashboard?fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=edit&fullscreen_start_ts=1719073205976&fullscreen_widget=6572526642365602&refresh_mode=sliding">here</a>
    </td>
   </tr>
   <tr>
    <td>DATADOG_CLIENT_TOKEN
    </td>
-   <td>Datadog RUM client token
+   <td><a href="https://app.datadoghq.com/organization-settings/client-tokens">Datadog RUM client token</a>  (search Paste)
    </td>
   </tr>
 </table>

--- a/internal-docs/engineering/developing-locally.md
+++ b/internal-docs/engineering/developing-locally.md
@@ -98,7 +98,7 @@ DATADOG_CLIENT_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxx
   <tr>
    <td>DATADOG_APPLICATION_ID
    </td>
-   <td>Datadog RUM app ID. You can get this from the dashbaord chart <a href="https://app.datadoghq.com/dashboard/p79-36e-cxi/paste-monitoring-dashboard?fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=edit&fullscreen_start_ts=1719073205976&fullscreen_widget=6572526642365602&refresh_mode=sliding">here</a>
+   <td>Datadog RUM app ID. You can get this from the dashboard chart <a href="https://app.datadoghq.com/dashboard/p79-36e-cxi/paste-monitoring-dashboard?fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=edit&fullscreen_start_ts=1719073205976&fullscreen_widget=6572526642365602&refresh_mode=sliding">here</a>
    </td>
   </tr>
   <tr>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "yarn prebuild && yarn nx run-many --target=build --exclude @twilio-paste/website @twilio-paste/theme-designer @twilio-paste/nextjs-template @twilio-paste/token-contrast-checker",
     "build:js": "yarn prebuild && yarn nx run-many --target=build:js --exclude @twilio-paste/website @twilio-paste/theme-designer",
     "build:typedocs": "yarn prebuild && yarn nx run-many --target=build:typedocs",
+    "build:typedocs:clean":"rm -rf .nx/cache && yarn build && yarn build:typedocs",
     "build:core": "yarn nx run @twilio-paste/core:build",
     "build:codemods": "yarn nx run @twilio-paste/codemods:build",
     "build:tokens": "yarn nx run @twilio-paste/design-tokens:tokens",


### PR DESCRIPTION
Added a new script into package.json to run a series of commands to resolve the typedoc issue when forking the repo.

After investigation I found that if you run the typedoc command before running the build command it will output incorrect typedocs and cause large unintended and incorrect changes to various typedoc files. What is more interesting is that these incorrect changes are different per machine.

The resolution is to clean the local NX cache and run the full build and typedocs scrips. Tested locally by forking the repo multiple times.

If we see this issue in collab PRs we can now ask them to just run this to resolve the issue instead of granting write access to our repo
