### PR TITLE
fix(combobox): modify `MultiSelectComboboxProps.onSelectedItemsChange` typing to reflect reality

### DIFF
--- a/.changeset/shy-birds-jump.md
+++ b/.changeset/shy-birds-jump.md
@@ -1,0 +1,5 @@
+---
+"@twilio-paste/combobox": patch
+---
+
+Changed type of MultiselectComboboxProps.onSelectedItemsChange.newSelectedItems to include type that is returned when not in IoC mode

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -247,9 +247,12 @@ export interface MultiselectComboboxProps
   /**
    * Callback function for after an item is selected or deselected
    *
+   * If `state` prop is passed, `UseMultiSelectPrimitiveStateChange<Item>` is the type for the `newSelectedItems` callback param
+   *
+   * If `state` prop isn't passed, `any[]` is the type for the `newSelectedItems` callback param
    * @memberof MultiselectComboboxProps
    */
-  onSelectedItemsChange?: (newSelectedItems: UseMultiSelectPrimitiveStateChange<Item>) => void;
+  onSelectedItemsChange?: (newSelectedItems: any[] | UseMultiSelectPrimitiveStateChange<Item>) => void;
   /**
    * Hidden helper text for screen readers
    *


### PR DESCRIPTION
The current typing for this prop is misleading and has caused some confusion on the Segment side of the house. From my code comment, the true behavior of the callback function here is as follows:
```
* If `state` prop is passed, `UseMultiSelectPrimitiveStateChange<Item>` is the type for the `newSelectedItems` callback param
*
* If `state` prop isn't passed, `any[]` is the type for the `newSelectedItems` callback param
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
