### PR TITLE
avatar-size-user-dialog

### DIFF
--- a/.changeset/khaki-rocks-fix.md
+++ b/.changeset/khaki-rocks-fix.md
@@ -1,0 +1,5 @@
+---
+"@twilio-paste/user-dialog": patch
+---
+
+Update the size of the UserDialog's inner Avatar component.

--- a/.changeset/khaki-rocks-fix.md
+++ b/.changeset/khaki-rocks-fix.md
@@ -1,5 +1,6 @@
 ---
 "@twilio-paste/user-dialog": patch
+"@twilio-paste/core": patch
 ---
 
 Update the size of the UserDialog's inner Avatar component.

--- a/packages/paste-core/components/user-dialog/src/UserDialog.tsx
+++ b/packages/paste-core/components/user-dialog/src/UserDialog.tsx
@@ -93,7 +93,7 @@ export const UserDialog = React.forwardRef<HTMLDivElement, UserDialogProps>(
           >
             <Avatar
               variant="user"
-              size="sizeIcon70"
+              size="sizeIcon40"
               name={avatarProps.name}
               icon={avatarProps.icon}
               src={avatarProps.src}


### PR DESCRIPTION
Updating the size of the Avatar element in UserDialog. The current size of the Avatar is slightly too large and looks a bit out of place.

No functional changes to the component have occurred.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
