### PR TITLE
chore(ci): temporarily disable broken actions

### DIFF
--- a/.github/workflows/on_merge_to_main_supabase.yml
+++ b/.github/workflows/on_merge_to_main_supabase.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ false }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/update_docs_embed.yml
+++ b/.github/workflows/update_docs_embed.yml
@@ -62,11 +62,11 @@ jobs:
         if: steps.yarn_cache_id.outputs.cache-hit != 'true' || steps.node_modules_cache_id.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
-      - name: Link Supabase project
-        run: yarn workspace @twilio-paste/backend supabase link --project-ref $PROJECT_ID
+      # - name: Link Supabase project
+      #   run: yarn workspace @twilio-paste/backend supabase link --project-ref $PROJECT_ID
 
-      - name: Run migrations
-        run: yarn workspace @twilio-paste/backend supabase db push
+      # - name: Run migrations
+      #   run: yarn workspace @twilio-paste/backend supabase db push
 
       - name: Update embeddings
         if: ${{ !inputs.refresh }}


### PR DESCRIPTION
Supbabase link commands are not working with prod. A support ticket has been raised but we can temporarily remove these.

The purpose of these are to detect changes in database structure and create and apply migrations to update the prod instance. These are things such as adding/removing columns, creating and removing tables.

The generate embedding issue should actually be resolved from this as we do not need to do any database maintenence but run a script using the javascript library to connect to the DB. This connects a different way than the CLI step that is breaking. I believe this Javascript script should still work as that is the same library used to connect to DB for search functionality in the site that is still working.