### PR TITLE
fix: combobox inside of popover bug

### DIFF
--- a/.changeset/healthy-cobras-whisper.md
+++ b/.changeset/healthy-cobras-whisper.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/combobox": minor
+"@twilio-paste/core": minor
+---
+
+[Combobox] Add new prop `usePortal` which defaults to `true`. The prop was introduced to address a bug when Comboboxes are placed in Popovers. usePortal should be set to false when using a Combobox inside a Popover in order to retain full functionality.

--- a/packages/paste-core/components/combobox/src/ListboxPositioner.tsx
+++ b/packages/paste-core/components/combobox/src/ListboxPositioner.tsx
@@ -57,8 +57,8 @@ export const ListBoxPositioner: React.FC<ListBoxPositionerProps> = ({ inputBoxRe
         };
       }
     }
-
     return {
+      // TODO: adjust placement for comboboxes inside of portals (popovers/modals)
       position: "fixed",
       top: inputBoxDimensions?.bottom,
       left: inputBoxDimensions?.left,

--- a/packages/paste-core/components/combobox/src/ListboxPositioner.tsx
+++ b/packages/paste-core/components/combobox/src/ListboxPositioner.tsx
@@ -58,7 +58,6 @@ export const ListBoxPositioner: React.FC<ListBoxPositionerProps> = ({ inputBoxRe
       }
     }
     return {
-      // TODO: adjust placement for comboboxes inside of portals (popovers/modals)
       position: "fixed",
       top: inputBoxDimensions?.bottom,
       left: inputBoxDimensions?.left,

--- a/packages/paste-core/components/combobox/src/ListboxWrapper.tsx
+++ b/packages/paste-core/components/combobox/src/ListboxWrapper.tsx
@@ -1,0 +1,35 @@
+import { Box } from "@twilio-paste/box";
+import { Portal } from "@twilio-paste/reakit-library";
+import * as React from "react";
+
+import { ListBoxPositioner } from "./ListboxPositioner";
+
+/*
+ * This component renders the listbox in an absolutely positioned Box when `usePortal={false}`.
+ * Portal and ListBoxPositioner shouldn't be used when the Combobox is placed in a Popover.
+ * Using Combobox in a Popover was previously causing interaction issues because of the Portal that Popover uses.
+ * Because ListBoxPositioner isn't used when `usePortal={false}`, the listbox won't change position based on the window
+ * (e.g. moving above the input box when the Combobox is at the bottom of the window).
+ */
+
+export const ListboxWrapper: React.FC<{
+  inputBoxRef: React.RefObject<HTMLElement>;
+  parentRef: React.RefObject<HTMLElement>;
+  usePortal: boolean;
+  children: React.ReactNode;
+}> = ({ inputBoxRef, parentRef, usePortal, children }) => {
+  if (!usePortal)
+    return (
+      <Box position="absolute" top="100%" width="100%">
+        {children}
+      </Box>
+    );
+  return (
+    <Portal>
+      <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
+        {children}
+      </ListBoxPositioner>
+    </Portal>
+  );
+};
+ListboxWrapper.displayName = "ListboxWrapper";

--- a/packages/paste-core/components/combobox/src/multiselect/MultiselectCombobox.tsx
+++ b/packages/paste-core/components/combobox/src/multiselect/MultiselectCombobox.tsx
@@ -5,12 +5,12 @@ import { HelpText } from "@twilio-paste/help-text";
 import { ChevronDownIcon } from "@twilio-paste/icons/esm/ChevronDownIcon";
 import { InputBox, InputChevronWrapper, getInputChevronIconColor } from "@twilio-paste/input-box";
 import { Label } from "@twilio-paste/label";
-import { Portal } from "@twilio-paste/reakit-library";
 import { ScreenReaderOnly } from "@twilio-paste/screen-reader-only";
 import { useUID } from "@twilio-paste/uid-library";
 import { useWindowSize } from "@twilio-paste/utils";
 import includes from "lodash/includes";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { useVirtual } from "react-virtual";
 
 import { ComboboxItems } from "../ComboboxItems";
@@ -275,6 +275,12 @@ export const MultiselectCombobox = React.forwardRef<HTMLInputElement, Multiselec
     });
     const ariaExpanded = comboboxProps["aria-expanded"] || "false";
 
