### PR TITLE
fix(nx): remove access token. Sets via env variables

### DIFF
--- a/.github/workflows/on_pull_request_package_size.yml
+++ b/.github/workflows/on_pull_request_package_size.yml
@@ -6,6 +6,9 @@ jobs:
   package-size:
     name: Check package sizes
     runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/on_pull_request_supabase.yml
+++ b/.github/workflows/on_pull_request_supabase.yml
@@ -12,6 +12,7 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
       SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_STAGING_PROJECT_ID }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/update_docs_embed.yml
+++ b/.github/workflows/update_docs_embed.yml
@@ -22,6 +22,7 @@ jobs:
       SUPABASE_URL: ${{ secrets.SUPABASE_PRODUCTION_URL }}
       SUPABASE_KEY: ${{ secrets.SUPABASE_PRODUCTION_KEY }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PRODUCTION_DB_PASSWORD }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout Repo

--- a/nx.json
+++ b/nx.json
@@ -75,6 +75,5 @@
     "sharedGlobals": [],
     "production": ["default"]
   },
-  "nxCloudAccessToken": "MjY0NzIzMDYtMjFkNi00NDVkLWI2NWQtMjZhMzY2MmY1MjY2fHJlYWQ=",
   "parallel": 10
 }


### PR DESCRIPTION
Remove the static NX token. It was a read only token for an open source project but flagged by internal security. 

The token was deleted from NX Cloud and another one is shared in team 1Password if needed for local development.

The token has been updated in GitHub variables and you can see it correctly connecting for this PR 4042:
![image](https://github.com/user-attachments/assets/d0d443b4-a683-4d9b-ae7a-9b762a50a09f)
