### PR TITLE
fix(toast): fix for multiple toast dismiss

### DIFF
--- a/.changeset/curly-ants-report.md
+++ b/.changeset/curly-ants-report.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/toast": patch
+"@twilio-paste/core": patch
+---
+
+[Toast] resolved issue where multiple toasts were not being dismissed

--- a/packages/paste-core/components/toast/src/useToaster.ts
+++ b/packages/paste-core/components/toast/src/useToaster.ts
@@ -14,13 +14,14 @@ export const useToaster = (): UseToasterReturnedProps => {
       /**
        * Clear all timeouts from the toaster when the component unmounts
        */
+
       toasts.forEach((toast) => {
         if (toast.timeOutId) {
           window.clearTimeout(toast.timeOutId);
         }
       });
     };
-  }, [toasts]);
+  }, []);
 
   const pop = (id: ToasterToast["id"]): void => {
     if (!isMounted.current) {


### PR DESCRIPTION
The issue with this was the useEffect hook. the return section is a cleanup, designed to be ran when the component is unmounting. The issue is, when passing a prop is added ot the dependency array the useEffect cleanup is ran for **every change**. So whenever a new toast was added/removed the cleanup was ran. This means teh timeouts for toasts that were already in the array were being cleared and the pop funciton was not being called for them.

This is consistent with the behavior we saw before as only the new toast was being cleared and the old toasts were not being dismissed.

[This article](https://reacttraining.com/blog/useEffect-cleanup) summarizes the issue well in the section `The other circumstance the cleanup gets called `

before:

https://github.com/user-attachments/assets/1e9abe04-b83d-48b0-b043-b6d09324dd6f


after:

https://github.com/user-attachments/assets/fadd801a-68fb-4f90-b8dd-f4d41c5f5d25


