### PR TITLE
fix(checkbox): expose helpText on CheckboxDisclaimer

### DIFF
--- a/.changeset/short-years-taste.md
+++ b/.changeset/short-years-taste.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/checkbox": patch
+"@twilio-paste/core": patch
+---
+
+[Checkbox] exposed helpText on CheckboxDisclaimer

--- a/packages/paste-core/components/checkbox/src/CheckboxDisclaimer.tsx
+++ b/packages/paste-core/components/checkbox/src/CheckboxDisclaimer.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from "./Checkbox";
 import type { CheckboxProps } from "./Checkbox";
 
 export interface CheckboxDisclaimerProps
-  extends Omit<CheckboxProps, "isSelectAll" | "isSelectAllChild" | "indeterminate" | "helpText" | "hasError"> {
+  extends Omit<CheckboxProps, "isSelectAll" | "isSelectAllChild" | "indeterminate" | "hasError"> {
   children: NonNullable<React.ReactNode>;
   /**
    * Sets the Checkbox Group in error state

--- a/packages/paste-core/components/checkbox/stories/checkbox.stories.tsx
+++ b/packages/paste-core/components/checkbox/stories/checkbox.stories.tsx
@@ -640,6 +640,26 @@ export const CheckboxDisclaimerError = (): React.ReactNode => {
 
 CheckboxDisclaimerError.storyName = "Checkbox Disclaimer - Error";
 
+export const CheckboxDisclaimerHelpText = (): React.ReactNode => {
+  return (
+    <CheckboxDisclaimer
+      helpText="This text is designed to provide helpful information."
+      id={useUID()}
+      value="foo"
+      name="foo"
+    >
+      <Text as="span">
+        I declare the information provided above is accurate. I acknowledge that Twilio will process the information
+        provided above for the purpose of identity verification, and will be sharing it with my local telecomm providers
+        or authorities where required by local law. I understand that Twilio phone numbers may be taken out of service
+        for inaccurate or false information.
+      </Text>
+    </CheckboxDisclaimer>
+  );
+};
+
+CheckboxDisclaimerHelpText.storyName = "Checkbox Disclaimer - HelpText";
+
 export const CheckboxDisclaimerDisabled = (): React.ReactNode => {
   return (
     <CheckboxDisclaimer disabled id={useUID()} value="foo" name="foo">

--- a/packages/paste-core/components/checkbox/type-docs.json
+++ b/packages/paste-core/components/checkbox/type-docs.json
@@ -3989,6 +3989,12 @@
       "required": false,
       "externalProp": true
     },
+    "helpText": {
+      "type": "| string\n  | number\n  | boolean\n  | ReactElement<any, string | JSXElementConstructor<any>>\n  | ReactFragment\n  | ReactPortal",
+      "defaultValue": "null",
+      "required": false,
+      "externalProp": false
+    },
     "hidden": {
       "type": "boolean",
       "defaultValue": null,


### PR DESCRIPTION
Fix a bug where using helpText on CheckboxDisclaimer would give typescript errors