+    const [domReady, setDomReady] = React.useState(false);
+
+    React.useEffect(() => {
+      setDomReady(true);
+    }, []);
+
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
         <Label disabled={disabled} required={required} variant={variant} {...getLabelProps()}>
@@ -365,32 +371,34 @@ export const MultiselectCombobox = React.forwardRef<HTMLInputElement, Multiselec
             </InputChevronWrapper>
           </Box>
         </InputBox>
-        <Portal>
-          <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
-            <ComboboxListbox
-              {...getMenuProps({ ref: parentRef })}
-              element={`${element}_LISTBOX`}
-              hidden={!isOpen}
-              aria-multiselectable="true"
-            >
-              <ComboboxItems
-                ref={scrollToIndexRef}
-                items={items}
-                element={element}
-                getItemProps={getItemProps}
-                highlightedIndex={highlightedIndex}
-                selectedItems={selectedItems}
-                disabledItems={disabledItems}
-                totalSize={rowVirtualizer.totalSize}
-                virtualItems={rowVirtualizer.virtualItems}
-                optionTemplate={optionTemplate}
-                groupItemsBy={groupItemsBy}
-                groupLabelTemplate={groupLabelTemplate}
-                emptyState={emptyState}
-              />
-            </ComboboxListbox>
-          </ListBoxPositioner>
-        </Portal>
+        {domReady &&
+          createPortal(
+            <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
+              <ComboboxListbox
+                {...getMenuProps({ ref: parentRef })}
+                element={`${element}_LISTBOX`}
+                hidden={!isOpen}
+                aria-multiselectable="true"
+              >
+                <ComboboxItems
+                  ref={scrollToIndexRef}
+                  items={items}
+                  element={element}
+                  getItemProps={getItemProps}
+                  highlightedIndex={highlightedIndex}
+                  selectedItems={selectedItems}
+                  disabledItems={disabledItems}
+                  totalSize={rowVirtualizer.totalSize}
+                  virtualItems={rowVirtualizer.virtualItems}
+                  optionTemplate={optionTemplate}
+                  groupItemsBy={groupItemsBy}
+                  groupLabelTemplate={groupLabelTemplate}
+                  emptyState={emptyState}
+                />
+              </ComboboxListbox>
+            </ListBoxPositioner>,
+            inputBoxRef.current as Element,
+          )}
         {helpText && (
           <HelpText id={helpTextId} variant={getHelpTextVariant(variant, hasError)} element={`${element}_HELP_TEXT`}>
             {helpText}

--- a/packages/paste-core/components/combobox/src/multiselect/MultiselectCombobox.tsx
+++ b/packages/paste-core/components/combobox/src/multiselect/MultiselectCombobox.tsx
@@ -10,11 +10,10 @@ import { useUID } from "@twilio-paste/uid-library";
 import { useWindowSize } from "@twilio-paste/utils";
 import includes from "lodash/includes";
 import * as React from "react";
-import { createPortal } from "react-dom";
 import { useVirtual } from "react-virtual";
 
 import { ComboboxItems } from "../ComboboxItems";
-import { ListBoxPositioner } from "../ListboxPositioner";
+import { ListboxWrapper } from "../ListboxWrapper";
 import { getHelpTextVariant } from "../helpers";
 import { ComboboxListbox } from "../styles/ComboboxListbox";
 import type { MultiselectComboboxProps } from "../types";
@@ -24,6 +23,7 @@ import { extractPropsFromState } from "./extractPropsFromState";
 export const MultiselectCombobox = React.forwardRef<HTMLInputElement, MultiselectComboboxProps>(
   (
     {
+      usePortal = true,
       element = "MULTISELECT_COMBOBOX",
       disabled,
       hasError,
@@ -275,12 +275,6 @@ export const MultiselectCombobox = React.forwardRef<HTMLInputElement, Multiselec
     });
     const ariaExpanded = comboboxProps["aria-expanded"] || "false";
 
-    const [domReady, setDomReady] = React.useState(false);
-
-    React.useEffect(() => {
-      setDomReady(true);
-    }, []);
-
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
         <Label disabled={disabled} required={required} variant={variant} {...getLabelProps()}>
@@ -371,34 +365,30 @@ export const MultiselectCombobox = React.forwardRef<HTMLInputElement, Multiselec
             </InputChevronWrapper>
           </Box>
         </InputBox>
-        {domReady &&
-          createPortal(
-            <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
-              <ComboboxListbox
-                {...getMenuProps({ ref: parentRef })}
-                element={`${element}_LISTBOX`}
-                hidden={!isOpen}
-                aria-multiselectable="true"
-              >
-                <ComboboxItems
-                  ref={scrollToIndexRef}
-                  items={items}
-                  element={element}
-                  getItemProps={getItemProps}
-                  highlightedIndex={highlightedIndex}
-                  selectedItems={selectedItems}
-                  disabledItems={disabledItems}
-                  totalSize={rowVirtualizer.totalSize}
-                  virtualItems={rowVirtualizer.virtualItems}
-                  optionTemplate={optionTemplate}
-                  groupItemsBy={groupItemsBy}
-                  groupLabelTemplate={groupLabelTemplate}
-                  emptyState={emptyState}
-                />
-              </ComboboxListbox>
-            </ListBoxPositioner>,
-            inputBoxRef.current as Element,
-          )}
+        <ListboxWrapper inputBoxRef={inputBoxRef} parentRef={parentRef} usePortal={usePortal}>
+          <ComboboxListbox
+            {...getMenuProps({ ref: parentRef })}
+            element={`${element}_LISTBOX`}
+            hidden={!isOpen}
+            aria-multiselectable="true"
+          >
+            <ComboboxItems
+              ref={scrollToIndexRef}
+              items={items}
+              element={element}
+              getItemProps={getItemProps}
+              highlightedIndex={highlightedIndex}
+              selectedItems={selectedItems}
+              disabledItems={disabledItems}
+              totalSize={rowVirtualizer.totalSize}
+              virtualItems={rowVirtualizer.virtualItems}
+              optionTemplate={optionTemplate}
+              groupItemsBy={groupItemsBy}
+              groupLabelTemplate={groupLabelTemplate}
+              emptyState={emptyState}
+            />
+          </ComboboxListbox>
+        </ListboxWrapper>
         {helpText && (
           <HelpText id={helpTextId} variant={getHelpTextVariant(variant, hasError)} element={`${element}_HELP_TEXT`}>
             {helpText}

--- a/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
@@ -5,10 +5,10 @@ import { ChevronDownIcon } from "@twilio-paste/icons/esm/ChevronDownIcon";
 import type { InputVariants } from "@twilio-paste/input";
 import { InputBox, InputChevronWrapper, getInputChevronIconColor } from "@twilio-paste/input-box";
 import { Label } from "@twilio-paste/label";
-import { Portal } from "@twilio-paste/reakit-library";
 import { useUID } from "@twilio-paste/uid-library";
 import { useWindowSize } from "@twilio-paste/utils";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { useVirtual } from "react-virtual";
 
 import { ComboboxItems } from "../ComboboxItems";
@@ -143,6 +143,12 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       [items, internalSelectedItem],
     );
 
+    const [domReady, setDomReady] = React.useState(false);
+
+    React.useEffect(() => {
+      setDomReady(true);
+    }, []);
+
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
         <Box {...(hideVisibleLabel && { ...visuallyHiddenStyles })}>
@@ -180,26 +186,28 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
             )}
           </ComboboxInputWrapper>
         </InputBox>
-        <Portal>
-          <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
-            <ComboboxListbox hidden={!isOpen} element={`${element}_LISTBOX`} {...getMenuProps({ ref: parentRef })}>
-              <ComboboxItems
-                ref={scrollToIndexRef}
-                items={items}
-                element={element}
-                getItemProps={getItemProps}
-                highlightedIndex={highlightedIndex}
-                disabledItems={disabledItems}
-                optionTemplate={optionTemplate}
-                groupItemsBy={groupItemsBy}
-                groupLabelTemplate={groupLabelTemplate}
-                totalSize={rowVirtualizer.totalSize}
-                virtualItems={rowVirtualizer.virtualItems}
-                emptyState={emptyState}
-              />
-            </ComboboxListbox>
-          </ListBoxPositioner>
-        </Portal>
+        {domReady &&
+          createPortal(
+            <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
+              <ComboboxListbox hidden={!isOpen} element={`${element}_LISTBOX`} {...getMenuProps({ ref: parentRef })}>
+                <ComboboxItems
+                  ref={scrollToIndexRef}
+                  items={items}
+                  element={element}
+                  getItemProps={getItemProps}
+                  highlightedIndex={highlightedIndex}
+                  disabledItems={disabledItems}
+                  optionTemplate={optionTemplate}
+                  groupItemsBy={groupItemsBy}
+                  groupLabelTemplate={groupLabelTemplate}
+                  totalSize={rowVirtualizer.totalSize}
+                  virtualItems={rowVirtualizer.virtualItems}
+                  emptyState={emptyState}
+                />
+              </ComboboxListbox>
+            </ListBoxPositioner>,
+            inputBoxRef.current as Element,
+          )}
         {helpText && (
           <HelpText id={helpTextId} variant={getHelpTextVariant(variant, hasError)}>
             {helpText}

--- a/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
+++ b/packages/paste-core/components/combobox/src/singleselect/Combobox.tsx
@@ -8,11 +8,10 @@ import { Label } from "@twilio-paste/label";
 import { useUID } from "@twilio-paste/uid-library";
 import { useWindowSize } from "@twilio-paste/utils";
 import * as React from "react";
-import { createPortal } from "react-dom";
 import { useVirtual } from "react-virtual";
 
 import { ComboboxItems } from "../ComboboxItems";
-import { ListBoxPositioner } from "../ListboxPositioner";
+import { ListboxWrapper } from "../ListboxWrapper";
 import { visuallyHiddenStyles } from "../helpers";
 import { ComboboxInputSelect } from "../styles/ComboboxInputSelect";
 import { ComboboxInputWrapper } from "../styles/ComboboxInputWrapper";
@@ -36,6 +35,7 @@ const getHelpTextVariant = (variant: InputVariants, hasError: boolean | undefine
 const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   (
     {
+      usePortal = true,
       autocomplete,
       disabled,
       element = "COMBOBOX",
@@ -143,12 +143,6 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
       [items, internalSelectedItem],
     );
 
-    const [domReady, setDomReady] = React.useState(false);
-
-    React.useEffect(() => {
-      setDomReady(true);
-    }, []);
-
     return (
       <Box position="relative" element={`${element}_WRAPPER`}>
         <Box {...(hideVisibleLabel && { ...visuallyHiddenStyles })}>
@@ -186,28 +180,24 @@ const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
             )}
           </ComboboxInputWrapper>
         </InputBox>
-        {domReady &&
-          createPortal(
-            <ListBoxPositioner inputBoxRef={inputBoxRef} dropdownBoxRef={parentRef}>
-              <ComboboxListbox hidden={!isOpen} element={`${element}_LISTBOX`} {...getMenuProps({ ref: parentRef })}>
-                <ComboboxItems
-                  ref={scrollToIndexRef}
-                  items={items}
-                  element={element}
-                  getItemProps={getItemProps}
-                  highlightedIndex={highlightedIndex}
-                  disabledItems={disabledItems}
-                  optionTemplate={optionTemplate}
-                  groupItemsBy={groupItemsBy}
-                  groupLabelTemplate={groupLabelTemplate}
-                  totalSize={rowVirtualizer.totalSize}
-                  virtualItems={rowVirtualizer.virtualItems}
-                  emptyState={emptyState}
-                />
-              </ComboboxListbox>
-            </ListBoxPositioner>,
-            inputBoxRef.current as Element,
-          )}
+        <ListboxWrapper inputBoxRef={inputBoxRef} parentRef={parentRef} usePortal={usePortal}>
+          <ComboboxListbox hidden={!isOpen} element={`${element}_LISTBOX`} {...getMenuProps({ ref: parentRef })}>
+            <ComboboxItems
+              ref={scrollToIndexRef}
+              items={items}
+              element={element}
+              getItemProps={getItemProps}
+              highlightedIndex={highlightedIndex}
+              disabledItems={disabledItems}
+              optionTemplate={optionTemplate}
+              groupItemsBy={groupItemsBy}
+              groupLabelTemplate={groupLabelTemplate}
+              totalSize={rowVirtualizer.totalSize}
+              virtualItems={rowVirtualizer.virtualItems}
+              emptyState={emptyState}
+            />
+          </ComboboxListbox>
+        </ListboxWrapper>
         {helpText && (
           <HelpText id={helpTextId} variant={getHelpTextVariant(variant, hasError)}>
             {helpText}

--- a/packages/paste-core/components/combobox/src/types.ts
+++ b/packages/paste-core/components/combobox/src/types.ts
@@ -43,6 +43,14 @@ export type HighlightedIndexChanges = {
 
 export interface ComboboxProps extends Omit<InputProps, "id" | "type" | "value" | "autoComplete"> {
   /**
+   * Determines whether the Combobox Listbox (options list) is rendered inside a Portal. Defaults to `true`. Use `false` if you are using Combobox inside a Paste Popover to prevent interaction bugs.
+   *
+   * @type {boolean}
+   * @memberof ComboboxProps
+   * @default true
+   */
+  usePortal?: boolean;
+  /**
    * Activates the autocomplete/typeahead feature
    *
    * @type {boolean}

--- a/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
@@ -9,6 +9,7 @@ import { SearchIcon } from "@twilio-paste/icons/esm/SearchIcon";
 import { Label } from "@twilio-paste/label";
 import { MediaBody, MediaFigure, MediaObject } from "@twilio-paste/media-object";
 import { Modal, ModalBody, ModalHeader, ModalHeading } from "@twilio-paste/modal";
+import { Popover, PopoverButton, PopoverContainer, usePopoverState } from "@twilio-paste/popover";
 import { Option, Select } from "@twilio-paste/select";
 import { Text } from "@twilio-paste/text";
 import { useUID } from "@twilio-paste/uid-library";
@@ -884,4 +885,15 @@ ComboboxInModal.parameters = {
   a11y: {
     disable: true,
   },
+};
+
+export const ComboboxInPopover: StoryFn = () => {
+  return (
+    <PopoverContainer baseId="popover-example">
+      <PopoverButton variant="primary">Open</PopoverButton>
+      <Popover aria-label="Popover">
+        <Combobox items={items} labelText="Select an item" />
+      </Popover>
+    </PopoverContainer>
+  );
 };

--- a/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/Combobox.stories.tsx
@@ -9,7 +9,7 @@ import { SearchIcon } from "@twilio-paste/icons/esm/SearchIcon";
 import { Label } from "@twilio-paste/label";
 import { MediaBody, MediaFigure, MediaObject } from "@twilio-paste/media-object";
 import { Modal, ModalBody, ModalHeader, ModalHeading } from "@twilio-paste/modal";
-import { Popover, PopoverButton, PopoverContainer, usePopoverState } from "@twilio-paste/popover";
+import { Popover, PopoverButton, PopoverContainer } from "@twilio-paste/popover";
 import { Option, Select } from "@twilio-paste/select";
 import { Text } from "@twilio-paste/text";
 import { useUID } from "@twilio-paste/uid-library";
@@ -892,7 +892,7 @@ export const ComboboxInPopover: StoryFn = () => {
     <PopoverContainer baseId="popover-example">
       <PopoverButton variant="primary">Open</PopoverButton>
       <Popover aria-label="Popover">
-        <Combobox items={items} labelText="Select an item" />
+        <Combobox items={items} labelText="Select an item" usePortal={false} />
       </Popover>
     </PopoverContainer>
   );

--- a/packages/paste-core/components/combobox/stories/MultiselectCombobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/MultiselectCombobox.stories.tsx
@@ -7,7 +7,7 @@ import { AttachIcon } from "@twilio-paste/icons/esm/AttachIcon";
 import { InformationIcon } from "@twilio-paste/icons/esm/InformationIcon";
 import { MediaBody, MediaFigure, MediaObject } from "@twilio-paste/media-object";
 import { Modal, ModalBody, ModalHeader, ModalHeading } from "@twilio-paste/modal";
-import { Popover, PopoverButton, PopoverContainer, usePopoverState } from "@twilio-paste/popover";
+import { Popover, PopoverButton, PopoverContainer } from "@twilio-paste/popover";
 import { Text } from "@twilio-paste/text";
 import { useUID } from "@twilio-paste/uid-library";
 import filter from "lodash/filter";
@@ -687,6 +687,7 @@ export const MultiselectComboboxInPopover: StoryFn = () => {
       <Popover aria-label="Popover">
         <Box width="size30">
           <MultiselectCombobox
+            usePortal={false}
             selectedItemsLabelText="items:"
             items={filteredItems}
             labelText="Select an item"

--- a/packages/paste-core/components/combobox/stories/MultiselectCombobox.stories.tsx
+++ b/packages/paste-core/components/combobox/stories/MultiselectCombobox.stories.tsx
@@ -7,6 +7,7 @@ import { AttachIcon } from "@twilio-paste/icons/esm/AttachIcon";
 import { InformationIcon } from "@twilio-paste/icons/esm/InformationIcon";
 import { MediaBody, MediaFigure, MediaObject } from "@twilio-paste/media-object";
 import { Modal, ModalBody, ModalHeader, ModalHeading } from "@twilio-paste/modal";
+import { Popover, PopoverButton, PopoverContainer, usePopoverState } from "@twilio-paste/popover";
 import { Text } from "@twilio-paste/text";
 import { useUID } from "@twilio-paste/uid-library";
 import filter from "lodash/filter";
@@ -674,6 +675,29 @@ MultiselectComboboxInModal.parameters = {
     // redundant flaky test
     disable: true,
   },
+};
+
+export const MultiselectComboboxInPopover: StoryFn = () => {
+  const [inputValue, setInputValue] = React.useState("");
+  const filteredItems = React.useMemo(() => getFilteredItems(inputValue), [inputValue]);
+
+  return (
+    <PopoverContainer baseId="popover-example">
+      <PopoverButton variant="primary">Open</PopoverButton>
+      <Popover aria-label="Popover">
+        <Box width="size30">
+          <MultiselectCombobox
+            selectedItemsLabelText="items:"
+            items={filteredItems}
+            labelText="Select an item"
+            onInputValueChange={({ inputValue: newInputValue = "" }) => {
+              setInputValue(newInputValue);
+            }}
+          />
+        </Box>
+      </Popover>
+    </PopoverContainer>
+  );
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/paste-core/components/combobox/type-docs.json
+++ b/packages/paste-core/components/combobox/type-docs.json
@@ -6740,6 +6740,13 @@
       "required": false,
       "externalProp": true
     },
+    "usePortal": {
+      "type": "boolean",
+      "defaultValue": true,
+      "required": false,
+      "externalProp": false,
+      "description": "Determines whether the Combobox Listbox (options list) is rendered inside a Portal. Defaults to `true`. Use `false` if you are using Combobox inside a Paste Popover to prevent interaction bugs."
+    },
     "variant": {
       "type": "InputVariants",
       "defaultValue": "default",
@@ -8714,6 +8721,13 @@
       "defaultValue": null,
       "required": false,
       "externalProp": true
+    },
+    "usePortal": {
+      "type": "boolean",
+      "defaultValue": true,
+      "required": false,
+      "externalProp": false,
+      "description": "Determines whether the Combobox Listbox (options list) is rendered inside a Portal. Defaults to `true`. Use `false` if you are using Combobox inside a Paste Popover to prevent interaction bugs."
     },
     "variant": {
       "type": "InputVariants",

--- a/packages/paste-website/src/component-examples/ComboboxExamples.ts
+++ b/packages/paste-website/src/component-examples/ComboboxExamples.ts
@@ -502,3 +502,28 @@ render(
   <EmptyStateCombobox />
 )
 `.trim();
+
+export const popoverExample = `
+
+const items = [
+  "Alert",
+  "Heading",
+  "List",
+  "Paragraph",
+];
+
+const PopoverCombobox = () => {
+  return (
+    <PopoverContainer baseId="popover-example">
+      <PopoverButton variant="primary">Open</PopoverButton>
+      <Popover aria-label="Popover">
+        <Combobox items={items} labelText="Select an item" usePortal={false} />
+      </Popover>
+    </PopoverContainer>  
+  );
+};
+
+render(
+  <PopoverCombobox />
+)
+`.trim();

--- a/packages/paste-website/src/component-examples/MultiselectComboboxExamples.ts
+++ b/packages/paste-website/src/component-examples/MultiselectComboboxExamples.ts
@@ -624,3 +624,48 @@ render(
   <MultiselectComboboxExample />
 )
 `.trim();
+
+export const popoverExample = `
+
+const items = [
+  "Alert",
+  "Heading",
+  "List",
+  "Paragraph",
+];
+
+function getFilteredItems(inputValue) {
+  const lowerCasedInputValue = inputValue.toLowerCase();
+
+  return items.filter(function filterItems(item) {
+    return item.toLowerCase().includes(lowerCasedInputValue);
+  });
+}
+
+const PopoverCombobox = () => {
+  const [inputValue, setInputValue] = React.useState("");
+  const filteredItems = React.useMemo(() => getFilteredItems(inputValue), [inputValue]);
+  return (
+    <PopoverContainer baseId="popover-example">
+      <PopoverButton variant="primary">Open</PopoverButton>
+      <Popover aria-label="Popover">
+        <Box width="size30">
+          <MultiselectCombobox
+            usePortal={false}
+            selectedItemsLabelText="items:"
+            items={filteredItems}
+            labelText="Select an item"
+            onInputValueChange={({ inputValue: newInputValue = "" }) => {
+              setInputValue(newInputValue);
+            }}
+          />
+        </Box>
+      </Popover>
+    </PopoverContainer>
+  );
+};
+
+render(
+  <PopoverCombobox />
+)
+`.trim();

--- a/packages/paste-website/src/pages/components/combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/combobox/index.mdx
@@ -22,6 +22,8 @@ import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {Text} from '@twilio-paste/text';
 import {UnorderedList, ListItem} from '@twilio-paste/list';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+import {InlineCode} from '@twilio-paste/inline-code'
+import { Popover, PopoverButton, PopoverContainer } from "@twilio-paste/popover";
 import Changelog from '@twilio-paste/combobox/CHANGELOG.md';
 import {SidebarCategoryRoutes} from '../../../constants';
 import {
@@ -37,6 +39,7 @@ import {
   groupedComboboxExample,
   groupedLabelComboboxExample,
   stateHookCombobox,
+  popoverExample
 } from '../../../component-examples/ComboboxExamples';
 import packageJson from '@twilio-paste/combobox/package.json';
 import ComponentPageLayout from '../../../layouts/ComponentPageLayout';
@@ -285,6 +288,22 @@ Use an empty state to indicate to a user that their input does not match any val
 ## Composition Notes
 
 A Combobox consists of a label, an input and a listbox.
+
+<Callout variant="warning" marginY="space70">
+  <CalloutHeading as="h5">Combobox and Popover</CalloutHeading>
+  <CalloutText>
+    The Combobox listbox is rendered in a <Anchor href="https://reakit.io/docs/portal/" showExternal>Reakit Portal</Anchor> to control positioning and maintain accessibility. When Combobox is placed in a <Anchor href="/components/popover">Popover</Anchor> (which is also a Reakit Portal under the hood), add <InlineCode>usePortal=false</InlineCode> to your Combobox to prevent interaction bugs caused by nested portals.
+  </CalloutText>
+</Callout>
+
+<LivePreview
+  scope={{PopoverButton, PopoverContainer, Popover, Combobox}}
+  noInline
+  language="jsx"
+  showOverflow
+>
+  {popoverExample}
+</LivePreview>
 
 ### Positioning form fields
 

--- a/packages/paste-website/src/pages/components/multiselect-combobox/index.mdx
+++ b/packages/paste-website/src/pages/components/multiselect-combobox/index.mdx
@@ -22,6 +22,8 @@ import {CloseIcon} from '@twilio-paste/icons/esm/CloseIcon';
 import {AttachIcon} from '@twilio-paste/icons/esm/AttachIcon';
 import {UnorderedList, ListItem} from '@twilio-paste/list';
 import {Callout, CalloutHeading, CalloutText} from '@twilio-paste/callout';
+import { Popover, PopoverButton, PopoverContainer } from "@twilio-paste/popover";
+import {InlineCode} from '@twilio-paste/inline-code'
 import {DoDont, Do, Dont} from '../../../components/DoDont';
 import filter from 'lodash/filter';
 import {SidebarCategoryRoutes} from '../../../constants';
@@ -38,6 +40,7 @@ import {
   emptyStateExample,
   maxHeightExample,
   stateHookExample,
+  popoverExample
 } from '../../../component-examples/MultiselectComboboxExamples';
 import packageJson from '@twilio-paste/combobox/package.json';
 import ComponentPageLayout from '../../../layouts/ComponentPageLayout';
@@ -280,6 +283,22 @@ Use an empty state to indicate to a user that their input does not match any val
 ## Composition Notes
 
 A Multiselect Combobox is comprised of a label, an input and a listbox.
+
+<Callout variant="warning" marginY="space70">
+  <CalloutHeading as="h5">Combobox and Popover</CalloutHeading>
+  <CalloutText>
+    The Multiselect Combobox listbox is rendered in a <Anchor href="https://reakit.io/docs/portal/" showExternal>Reakit Portal</Anchor> to control positioning and maintain accessibility. When Multiselect Combobox is placed in a <Anchor href="/components/popover">Popover</Anchor> (which is also a Reakit Portal under the hood), add <InlineCode>usePortal=false</InlineCode> to your Multiselect Combobox to prevent interaction bugs caused by nested portals.
+  </CalloutText>
+</Callout>
+
+<LivePreview
+  scope={{Box, PopoverButton, PopoverContainer, Popover, MultiselectCombobox}}
+  noInline
+  language="jsx"
+  showOverflow
+>
+  {popoverExample}
+</LivePreview>
 
 ### Positioning form fields
 


### PR DESCRIPTION
Fixes a bug where Comboboxes (Singleselect and Multiselect) can't be used when placed inside of Popovers. The bug was caused by the Combobox Listbox Portal interfering with the Popover Reakit Portal, and was preventing hover styles from being applied as well as closing the entire Popover on a selection of an item (Multiselect only). [See this CodeSandbox for a reproduction and more context](https://codesandbox.io/p/sandbox/combobox-in-popover-krzsgd).

This PR adds the `usePortal` prop to Combobox (which defaults to `true`). It should be used (and set to `false`) when Combobox is used in a Popover. When Combobox doesn't use a Portal, it uses an absolutely positioned Box to position the listbox and attach it to the input box. This means that the ListboxPositioner isn't used on these Comboboxes, so the listbox won't position itself above the input box when the input is at the bottom of the window. If this bug comes up it will be addressed in the future.

Examples added to Singleselect and Multiselect Combobox docs.