### PR TITLE
fix(docs): corner ornament name

### DIFF
--- a/packages/paste-website/src/pages/components/corner-ornament/api.mdx
+++ b/packages/paste-website/src/pages/components/corner-ornament/api.mdx
@@ -16,7 +16,7 @@ export default ComponentPageLayout;
 
 export const getStaticProps = async () => {
   const navigationData = await getNavigationData();
-  const feature = await getFeature('Corner ornament');
+  const feature = await getFeature('Corner Ornament');
   const {componentApi, componentApiTocData} = getComponentApi('@twilio-paste/corner-ornament');
   return {
     props: {

--- a/packages/paste-website/src/pages/components/corner-ornament/changelog.mdx
+++ b/packages/paste-website/src/pages/components/corner-ornament/changelog.mdx
@@ -16,7 +16,7 @@ export default ComponentPageLayout;
 
 export const getStaticProps = async () => {
   const navigationData = await getNavigationData();
-  const feature = await getFeature('Corner ornament');
+  const feature = await getFeature('Corner Ornament');
   return {
     props: {
       data: {

--- a/packages/paste-website/src/pages/components/corner-ornament/index.mdx
+++ b/packages/paste-website/src/pages/components/corner-ornament/index.mdx
@@ -37,7 +37,7 @@ export default ComponentPageLayout;
 
 export const getStaticProps = async () => {
   const navigationData = await getNavigationData();
-  const feature = await getFeature("Corner ornament");
+  const feature = await getFeature("Corner Ornament");
   return {
     props: {
       data: {


### PR DESCRIPTION
Corner Ornament got renamed 1 day ago and now fails to match teh package name from the Airtable dump
