### PR TITLE
fix(a11y): do not assign aria-labelledby attribute to icons unless there is an associated title

### DIFF
--- a/.changeset/tasty-emus-dream.md
+++ b/.changeset/tasty-emus-dream.md
@@ -1,0 +1,5 @@
+---
+"@twilio-paste/icons": patch
+---
+
+Only assign aria-labelledby attribute to icons with a title to link to

--- a/packages/paste-icons/__test__/icons.spec.tsx
+++ b/packages/paste-icons/__test__/icons.spec.tsx
@@ -23,9 +23,14 @@ import {
 
 describe("Icons", () => {
   describe("HTML attributes", () => {
-    it("should have the default element name", () => {
-      const { container } = render(<AgentIcon decorative />);
+    it("should have the default element name and attributes", () => {
+      const { container, getByTitle } = render(<AgentIcon decorative={false} title="Agent Smith" />);
+      expect(getByTitle('Agent Smith')).toBeInTheDocument();
       expect(container.querySelector('[data-paste-element="ICON"]')).toBeInTheDocument();
+    });
+    it("should not have an aria-labelledby attribute if decorative", () => {
+      const { container } = render(<AgentIcon decorative />);
+      expect(container.querySelector('svg')?.attributes).not.toContain("aria-labelledby");
     });
     it("should have a custom element name", () => {
       const { container } = render(<AgentIcon element="CUSTOM_ICON" decorative />);
@@ -34,7 +39,7 @@ describe("Icons", () => {
   });
 
   describe("Customization", () => {
-    it("should apply custom styles to customizaed icons", () => {
+    it("should apply custom styles to customized icons", () => {
       const { container } = render(
         <CustomizationProvider
           baseTheme="default"

--- a/packages/paste-icons/src/AcceptIcon.tsx
+++ b/packages/paste-icons/src/AcceptIcon.tsx
@@ -29,7 +29,7 @@ const AcceptIcon = React.forwardRef<HTMLElement, AcceptIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AddListIcon.tsx
+++ b/packages/paste-icons/src/AddListIcon.tsx
@@ -30,7 +30,7 @@ const AddListIcon = React.forwardRef<HTMLElement, AddListIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AddSeriesIcon.tsx
+++ b/packages/paste-icons/src/AddSeriesIcon.tsx
@@ -30,7 +30,7 @@ const AddSeriesIcon = React.forwardRef<HTMLElement, AddSeriesIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AgentIcon.tsx
+++ b/packages/paste-icons/src/AgentIcon.tsx
@@ -29,7 +29,7 @@ const AgentIcon = React.forwardRef<HTMLElement, AgentIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AlignLeftIcon.tsx
+++ b/packages/paste-icons/src/AlignLeftIcon.tsx
@@ -30,7 +30,7 @@ const AlignLeftIcon = React.forwardRef<HTMLElement, AlignLeftIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AlignRightIcon.tsx
+++ b/packages/paste-icons/src/AlignRightIcon.tsx
@@ -30,7 +30,7 @@ const AlignRightIcon = React.forwardRef<HTMLElement, AlignRightIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AlignVerticalCenterIcon.tsx
+++ b/packages/paste-icons/src/AlignVerticalCenterIcon.tsx
@@ -30,7 +30,7 @@ const AlignVerticalCenterIcon = React.forwardRef<HTMLElement, AlignVerticalCente
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArchiveIcon.tsx
+++ b/packages/paste-icons/src/ArchiveIcon.tsx
@@ -30,7 +30,7 @@ const ArchiveIcon = React.forwardRef<HTMLElement, ArchiveIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArrowBackIcon.tsx
+++ b/packages/paste-icons/src/ArrowBackIcon.tsx
@@ -29,7 +29,7 @@ const ArrowBackIcon = React.forwardRef<HTMLElement, ArrowBackIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArrowDownIcon.tsx
+++ b/packages/paste-icons/src/ArrowDownIcon.tsx
@@ -29,7 +29,7 @@ const ArrowDownIcon = React.forwardRef<HTMLElement, ArrowDownIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArrowForwardIcon.tsx
+++ b/packages/paste-icons/src/ArrowForwardIcon.tsx
@@ -29,7 +29,7 @@ const ArrowForwardIcon = React.forwardRef<HTMLElement, ArrowForwardIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArrowUpIcon.tsx
+++ b/packages/paste-icons/src/ArrowUpIcon.tsx
@@ -29,7 +29,7 @@ const ArrowUpIcon = React.forwardRef<HTMLElement, ArrowUpIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ArtificialIntelligenceIcon.tsx
+++ b/packages/paste-icons/src/ArtificialIntelligenceIcon.tsx
@@ -30,7 +30,7 @@ const ArtificialIntelligenceIcon = React.forwardRef<HTMLElement, ArtificialIntel
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AttachIcon.tsx
+++ b/packages/paste-icons/src/AttachIcon.tsx
@@ -29,7 +29,7 @@ const AttachIcon = React.forwardRef<HTMLElement, AttachIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AttachmentIcon.tsx
+++ b/packages/paste-icons/src/AttachmentIcon.tsx
@@ -30,7 +30,7 @@ const AttachmentIcon = React.forwardRef<HTMLElement, AttachmentIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AuthenticationIcon.tsx
+++ b/packages/paste-icons/src/AuthenticationIcon.tsx
@@ -30,7 +30,7 @@ const AuthenticationIcon = React.forwardRef<HTMLElement, AuthenticationIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AutomaticUpdatesIcon.tsx
+++ b/packages/paste-icons/src/AutomaticUpdatesIcon.tsx
@@ -30,7 +30,7 @@ const AutomaticUpdatesIcon = React.forwardRef<HTMLElement, AutomaticUpdatesIconP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/AvailableIcon.tsx
+++ b/packages/paste-icons/src/AvailableIcon.tsx
@@ -30,7 +30,7 @@ const AvailableIcon = React.forwardRef<HTMLElement, AvailableIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/BoldIcon.tsx
+++ b/packages/paste-icons/src/BoldIcon.tsx
@@ -30,7 +30,7 @@ const BoldIcon = React.forwardRef<HTMLElement, BoldIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/BuildIcon.tsx
+++ b/packages/paste-icons/src/BuildIcon.tsx
@@ -30,7 +30,7 @@ const BuildIcon = React.forwardRef<HTMLElement, BuildIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/BuiltInIcon.tsx
+++ b/packages/paste-icons/src/BuiltInIcon.tsx
@@ -29,7 +29,7 @@ const BuiltInIcon = React.forwardRef<HTMLElement, BuiltInIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/BusinessIcon.tsx
+++ b/packages/paste-icons/src/BusinessIcon.tsx
@@ -29,7 +29,7 @@ const BusinessIcon = React.forwardRef<HTMLElement, BusinessIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ButtonIcon.tsx
+++ b/packages/paste-icons/src/ButtonIcon.tsx
@@ -30,7 +30,7 @@ const ButtonIcon = React.forwardRef<HTMLElement, ButtonIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CalendarIcon.tsx
+++ b/packages/paste-icons/src/CalendarIcon.tsx
@@ -29,7 +29,7 @@ const CalendarIcon = React.forwardRef<HTMLElement, CalendarIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallActiveIcon.tsx
+++ b/packages/paste-icons/src/CallActiveIcon.tsx
@@ -29,7 +29,7 @@ const CallActiveIcon = React.forwardRef<HTMLElement, CallActiveIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallAddIcon.tsx
+++ b/packages/paste-icons/src/CallAddIcon.tsx
@@ -29,7 +29,7 @@ const CallAddIcon = React.forwardRef<HTMLElement, CallAddIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallFailedIcon.tsx
+++ b/packages/paste-icons/src/CallFailedIcon.tsx
@@ -29,7 +29,7 @@ const CallFailedIcon = React.forwardRef<HTMLElement, CallFailedIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallHoldIcon.tsx
+++ b/packages/paste-icons/src/CallHoldIcon.tsx
@@ -29,7 +29,7 @@ const CallHoldIcon = React.forwardRef<HTMLElement, CallHoldIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallIcon.tsx
+++ b/packages/paste-icons/src/CallIcon.tsx
@@ -29,7 +29,7 @@ const CallIcon = React.forwardRef<HTMLElement, CallIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallIncomingIcon.tsx
+++ b/packages/paste-icons/src/CallIncomingIcon.tsx
@@ -29,7 +29,7 @@ const CallIncomingIcon = React.forwardRef<HTMLElement, CallIncomingIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallOutgoingIcon.tsx
+++ b/packages/paste-icons/src/CallOutgoingIcon.tsx
@@ -29,7 +29,7 @@ const CallOutgoingIcon = React.forwardRef<HTMLElement, CallOutgoingIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CallTransferIcon.tsx
+++ b/packages/paste-icons/src/CallTransferIcon.tsx
@@ -29,7 +29,7 @@ const CallTransferIcon = React.forwardRef<HTMLElement, CallTransferIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CartIcon.tsx
+++ b/packages/paste-icons/src/CartIcon.tsx
@@ -30,7 +30,7 @@ const CartIcon = React.forwardRef<HTMLElement, CartIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChatIcon.tsx
+++ b/packages/paste-icons/src/ChatIcon.tsx
@@ -29,7 +29,7 @@ const ChatIcon = React.forwardRef<HTMLElement, ChatIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CheckboxCheckIcon.tsx
+++ b/packages/paste-icons/src/CheckboxCheckIcon.tsx
@@ -29,7 +29,7 @@ const CheckboxCheckIcon = React.forwardRef<HTMLElement, CheckboxCheckIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CheckboxLineIcon.tsx
+++ b/packages/paste-icons/src/CheckboxLineIcon.tsx
@@ -29,7 +29,7 @@ const CheckboxLineIcon = React.forwardRef<HTMLElement, CheckboxLineIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CheckmarkCircleIcon.tsx
+++ b/packages/paste-icons/src/CheckmarkCircleIcon.tsx
@@ -29,7 +29,7 @@ const CheckmarkCircleIcon = React.forwardRef<HTMLElement, CheckmarkCircleIconPro
           width="100%"
           height="100%"
           viewBox="0 0 24 24"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDisclosureCollapsedIcon.tsx
+++ b/packages/paste-icons/src/ChevronDisclosureCollapsedIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDisclosureCollapsedIcon = React.forwardRef<HTMLElement, ChevronDisc
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDisclosureExpandedIcon.tsx
+++ b/packages/paste-icons/src/ChevronDisclosureExpandedIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDisclosureExpandedIcon = React.forwardRef<HTMLElement, ChevronDiscl
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDisclosureIcon.tsx
+++ b/packages/paste-icons/src/ChevronDisclosureIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDisclosureIcon = React.forwardRef<HTMLElement, ChevronDisclosureIco
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDoubleLeftIcon.tsx
+++ b/packages/paste-icons/src/ChevronDoubleLeftIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDoubleLeftIcon = React.forwardRef<HTMLElement, ChevronDoubleLeftIco
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDoubleRightIcon.tsx
+++ b/packages/paste-icons/src/ChevronDoubleRightIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDoubleRightIcon = React.forwardRef<HTMLElement, ChevronDoubleRightI
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronDownIcon.tsx
+++ b/packages/paste-icons/src/ChevronDownIcon.tsx
@@ -29,7 +29,7 @@ const ChevronDownIcon = React.forwardRef<HTMLElement, ChevronDownIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronExpandIcon.tsx
+++ b/packages/paste-icons/src/ChevronExpandIcon.tsx
@@ -29,7 +29,7 @@ const ChevronExpandIcon = React.forwardRef<HTMLElement, ChevronExpandIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronLeftIcon.tsx
+++ b/packages/paste-icons/src/ChevronLeftIcon.tsx
@@ -29,7 +29,7 @@ const ChevronLeftIcon = React.forwardRef<HTMLElement, ChevronLeftIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronRightIcon.tsx
+++ b/packages/paste-icons/src/ChevronRightIcon.tsx
@@ -29,7 +29,7 @@ const ChevronRightIcon = React.forwardRef<HTMLElement, ChevronRightIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ChevronUpIcon.tsx
+++ b/packages/paste-icons/src/ChevronUpIcon.tsx
@@ -29,7 +29,7 @@ const ChevronUpIcon = React.forwardRef<HTMLElement, ChevronUpIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ClearIcon.tsx
+++ b/packages/paste-icons/src/ClearIcon.tsx
@@ -29,7 +29,7 @@ const ClearIcon = React.forwardRef<HTMLElement, ClearIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CloseCircleIcon.tsx
+++ b/packages/paste-icons/src/CloseCircleIcon.tsx
@@ -30,7 +30,7 @@ const CloseCircleIcon = React.forwardRef<HTMLElement, CloseCircleIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CloseIcon.tsx
+++ b/packages/paste-icons/src/CloseIcon.tsx
@@ -29,7 +29,7 @@ const CloseIcon = React.forwardRef<HTMLElement, CloseIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CloudIcon.tsx
+++ b/packages/paste-icons/src/CloudIcon.tsx
@@ -30,7 +30,7 @@ const CloudIcon = React.forwardRef<HTMLElement, CloudIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CodeIcon.tsx
+++ b/packages/paste-icons/src/CodeIcon.tsx
@@ -30,7 +30,7 @@ const CodeIcon = React.forwardRef<HTMLElement, CodeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CollapseIcon.tsx
+++ b/packages/paste-icons/src/CollapseIcon.tsx
@@ -30,7 +30,7 @@ const CollapseIcon = React.forwardRef<HTMLElement, CollapseIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ColorPickerIcon.tsx
+++ b/packages/paste-icons/src/ColorPickerIcon.tsx
@@ -30,7 +30,7 @@ const ColorPickerIcon = React.forwardRef<HTMLElement, ColorPickerIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ColumnIcon.tsx
+++ b/packages/paste-icons/src/ColumnIcon.tsx
@@ -30,7 +30,7 @@ const ColumnIcon = React.forwardRef<HTMLElement, ColumnIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CommunityIcon.tsx
+++ b/packages/paste-icons/src/CommunityIcon.tsx
@@ -29,7 +29,7 @@ const CommunityIcon = React.forwardRef<HTMLElement, CommunityIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ConnectivityAvailableIcon.tsx
+++ b/packages/paste-icons/src/ConnectivityAvailableIcon.tsx
@@ -30,7 +30,7 @@ const ConnectivityAvailableIcon = React.forwardRef<HTMLElement, ConnectivityAvai
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={4} />

--- a/packages/paste-icons/src/ConnectivityBusyIcon.tsx
+++ b/packages/paste-icons/src/ConnectivityBusyIcon.tsx
@@ -30,7 +30,7 @@ const ConnectivityBusyIcon = React.forwardRef<HTMLElement, ConnectivityBusyIconP
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={4} />

--- a/packages/paste-icons/src/ConnectivityNeutralIcon.tsx
+++ b/packages/paste-icons/src/ConnectivityNeutralIcon.tsx
@@ -30,7 +30,7 @@ const ConnectivityNeutralIcon = React.forwardRef<HTMLElement, ConnectivityNeutra
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={4} />

--- a/packages/paste-icons/src/ConnectivityOfflineIcon.tsx
+++ b/packages/paste-icons/src/ConnectivityOfflineIcon.tsx
@@ -30,7 +30,7 @@ const ConnectivityOfflineIcon = React.forwardRef<HTMLElement, ConnectivityOfflin
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ConnectivityUnavailableIcon.tsx
+++ b/packages/paste-icons/src/ConnectivityUnavailableIcon.tsx
@@ -30,7 +30,7 @@ const ConnectivityUnavailableIcon = React.forwardRef<HTMLElement, ConnectivityUn
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={4} />

--- a/packages/paste-icons/src/CopyIcon.tsx
+++ b/packages/paste-icons/src/CopyIcon.tsx
@@ -29,7 +29,7 @@ const CopyIcon = React.forwardRef<HTMLElement, CopyIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CreditCardIcon.tsx
+++ b/packages/paste-icons/src/CreditCardIcon.tsx
@@ -30,7 +30,7 @@ const CreditCardIcon = React.forwardRef<HTMLElement, CreditCardIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CustomIcon.tsx
+++ b/packages/paste-icons/src/CustomIcon.tsx
@@ -29,7 +29,7 @@ const CustomIcon = React.forwardRef<HTMLElement, CustomIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/CustomerCareIcon.tsx
+++ b/packages/paste-icons/src/CustomerCareIcon.tsx
@@ -30,7 +30,7 @@ const CustomerCareIcon = React.forwardRef<HTMLElement, CustomerCareIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DarkModeIcon.tsx
+++ b/packages/paste-icons/src/DarkModeIcon.tsx
@@ -30,7 +30,7 @@ const DarkModeIcon = React.forwardRef<HTMLElement, DarkModeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataArrayIcon.tsx
+++ b/packages/paste-icons/src/DataArrayIcon.tsx
@@ -30,7 +30,7 @@ const DataArrayIcon = React.forwardRef<HTMLElement, DataArrayIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataBarChartIcon.tsx
+++ b/packages/paste-icons/src/DataBarChartIcon.tsx
@@ -30,7 +30,7 @@ const DataBarChartIcon = React.forwardRef<HTMLElement, DataBarChartIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataBooleanIcon.tsx
+++ b/packages/paste-icons/src/DataBooleanIcon.tsx
@@ -30,7 +30,7 @@ const DataBooleanIcon = React.forwardRef<HTMLElement, DataBooleanIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataLineChartIcon.tsx
+++ b/packages/paste-icons/src/DataLineChartIcon.tsx
@@ -30,7 +30,7 @@ const DataLineChartIcon = React.forwardRef<HTMLElement, DataLineChartIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M4 3.5a.5.5 0 00-1 0v13a.5.5 0 00.5.5h13a.5.5 0 000-1H4V3.5z" />

--- a/packages/paste-icons/src/DataNumberIcon.tsx
+++ b/packages/paste-icons/src/DataNumberIcon.tsx
@@ -30,7 +30,7 @@ const DataNumberIcon = React.forwardRef<HTMLElement, DataNumberIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataObjectIcon.tsx
+++ b/packages/paste-icons/src/DataObjectIcon.tsx
@@ -30,7 +30,7 @@ const DataObjectIcon = React.forwardRef<HTMLElement, DataObjectIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataPieChartIcon.tsx
+++ b/packages/paste-icons/src/DataPieChartIcon.tsx
@@ -30,7 +30,7 @@ const DataPieChartIcon = React.forwardRef<HTMLElement, DataPieChartIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataStringIcon.tsx
+++ b/packages/paste-icons/src/DataStringIcon.tsx
@@ -30,7 +30,7 @@ const DataStringIcon = React.forwardRef<HTMLElement, DataStringIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DataTableIcon.tsx
+++ b/packages/paste-icons/src/DataTableIcon.tsx
@@ -30,7 +30,7 @@ const DataTableIcon = React.forwardRef<HTMLElement, DataTableIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DatabaseIcon.tsx
+++ b/packages/paste-icons/src/DatabaseIcon.tsx
@@ -30,7 +30,7 @@ const DatabaseIcon = React.forwardRef<HTMLElement, DatabaseIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DeleteIcon.tsx
+++ b/packages/paste-icons/src/DeleteIcon.tsx
@@ -29,7 +29,7 @@ const DeleteIcon = React.forwardRef<HTMLElement, DeleteIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DeliveredIcon.tsx
+++ b/packages/paste-icons/src/DeliveredIcon.tsx
@@ -29,7 +29,7 @@ const DeliveredIcon = React.forwardRef<HTMLElement, DeliveredIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DialpadIcon.tsx
+++ b/packages/paste-icons/src/DialpadIcon.tsx
@@ -29,7 +29,7 @@ const DialpadIcon = React.forwardRef<HTMLElement, DialpadIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DirectoryIcon.tsx
+++ b/packages/paste-icons/src/DirectoryIcon.tsx
@@ -29,7 +29,7 @@ const DirectoryIcon = React.forwardRef<HTMLElement, DirectoryIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DisableIcon.tsx
+++ b/packages/paste-icons/src/DisableIcon.tsx
@@ -30,7 +30,7 @@ const DisableIcon = React.forwardRef<HTMLElement, DisableIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DividerIcon.tsx
+++ b/packages/paste-icons/src/DividerIcon.tsx
@@ -30,7 +30,7 @@ const DividerIcon = React.forwardRef<HTMLElement, DividerIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DoNotIcon.tsx
+++ b/packages/paste-icons/src/DoNotIcon.tsx
@@ -29,7 +29,7 @@ const DoNotIcon = React.forwardRef<HTMLElement, DoNotIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DocumentationIcon.tsx
+++ b/packages/paste-icons/src/DocumentationIcon.tsx
@@ -29,7 +29,7 @@ const DocumentationIcon = React.forwardRef<HTMLElement, DocumentationIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DownloadIcon.tsx
+++ b/packages/paste-icons/src/DownloadIcon.tsx
@@ -30,7 +30,7 @@ const DownloadIcon = React.forwardRef<HTMLElement, DownloadIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DragHorizontalIcon.tsx
+++ b/packages/paste-icons/src/DragHorizontalIcon.tsx
@@ -29,7 +29,7 @@ const DragHorizontalIcon = React.forwardRef<HTMLElement, DragHorizontalIconProps
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DragIcon.tsx
+++ b/packages/paste-icons/src/DragIcon.tsx
@@ -29,7 +29,7 @@ const DragIcon = React.forwardRef<HTMLElement, DragIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/DragVerticalIcon.tsx
+++ b/packages/paste-icons/src/DragVerticalIcon.tsx
@@ -29,7 +29,7 @@ const DragVerticalIcon = React.forwardRef<HTMLElement, DragVerticalIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M4 7.999a.5.5 0 100 1h12a.5.5 0 000-1H4zm0 3a.5.5 0 100 1h12a.5.5 0 000-1H4z" />

--- a/packages/paste-icons/src/EditIcon.tsx
+++ b/packages/paste-icons/src/EditIcon.tsx
@@ -29,7 +29,7 @@ const EditIcon = React.forwardRef<HTMLElement, EditIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ElasticSIPTrunkingCapableIcon.tsx
+++ b/packages/paste-icons/src/ElasticSIPTrunkingCapableIcon.tsx
@@ -29,7 +29,7 @@ const ElasticSIPTrunkingCapableIcon = React.forwardRef<HTMLElement, ElasticSIPTr
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/EmailIcon.tsx
+++ b/packages/paste-icons/src/EmailIcon.tsx
@@ -29,7 +29,7 @@ const EmailIcon = React.forwardRef<HTMLElement, EmailIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/EmojiIcon.tsx
+++ b/packages/paste-icons/src/EmojiIcon.tsx
@@ -29,7 +29,7 @@ const EmojiIcon = React.forwardRef<HTMLElement, EmojiIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ErrorIcon.tsx
+++ b/packages/paste-icons/src/ErrorIcon.tsx
@@ -29,7 +29,7 @@ const ErrorIcon = React.forwardRef<HTMLElement, ErrorIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ExpandIcon.tsx
+++ b/packages/paste-icons/src/ExpandIcon.tsx
@@ -29,7 +29,7 @@ const ExpandIcon = React.forwardRef<HTMLElement, ExpandIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ExportIcon.tsx
+++ b/packages/paste-icons/src/ExportIcon.tsx
@@ -30,7 +30,7 @@ const ExportIcon = React.forwardRef<HTMLElement, ExportIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FaxCapableIcon.tsx
+++ b/packages/paste-icons/src/FaxCapableIcon.tsx
@@ -29,7 +29,7 @@ const FaxCapableIcon = React.forwardRef<HTMLElement, FaxCapableIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FeedIcon.tsx
+++ b/packages/paste-icons/src/FeedIcon.tsx
@@ -30,7 +30,7 @@ const FeedIcon = React.forwardRef<HTMLElement, FeedIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FileAudioIcon.tsx
+++ b/packages/paste-icons/src/FileAudioIcon.tsx
@@ -29,7 +29,7 @@ const FileAudioIcon = React.forwardRef<HTMLElement, FileAudioIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FileIcon.tsx
+++ b/packages/paste-icons/src/FileIcon.tsx
@@ -29,7 +29,7 @@ const FileIcon = React.forwardRef<HTMLElement, FileIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FileImageIcon.tsx
+++ b/packages/paste-icons/src/FileImageIcon.tsx
@@ -30,7 +30,7 @@ const FileImageIcon = React.forwardRef<HTMLElement, FileImageIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M6.062 6.5H6.06a.813.813 0 10.002 0z" />

--- a/packages/paste-icons/src/FileVideoIcon.tsx
+++ b/packages/paste-icons/src/FileVideoIcon.tsx
@@ -29,7 +29,7 @@ const FileVideoIcon = React.forwardRef<HTMLElement, FileVideoIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FileZipIcon.tsx
+++ b/packages/paste-icons/src/FileZipIcon.tsx
@@ -29,7 +29,7 @@ const FileZipIcon = React.forwardRef<HTMLElement, FileZipIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FilterIcon.tsx
+++ b/packages/paste-icons/src/FilterIcon.tsx
@@ -29,7 +29,7 @@ const FilterIcon = React.forwardRef<HTMLElement, FilterIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FlagIcon.tsx
+++ b/packages/paste-icons/src/FlagIcon.tsx
@@ -29,7 +29,7 @@ const FlagIcon = React.forwardRef<HTMLElement, FlagIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/FolderIcon.tsx
+++ b/packages/paste-icons/src/FolderIcon.tsx
@@ -30,7 +30,7 @@ const FolderIcon = React.forwardRef<HTMLElement, FolderIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/GitIcon.tsx
+++ b/packages/paste-icons/src/GitIcon.tsx
@@ -30,7 +30,7 @@ const GitIcon = React.forwardRef<HTMLElement, GitIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/HeatmapIcon.tsx
+++ b/packages/paste-icons/src/HeatmapIcon.tsx
@@ -30,7 +30,7 @@ const HeatmapIcon = React.forwardRef<HTMLElement, HeatmapIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/HideIcon.tsx
+++ b/packages/paste-icons/src/HideIcon.tsx
@@ -30,7 +30,7 @@ const HideIcon = React.forwardRef<HTMLElement, HideIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/HistoryIcon.tsx
+++ b/packages/paste-icons/src/HistoryIcon.tsx
@@ -30,7 +30,7 @@ const HistoryIcon = React.forwardRef<HTMLElement, HistoryIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ImageTextIcon.tsx
+++ b/packages/paste-icons/src/ImageTextIcon.tsx
@@ -30,7 +30,7 @@ const ImageTextIcon = React.forwardRef<HTMLElement, ImageTextIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/InboxIcon.tsx
+++ b/packages/paste-icons/src/InboxIcon.tsx
@@ -30,7 +30,7 @@ const InboxIcon = React.forwardRef<HTMLElement, InboxIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/IndentDecreaseIcon.tsx
+++ b/packages/paste-icons/src/IndentDecreaseIcon.tsx
@@ -30,7 +30,7 @@ const IndentDecreaseIcon = React.forwardRef<HTMLElement, IndentDecreaseIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/IndentIncreaseIcon.tsx
+++ b/packages/paste-icons/src/IndentIncreaseIcon.tsx
@@ -30,7 +30,7 @@ const IndentIncreaseIcon = React.forwardRef<HTMLElement, IndentIncreaseIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/InformationIcon.tsx
+++ b/packages/paste-icons/src/InformationIcon.tsx
@@ -29,7 +29,7 @@ const InformationIcon = React.forwardRef<HTMLElement, InformationIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ItalicIcon.tsx
+++ b/packages/paste-icons/src/ItalicIcon.tsx
@@ -30,7 +30,7 @@ const ItalicIcon = React.forwardRef<HTMLElement, ItalicIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LightModeIcon.tsx
+++ b/packages/paste-icons/src/LightModeIcon.tsx
@@ -30,7 +30,7 @@ const LightModeIcon = React.forwardRef<HTMLElement, LightModeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LinkExternalIcon.tsx
+++ b/packages/paste-icons/src/LinkExternalIcon.tsx
@@ -29,7 +29,7 @@ const LinkExternalIcon = React.forwardRef<HTMLElement, LinkExternalIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LinkIcon.tsx
+++ b/packages/paste-icons/src/LinkIcon.tsx
@@ -30,7 +30,7 @@ const LinkIcon = React.forwardRef<HTMLElement, LinkIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LoadingIcon.tsx
+++ b/packages/paste-icons/src/LoadingIcon.tsx
@@ -29,7 +29,7 @@ const LoadingIcon = React.forwardRef<HTMLElement, LoadingIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LockIcon.tsx
+++ b/packages/paste-icons/src/LockIcon.tsx
@@ -30,7 +30,7 @@ const LockIcon = React.forwardRef<HTMLElement, LockIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M10.5 12a.5.5 0 00-1 0v2a.5.5 0 001 0v-2z" />

--- a/packages/paste-icons/src/LogInIcon.tsx
+++ b/packages/paste-icons/src/LogInIcon.tsx
@@ -30,7 +30,7 @@ const LogInIcon = React.forwardRef<HTMLElement, LogInIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LogOutIcon.tsx
+++ b/packages/paste-icons/src/LogOutIcon.tsx
@@ -29,7 +29,7 @@ const LogOutIcon = React.forwardRef<HTMLElement, LogOutIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LogoPasteIcon.tsx
+++ b/packages/paste-icons/src/LogoPasteIcon.tsx
@@ -30,7 +30,7 @@ const LogoPasteIcon = React.forwardRef<HTMLElement, LogoPasteIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LogoTwilioIcon.tsx
+++ b/packages/paste-icons/src/LogoTwilioIcon.tsx
@@ -29,7 +29,7 @@ const LogoTwilioIcon = React.forwardRef<HTMLElement, LogoTwilioIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/LowerHandIcon.tsx
+++ b/packages/paste-icons/src/LowerHandIcon.tsx
@@ -30,7 +30,7 @@ const LowerHandIcon = React.forwardRef<HTMLElement, LowerHandIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MMSCapableIcon.tsx
+++ b/packages/paste-icons/src/MMSCapableIcon.tsx
@@ -29,7 +29,7 @@ const MMSCapableIcon = React.forwardRef<HTMLElement, MMSCapableIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MenuIcon.tsx
+++ b/packages/paste-icons/src/MenuIcon.tsx
@@ -29,7 +29,7 @@ const MenuIcon = React.forwardRef<HTMLElement, MenuIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MicrophoneOffIcon.tsx
+++ b/packages/paste-icons/src/MicrophoneOffIcon.tsx
@@ -30,7 +30,7 @@ const MicrophoneOffIcon = React.forwardRef<HTMLElement, MicrophoneOffIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MicrophoneOnIcon.tsx
+++ b/packages/paste-icons/src/MicrophoneOnIcon.tsx
@@ -30,7 +30,7 @@ const MicrophoneOnIcon = React.forwardRef<HTMLElement, MicrophoneOnIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MinusIcon.tsx
+++ b/packages/paste-icons/src/MinusIcon.tsx
@@ -29,7 +29,7 @@ const MinusIcon = React.forwardRef<HTMLElement, MinusIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/MobileIcon.tsx
+++ b/packages/paste-icons/src/MobileIcon.tsx
@@ -30,7 +30,7 @@ const MobileIcon = React.forwardRef<HTMLElement, MobileIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M9 15.5a1 1 0 102 0 1 1 0 00-2 0z" />

--- a/packages/paste-icons/src/MoreIcon.tsx
+++ b/packages/paste-icons/src/MoreIcon.tsx
@@ -29,7 +29,7 @@ const MoreIcon = React.forwardRef<HTMLElement, MoreIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/NeutralIcon.tsx
+++ b/packages/paste-icons/src/NeutralIcon.tsx
@@ -29,7 +29,7 @@ const NeutralIcon = React.forwardRef<HTMLElement, NeutralIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/NewIcon.tsx
+++ b/packages/paste-icons/src/NewIcon.tsx
@@ -29,7 +29,7 @@ const NewIcon = React.forwardRef<HTMLElement, NewIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/NotesIcon.tsx
+++ b/packages/paste-icons/src/NotesIcon.tsx
@@ -30,7 +30,7 @@ const NotesIcon = React.forwardRef<HTMLElement, NotesIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/NotificationIcon.tsx
+++ b/packages/paste-icons/src/NotificationIcon.tsx
@@ -30,7 +30,7 @@ const NotificationIcon = React.forwardRef<HTMLElement, NotificationIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/NotificationOrnamentIcon.tsx
+++ b/packages/paste-icons/src/NotificationOrnamentIcon.tsx
@@ -30,7 +30,7 @@ const NotificationOrnamentIcon = React.forwardRef<HTMLElement, NotificationOrnam
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={6} />

--- a/packages/paste-icons/src/OrderedListIcon.tsx
+++ b/packages/paste-icons/src/OrderedListIcon.tsx
@@ -30,7 +30,7 @@ const OrderedListIcon = React.forwardRef<HTMLElement, OrderedListIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/OutOfDateIcon.tsx
+++ b/packages/paste-icons/src/OutOfDateIcon.tsx
@@ -30,7 +30,7 @@ const OutOfDateIcon = React.forwardRef<HTMLElement, OutOfDateIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/PauseIcon.tsx
+++ b/packages/paste-icons/src/PauseIcon.tsx
@@ -29,7 +29,7 @@ const PauseIcon = React.forwardRef<HTMLElement, PauseIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/PaymentIcon.tsx
+++ b/packages/paste-icons/src/PaymentIcon.tsx
@@ -30,7 +30,7 @@ const PaymentIcon = React.forwardRef<HTMLElement, PaymentIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/PinIcon.tsx
+++ b/packages/paste-icons/src/PinIcon.tsx
@@ -29,7 +29,7 @@ const PinIcon = React.forwardRef<HTMLElement, PinIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/PlayIcon.tsx
+++ b/packages/paste-icons/src/PlayIcon.tsx
@@ -29,7 +29,7 @@ const PlayIcon = React.forwardRef<HTMLElement, PlayIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/PlusIcon.tsx
+++ b/packages/paste-icons/src/PlusIcon.tsx
@@ -29,7 +29,7 @@ const PlusIcon = React.forwardRef<HTMLElement, PlusIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessDisabledIcon.tsx
+++ b/packages/paste-icons/src/ProcessDisabledIcon.tsx
@@ -30,7 +30,7 @@ const ProcessDisabledIcon = React.forwardRef<HTMLElement, ProcessDisabledIconPro
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessDraftIcon.tsx
+++ b/packages/paste-icons/src/ProcessDraftIcon.tsx
@@ -30,7 +30,7 @@ const ProcessDraftIcon = React.forwardRef<HTMLElement, ProcessDraftIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessErrorIcon.tsx
+++ b/packages/paste-icons/src/ProcessErrorIcon.tsx
@@ -30,7 +30,7 @@ const ProcessErrorIcon = React.forwardRef<HTMLElement, ProcessErrorIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessInProgressIcon.tsx
+++ b/packages/paste-icons/src/ProcessInProgressIcon.tsx
@@ -30,7 +30,7 @@ const ProcessInProgressIcon = React.forwardRef<HTMLElement, ProcessInProgressIco
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessNeutralIcon.tsx
+++ b/packages/paste-icons/src/ProcessNeutralIcon.tsx
@@ -30,7 +30,7 @@ const ProcessNeutralIcon = React.forwardRef<HTMLElement, ProcessNeutralIconProps
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProcessSuccessIcon.tsx
+++ b/packages/paste-icons/src/ProcessSuccessIcon.tsx
@@ -30,7 +30,7 @@ const ProcessSuccessIcon = React.forwardRef<HTMLElement, ProcessSuccessIconProps
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <circle fill="currentColor" cx={10} cy={10} r={6.5} />

--- a/packages/paste-icons/src/ProcessWarningIcon.tsx
+++ b/packages/paste-icons/src/ProcessWarningIcon.tsx
@@ -30,7 +30,7 @@ const ProcessWarningIcon = React.forwardRef<HTMLElement, ProcessWarningIconProps
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAIAssistantsIcon.tsx
+++ b/packages/paste-icons/src/ProductAIAssistantsIcon.tsx
@@ -30,7 +30,7 @@ const ProductAIAssistantsIcon = React.forwardRef<HTMLElement, ProductAIAssistant
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAPIExplorerIcon.tsx
+++ b/packages/paste-icons/src/ProductAPIExplorerIcon.tsx
@@ -29,7 +29,7 @@ const ProductAPIExplorerIcon = React.forwardRef<HTMLElement, ProductAPIExplorerI
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAccountDashboardIcon.tsx
+++ b/packages/paste-icons/src/ProductAccountDashboardIcon.tsx
@@ -30,7 +30,7 @@ const ProductAccountDashboardIcon = React.forwardRef<HTMLElement, ProductAccount
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAddOnsIcon.tsx
+++ b/packages/paste-icons/src/ProductAddOnsIcon.tsx
@@ -29,7 +29,7 @@ const ProductAddOnsIcon = React.forwardRef<HTMLElement, ProductAddOnsIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminAccessControlIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminAccessControlIcon.tsx
@@ -29,7 +29,7 @@ const ProductAdminAccessControlIcon = React.forwardRef<HTMLElement, ProductAdmin
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminAccountsIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminAccountsIcon.tsx
@@ -30,7 +30,7 @@ const ProductAdminAccountsIcon = React.forwardRef<HTMLElement, ProductAdminAccou
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminDomainsIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminDomainsIcon.tsx
@@ -29,7 +29,7 @@ const ProductAdminDomainsIcon = React.forwardRef<HTMLElement, ProductAdminDomain
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminResoldCustomersIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminResoldCustomersIcon.tsx
@@ -29,7 +29,7 @@ const ProductAdminResoldCustomersIcon = React.forwardRef<HTMLElement, ProductAdm
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminSSOIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminSSOIcon.tsx
@@ -29,7 +29,7 @@ const ProductAdminSSOIcon = React.forwardRef<HTMLElement, ProductAdminSSOIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAdminUsersIcon.tsx
+++ b/packages/paste-icons/src/ProductAdminUsersIcon.tsx
@@ -29,7 +29,7 @@ const ProductAdminUsersIcon = React.forwardRef<HTMLElement, ProductAdminUsersIco
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAlarmsIcon.tsx
+++ b/packages/paste-icons/src/ProductAlarmsIcon.tsx
@@ -30,7 +30,7 @@ const ProductAlarmsIcon = React.forwardRef<HTMLElement, ProductAlarmsIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAssetsIcon.tsx
+++ b/packages/paste-icons/src/ProductAssetsIcon.tsx
@@ -29,7 +29,7 @@ const ProductAssetsIcon = React.forwardRef<HTMLElement, ProductAssetsIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAudiencesIcon.tsx
+++ b/packages/paste-icons/src/ProductAudiencesIcon.tsx
@@ -30,7 +30,7 @@ const ProductAudiencesIcon = React.forwardRef<HTMLElement, ProductAudiencesIconP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAuthyIcon.tsx
+++ b/packages/paste-icons/src/ProductAuthyIcon.tsx
@@ -29,7 +29,7 @@ const ProductAuthyIcon = React.forwardRef<HTMLElement, ProductAuthyIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductAutopilotIcon.tsx
+++ b/packages/paste-icons/src/ProductAutopilotIcon.tsx
@@ -29,7 +29,7 @@ const ProductAutopilotIcon = React.forwardRef<HTMLElement, ProductAutopilotIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductBillingIcon.tsx
+++ b/packages/paste-icons/src/ProductBillingIcon.tsx
@@ -29,7 +29,7 @@ const ProductBillingIcon = React.forwardRef<HTMLElement, ProductBillingIconProps
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductCLIIcon.tsx
+++ b/packages/paste-icons/src/ProductCLIIcon.tsx
@@ -29,7 +29,7 @@ const ProductCLIIcon = React.forwardRef<HTMLElement, ProductCLIIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductChannelsIcon.tsx
+++ b/packages/paste-icons/src/ProductChannelsIcon.tsx
@@ -29,7 +29,7 @@ const ProductChannelsIcon = React.forwardRef<HTMLElement, ProductChannelsIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductChatIcon.tsx
+++ b/packages/paste-icons/src/ProductChatIcon.tsx
@@ -29,7 +29,7 @@ const ProductChatIcon = React.forwardRef<HTMLElement, ProductChatIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductCodeExchangeCommunityIcon.tsx
+++ b/packages/paste-icons/src/ProductCodeExchangeCommunityIcon.tsx
@@ -29,7 +29,7 @@ const ProductCodeExchangeCommunityIcon = React.forwardRef<HTMLElement, ProductCo
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductCodeExchangePartnerIcon.tsx
+++ b/packages/paste-icons/src/ProductCodeExchangePartnerIcon.tsx
@@ -29,7 +29,7 @@ const ProductCodeExchangePartnerIcon = React.forwardRef<HTMLElement, ProductCode
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductCommsIcon.tsx
+++ b/packages/paste-icons/src/ProductCommsIcon.tsx
@@ -29,7 +29,7 @@ const ProductCommsIcon = React.forwardRef<HTMLElement, ProductCommsIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductConnectedDevicesIcon.tsx
+++ b/packages/paste-icons/src/ProductConnectedDevicesIcon.tsx
@@ -29,7 +29,7 @@ const ProductConnectedDevicesIcon = React.forwardRef<HTMLElement, ProductConnect
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductConnectionsIcon.tsx
+++ b/packages/paste-icons/src/ProductConnectionsIcon.tsx
@@ -30,7 +30,7 @@ const ProductConnectionsIcon = React.forwardRef<HTMLElement, ProductConnectionsI
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductContactCenterAdminIcon.tsx
+++ b/packages/paste-icons/src/ProductContactCenterAdminIcon.tsx
@@ -29,7 +29,7 @@ const ProductContactCenterAdminIcon = React.forwardRef<HTMLElement, ProductConta
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductContactCenterAssessmentsIcon.tsx
+++ b/packages/paste-icons/src/ProductContactCenterAssessmentsIcon.tsx
@@ -29,7 +29,7 @@ const ProductContactCenterAssessmentsIcon = React.forwardRef<HTMLElement, Produc
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductContactCenterQueuesIcon.tsx
+++ b/packages/paste-icons/src/ProductContactCenterQueuesIcon.tsx
@@ -29,7 +29,7 @@ const ProductContactCenterQueuesIcon = React.forwardRef<HTMLElement, ProductCont
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductContactCenterTasksIcon.tsx
+++ b/packages/paste-icons/src/ProductContactCenterTasksIcon.tsx
@@ -29,7 +29,7 @@ const ProductContactCenterTasksIcon = React.forwardRef<HTMLElement, ProductConta
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductContactCenterTeamsIcon.tsx
+++ b/packages/paste-icons/src/ProductContactCenterTeamsIcon.tsx
@@ -29,7 +29,7 @@ const ProductContactCenterTeamsIcon = React.forwardRef<HTMLElement, ProductConta
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductConversationalInsightsIcon.tsx
+++ b/packages/paste-icons/src/ProductConversationalInsightsIcon.tsx
@@ -30,7 +30,7 @@ const ProductConversationalInsightsIcon = React.forwardRef<HTMLElement, ProductC
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductConversationsIcon.tsx
+++ b/packages/paste-icons/src/ProductConversationsIcon.tsx
@@ -29,7 +29,7 @@ const ProductConversationsIcon = React.forwardRef<HTMLElement, ProductConversati
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductDebuggerIcon.tsx
+++ b/packages/paste-icons/src/ProductDebuggerIcon.tsx
@@ -30,7 +30,7 @@ const ProductDebuggerIcon = React.forwardRef<HTMLElement, ProductDebuggerIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductDestinationsIcon.tsx
+++ b/packages/paste-icons/src/ProductDestinationsIcon.tsx
@@ -29,7 +29,7 @@ const ProductDestinationsIcon = React.forwardRef<HTMLElement, ProductDestination
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductElasticSIPTrunkingIcon.tsx
+++ b/packages/paste-icons/src/ProductElasticSIPTrunkingIcon.tsx
@@ -29,7 +29,7 @@ const ProductElasticSIPTrunkingIcon = React.forwardRef<HTMLElement, ProductElast
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductEmailAPIIcon.tsx
+++ b/packages/paste-icons/src/ProductEmailAPIIcon.tsx
@@ -29,7 +29,7 @@ const ProductEmailAPIIcon = React.forwardRef<HTMLElement, ProductEmailAPIIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductEngageIcon.tsx
+++ b/packages/paste-icons/src/ProductEngageIcon.tsx
@@ -30,7 +30,7 @@ const ProductEngageIcon = React.forwardRef<HTMLElement, ProductEngageIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductEngagementIntelligencePlatformIcon.tsx
+++ b/packages/paste-icons/src/ProductEngagementIntelligencePlatformIcon.tsx
@@ -32,7 +32,7 @@ const ProductEngagementIntelligencePlatformIcon = React.forwardRef<
         viewBox="0 0 20 20"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        aria-labelledby={titleId}
+        aria-labelledby={decorative || title == null ? undefined : titleId}
       >
         {title ? <title id={titleId}>{title}</title> : null}
         <path

--- a/packages/paste-icons/src/ProductEventLibraryIcon.tsx
+++ b/packages/paste-icons/src/ProductEventLibraryIcon.tsx
@@ -30,7 +30,7 @@ const ProductEventLibraryIcon = React.forwardRef<HTMLElement, ProductEventLibrar
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductEventStreamIcon.tsx
+++ b/packages/paste-icons/src/ProductEventStreamIcon.tsx
@@ -30,7 +30,7 @@ const ProductEventStreamIcon = React.forwardRef<HTMLElement, ProductEventStreamI
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductEventStreamsIcon.tsx
+++ b/packages/paste-icons/src/ProductEventStreamsIcon.tsx
@@ -30,7 +30,7 @@ const ProductEventStreamsIcon = React.forwardRef<HTMLElement, ProductEventStream
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductFaxIcon.tsx
+++ b/packages/paste-icons/src/ProductFaxIcon.tsx
@@ -29,7 +29,7 @@ const ProductFaxIcon = React.forwardRef<HTMLElement, ProductFaxIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductFlexIcon.tsx
+++ b/packages/paste-icons/src/ProductFlexIcon.tsx
@@ -29,7 +29,7 @@ const ProductFlexIcon = React.forwardRef<HTMLElement, ProductFlexIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductFlowIcon.tsx
+++ b/packages/paste-icons/src/ProductFlowIcon.tsx
@@ -30,7 +30,7 @@ const ProductFlowIcon = React.forwardRef<HTMLElement, ProductFlowIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductFrontlineIcon.tsx
+++ b/packages/paste-icons/src/ProductFrontlineIcon.tsx
@@ -29,7 +29,7 @@ const ProductFrontlineIcon = React.forwardRef<HTMLElement, ProductFrontlineIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductFunctionsIcon.tsx
+++ b/packages/paste-icons/src/ProductFunctionsIcon.tsx
@@ -29,7 +29,7 @@ const ProductFunctionsIcon = React.forwardRef<HTMLElement, ProductFunctionsIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductHomeIcon.tsx
+++ b/packages/paste-icons/src/ProductHomeIcon.tsx
@@ -30,7 +30,7 @@ const ProductHomeIcon = React.forwardRef<HTMLElement, ProductHomeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInsightsIcon.tsx
+++ b/packages/paste-icons/src/ProductInsightsIcon.tsx
@@ -29,7 +29,7 @@ const ProductInsightsIcon = React.forwardRef<HTMLElement, ProductInsightsIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInterconnectIcon.tsx
+++ b/packages/paste-icons/src/ProductInterconnectIcon.tsx
@@ -29,7 +29,7 @@ const ProductInterconnectIcon = React.forwardRef<HTMLElement, ProductInterconnec
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInternetOfThingsEmbeddedSIMIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsEmbeddedSIMIcon.tsx
@@ -32,7 +32,7 @@ const ProductInternetOfThingsEmbeddedSIMIcon = React.forwardRef<
         viewBox="0 0 20 20"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        aria-labelledby={titleId}
+        aria-labelledby={decorative || title == null ? undefined : titleId}
       >
         {title ? <title id={titleId}>{title}</title> : null}
         <path

--- a/packages/paste-icons/src/ProductInternetOfThingsIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsIcon.tsx
@@ -29,7 +29,7 @@ const ProductInternetOfThingsIcon = React.forwardRef<HTMLElement, ProductInterne
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInternetOfThingsNarrowbandIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsNarrowbandIcon.tsx
@@ -30,7 +30,7 @@ const ProductInternetOfThingsNarrowbandIcon = React.forwardRef<HTMLElement, Prod
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInternetOfThingsProgrammableAssetTrackerIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsProgrammableAssetTrackerIcon.tsx
@@ -31,7 +31,7 @@ const ProductInternetOfThingsProgrammableAssetTrackerIcon = React.forwardRef<
         height="100%"
         viewBox="0 0 20 20"
         fill="none"
-        aria-labelledby={titleId}
+        aria-labelledby={decorative || title == null ? undefined : titleId}
       >
         {title ? <title id={titleId}>{title}</title> : null}
         <path

--- a/packages/paste-icons/src/ProductInternetOfThingsSuperSIMIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsSuperSIMIcon.tsx
@@ -30,7 +30,7 @@ const ProductInternetOfThingsSuperSIMIcon = React.forwardRef<HTMLElement, Produc
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductInternetOfThingsTrustOnboardIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsTrustOnboardIcon.tsx
@@ -32,7 +32,7 @@ const ProductInternetOfThingsTrustOnboardIcon = React.forwardRef<
         viewBox="0 0 20 20"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        aria-labelledby={titleId}
+        aria-labelledby={decorative || title == null ? undefined : titleId}
       >
         {title ? <title id={titleId}>{title}</title> : null}
         <path

--- a/packages/paste-icons/src/ProductInternetOfThingsWirelessIcon.tsx
+++ b/packages/paste-icons/src/ProductInternetOfThingsWirelessIcon.tsx
@@ -30,7 +30,7 @@ const ProductInternetOfThingsWirelessIcon = React.forwardRef<HTMLElement, Produc
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductJourneysIcon.tsx
+++ b/packages/paste-icons/src/ProductJourneysIcon.tsx
@@ -30,7 +30,7 @@ const ProductJourneysIcon = React.forwardRef<HTMLElement, ProductJourneysIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductKeysIcon.tsx
+++ b/packages/paste-icons/src/ProductKeysIcon.tsx
@@ -29,7 +29,7 @@ const ProductKeysIcon = React.forwardRef<HTMLElement, ProductKeysIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductLiveIcon.tsx
+++ b/packages/paste-icons/src/ProductLiveIcon.tsx
@@ -30,7 +30,7 @@ const ProductLiveIcon = React.forwardRef<HTMLElement, ProductLiveIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductLogsIcon.tsx
+++ b/packages/paste-icons/src/ProductLogsIcon.tsx
@@ -29,7 +29,7 @@ const ProductLogsIcon = React.forwardRef<HTMLElement, ProductLogsIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductLookupIcon.tsx
+++ b/packages/paste-icons/src/ProductLookupIcon.tsx
@@ -29,7 +29,7 @@ const ProductLookupIcon = React.forwardRef<HTMLElement, ProductLookupIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductMappingIcon.tsx
+++ b/packages/paste-icons/src/ProductMappingIcon.tsx
@@ -30,7 +30,7 @@ const ProductMappingIcon = React.forwardRef<HTMLElement, ProductMappingIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductMarketingCampaignsIcon.tsx
+++ b/packages/paste-icons/src/ProductMarketingCampaignsIcon.tsx
@@ -29,7 +29,7 @@ const ProductMarketingCampaignsIcon = React.forwardRef<HTMLElement, ProductMarke
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductMessagingIcon.tsx
+++ b/packages/paste-icons/src/ProductMessagingIcon.tsx
@@ -29,7 +29,7 @@ const ProductMessagingIcon = React.forwardRef<HTMLElement, ProductMessagingIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductMicrovisorIcon.tsx
+++ b/packages/paste-icons/src/ProductMicrovisorIcon.tsx
@@ -30,7 +30,7 @@ const ProductMicrovisorIcon = React.forwardRef<HTMLElement, ProductMicrovisorIco
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductNotifyIcon.tsx
+++ b/packages/paste-icons/src/ProductNotifyIcon.tsx
@@ -29,7 +29,7 @@ const ProductNotifyIcon = React.forwardRef<HTMLElement, ProductNotifyIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductOneAdminIcon.tsx
+++ b/packages/paste-icons/src/ProductOneAdminIcon.tsx
@@ -30,7 +30,7 @@ const ProductOneAdminIcon = React.forwardRef<HTMLElement, ProductOneAdminIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductPayConnectorIcon.tsx
+++ b/packages/paste-icons/src/ProductPayConnectorIcon.tsx
@@ -29,7 +29,7 @@ const ProductPayConnectorIcon = React.forwardRef<HTMLElement, ProductPayConnecto
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductPersonasIcon.tsx
+++ b/packages/paste-icons/src/ProductPersonasIcon.tsx
@@ -30,7 +30,7 @@ const ProductPersonasIcon = React.forwardRef<HTMLElement, ProductPersonasIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductPhoneNumbersIcon.tsx
+++ b/packages/paste-icons/src/ProductPhoneNumbersIcon.tsx
@@ -29,7 +29,7 @@ const ProductPhoneNumbersIcon = React.forwardRef<HTMLElement, ProductPhoneNumber
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductPrivacyIcon.tsx
+++ b/packages/paste-icons/src/ProductPrivacyIcon.tsx
@@ -30,7 +30,7 @@ const ProductPrivacyIcon = React.forwardRef<HTMLElement, ProductPrivacyIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductProtocolsIcon.tsx
+++ b/packages/paste-icons/src/ProductProtocolsIcon.tsx
@@ -30,7 +30,7 @@ const ProductProtocolsIcon = React.forwardRef<HTMLElement, ProductProtocolsIconP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductProxyIcon.tsx
+++ b/packages/paste-icons/src/ProductProxyIcon.tsx
@@ -29,7 +29,7 @@ const ProductProxyIcon = React.forwardRef<HTMLElement, ProductProxyIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductRegionalIcon.tsx
+++ b/packages/paste-icons/src/ProductRegionalIcon.tsx
@@ -29,7 +29,7 @@ const ProductRegionalIcon = React.forwardRef<HTMLElement, ProductRegionalIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductReverseETLIcon.tsx
+++ b/packages/paste-icons/src/ProductReverseETLIcon.tsx
@@ -30,7 +30,7 @@ const ProductReverseETLIcon = React.forwardRef<HTMLElement, ProductReverseETLIco
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSDKIcon.tsx
+++ b/packages/paste-icons/src/ProductSDKIcon.tsx
@@ -29,7 +29,7 @@ const ProductSDKIcon = React.forwardRef<HTMLElement, ProductSDKIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSegmentIcon.tsx
+++ b/packages/paste-icons/src/ProductSegmentIcon.tsx
@@ -29,7 +29,7 @@ const ProductSegmentIcon = React.forwardRef<HTMLElement, ProductSegmentIconProps
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSendGridIcon.tsx
+++ b/packages/paste-icons/src/ProductSendGridIcon.tsx
@@ -30,7 +30,7 @@ const ProductSendGridIcon = React.forwardRef<HTMLElement, ProductSendGridIconPro
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSettingsIcon.tsx
+++ b/packages/paste-icons/src/ProductSettingsIcon.tsx
@@ -29,7 +29,7 @@ const ProductSettingsIcon = React.forwardRef<HTMLElement, ProductSettingsIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSourceSchemaIcon.tsx
+++ b/packages/paste-icons/src/ProductSourceSchemaIcon.tsx
@@ -30,7 +30,7 @@ const ProductSourceSchemaIcon = React.forwardRef<HTMLElement, ProductSourceSchem
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSourcesIcon.tsx
+++ b/packages/paste-icons/src/ProductSourcesIcon.tsx
@@ -29,7 +29,7 @@ const ProductSourcesIcon = React.forwardRef<HTMLElement, ProductSourcesIconProps
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductStudioIcon.tsx
+++ b/packages/paste-icons/src/ProductStudioIcon.tsx
@@ -29,7 +29,7 @@ const ProductStudioIcon = React.forwardRef<HTMLElement, ProductStudioIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSupportIcon.tsx
+++ b/packages/paste-icons/src/ProductSupportIcon.tsx
@@ -30,7 +30,7 @@ const ProductSupportIcon = React.forwardRef<HTMLElement, ProductSupportIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSwitcherIcon.tsx
+++ b/packages/paste-icons/src/ProductSwitcherIcon.tsx
@@ -30,7 +30,7 @@ const ProductSwitcherIcon = React.forwardRef<HTMLElement, ProductSwitcherIconPro
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductSyncIcon.tsx
+++ b/packages/paste-icons/src/ProductSyncIcon.tsx
@@ -29,7 +29,7 @@ const ProductSyncIcon = React.forwardRef<HTMLElement, ProductSyncIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductTaskRouterIcon.tsx
+++ b/packages/paste-icons/src/ProductTaskRouterIcon.tsx
@@ -29,7 +29,7 @@ const ProductTaskRouterIcon = React.forwardRef<HTMLElement, ProductTaskRouterIco
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductTraitsIcon.tsx
+++ b/packages/paste-icons/src/ProductTraitsIcon.tsx
@@ -30,7 +30,7 @@ const ProductTraitsIcon = React.forwardRef<HTMLElement, ProductTraitsIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductTrustHubIcon.tsx
+++ b/packages/paste-icons/src/ProductTrustHubIcon.tsx
@@ -29,7 +29,7 @@ const ProductTrustHubIcon = React.forwardRef<HTMLElement, ProductTrustHubIconPro
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductTwiMLBinsIcon.tsx
+++ b/packages/paste-icons/src/ProductTwiMLBinsIcon.tsx
@@ -29,7 +29,7 @@ const ProductTwiMLBinsIcon = React.forwardRef<HTMLElement, ProductTwiMLBinsIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductTwilioOrgIcon.tsx
+++ b/packages/paste-icons/src/ProductTwilioOrgIcon.tsx
@@ -29,7 +29,7 @@ const ProductTwilioOrgIcon = React.forwardRef<HTMLElement, ProductTwilioOrgIconP
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductUSSDIcon.tsx
+++ b/packages/paste-icons/src/ProductUSSDIcon.tsx
@@ -30,7 +30,7 @@ const ProductUSSDIcon = React.forwardRef<HTMLElement, ProductUSSDIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductUnifiedProfilesIcon.tsx
+++ b/packages/paste-icons/src/ProductUnifiedProfilesIcon.tsx
@@ -30,7 +30,7 @@ const ProductUnifiedProfilesIcon = React.forwardRef<HTMLElement, ProductUnifiedP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductUnifyIcon.tsx
+++ b/packages/paste-icons/src/ProductUnifyIcon.tsx
@@ -30,7 +30,7 @@ const ProductUnifyIcon = React.forwardRef<HTMLElement, ProductUnifyIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductUsageIcon.tsx
+++ b/packages/paste-icons/src/ProductUsageIcon.tsx
@@ -29,7 +29,7 @@ const ProductUsageIcon = React.forwardRef<HTMLElement, ProductUsageIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductVerifyIcon.tsx
+++ b/packages/paste-icons/src/ProductVerifyIcon.tsx
@@ -29,7 +29,7 @@ const ProductVerifyIcon = React.forwardRef<HTMLElement, ProductVerifyIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductVideoIcon.tsx
+++ b/packages/paste-icons/src/ProductVideoIcon.tsx
@@ -29,7 +29,7 @@ const ProductVideoIcon = React.forwardRef<HTMLElement, ProductVideoIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductVoiceIcon.tsx
+++ b/packages/paste-icons/src/ProductVoiceIcon.tsx
@@ -29,7 +29,7 @@ const ProductVoiceIcon = React.forwardRef<HTMLElement, ProductVoiceIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ProductVoiceIntelligenceIcon.tsx
+++ b/packages/paste-icons/src/ProductVoiceIntelligenceIcon.tsx
@@ -30,7 +30,7 @@ const ProductVoiceIntelligenceIcon = React.forwardRef<HTMLElement, ProductVoiceI
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RCSCapableIcon.tsx
+++ b/packages/paste-icons/src/RCSCapableIcon.tsx
@@ -30,7 +30,7 @@ const RCSCapableIcon = React.forwardRef<HTMLElement, RCSCapableIconProps>(
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RaiseHandIcon.tsx
+++ b/packages/paste-icons/src/RaiseHandIcon.tsx
@@ -30,7 +30,7 @@ const RaiseHandIcon = React.forwardRef<HTMLElement, RaiseHandIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RecordIcon.tsx
+++ b/packages/paste-icons/src/RecordIcon.tsx
@@ -30,7 +30,7 @@ const RecordIcon = React.forwardRef<HTMLElement, RecordIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M3.5 10a6.5 6.5 0 1013 0 6.5 6.5 0 00-13 0z" />

--- a/packages/paste-icons/src/RedoIcon.tsx
+++ b/packages/paste-icons/src/RedoIcon.tsx
@@ -30,7 +30,7 @@ const RedoIcon = React.forwardRef<HTMLElement, RedoIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RefreshIcon.tsx
+++ b/packages/paste-icons/src/RefreshIcon.tsx
@@ -30,7 +30,7 @@ const RefreshIcon = React.forwardRef<HTMLElement, RefreshIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RepeatIcon.tsx
+++ b/packages/paste-icons/src/RepeatIcon.tsx
@@ -30,7 +30,7 @@ const RepeatIcon = React.forwardRef<HTMLElement, RepeatIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/RepeatPurchaseIcon.tsx
+++ b/packages/paste-icons/src/RepeatPurchaseIcon.tsx
@@ -30,7 +30,7 @@ const RepeatPurchaseIcon = React.forwardRef<HTMLElement, RepeatPurchaseIconProps
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ResetIcon.tsx
+++ b/packages/paste-icons/src/ResetIcon.tsx
@@ -30,7 +30,7 @@ const ResetIcon = React.forwardRef<HTMLElement, ResetIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SMSCapableIcon.tsx
+++ b/packages/paste-icons/src/SMSCapableIcon.tsx
@@ -29,7 +29,7 @@ const SMSCapableIcon = React.forwardRef<HTMLElement, SMSCapableIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SMSIcon.tsx
+++ b/packages/paste-icons/src/SMSIcon.tsx
@@ -29,7 +29,7 @@ const SMSIcon = React.forwardRef<HTMLElement, SMSIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ScreenShareIcon.tsx
+++ b/packages/paste-icons/src/ScreenShareIcon.tsx
@@ -30,7 +30,7 @@ const ScreenShareIcon = React.forwardRef<HTMLElement, ScreenShareIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SearchIcon.tsx
+++ b/packages/paste-icons/src/SearchIcon.tsx
@@ -29,7 +29,7 @@ const SearchIcon = React.forwardRef<HTMLElement, SearchIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SelectIcon.tsx
+++ b/packages/paste-icons/src/SelectIcon.tsx
@@ -30,7 +30,7 @@ const SelectIcon = React.forwardRef<HTMLElement, SelectIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SelectedIcon.tsx
+++ b/packages/paste-icons/src/SelectedIcon.tsx
@@ -30,7 +30,7 @@ const SelectedIcon = React.forwardRef<HTMLElement, SelectedIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SendIcon.tsx
+++ b/packages/paste-icons/src/SendIcon.tsx
@@ -30,7 +30,7 @@ const SendIcon = React.forwardRef<HTMLElement, SendIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SentIcon.tsx
+++ b/packages/paste-icons/src/SentIcon.tsx
@@ -29,7 +29,7 @@ const SentIcon = React.forwardRef<HTMLElement, SentIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SentimentNegativeIcon.tsx
+++ b/packages/paste-icons/src/SentimentNegativeIcon.tsx
@@ -29,7 +29,7 @@ const SentimentNegativeIcon = React.forwardRef<HTMLElement, SentimentNegativeIco
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SentimentNeutralIcon.tsx
+++ b/packages/paste-icons/src/SentimentNeutralIcon.tsx
@@ -29,7 +29,7 @@ const SentimentNeutralIcon = React.forwardRef<HTMLElement, SentimentNeutralIconP
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SentimentPositiveIcon.tsx
+++ b/packages/paste-icons/src/SentimentPositiveIcon.tsx
@@ -29,7 +29,7 @@ const SentimentPositiveIcon = React.forwardRef<HTMLElement, SentimentPositiveIco
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ShareIcon.tsx
+++ b/packages/paste-icons/src/ShareIcon.tsx
@@ -29,7 +29,7 @@ const ShareIcon = React.forwardRef<HTMLElement, ShareIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ShowIcon.tsx
+++ b/packages/paste-icons/src/ShowIcon.tsx
@@ -30,7 +30,7 @@ const ShowIcon = React.forwardRef<HTMLElement, ShowIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ShrinkIcon.tsx
+++ b/packages/paste-icons/src/ShrinkIcon.tsx
@@ -29,7 +29,7 @@ const ShrinkIcon = React.forwardRef<HTMLElement, ShrinkIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SkipBackIcon.tsx
+++ b/packages/paste-icons/src/SkipBackIcon.tsx
@@ -29,7 +29,7 @@ const SkipBackIcon = React.forwardRef<HTMLElement, SkipBackIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SkipForwardIcon.tsx
+++ b/packages/paste-icons/src/SkipForwardIcon.tsx
@@ -29,7 +29,7 @@ const SkipForwardIcon = React.forwardRef<HTMLElement, SkipForwardIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SocialIcon.tsx
+++ b/packages/paste-icons/src/SocialIcon.tsx
@@ -30,7 +30,7 @@ const SocialIcon = React.forwardRef<HTMLElement, SocialIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SortAlphabeticalIcon.tsx
+++ b/packages/paste-icons/src/SortAlphabeticalIcon.tsx
@@ -30,7 +30,7 @@ const SortAlphabeticalIcon = React.forwardRef<HTMLElement, SortAlphabeticalIconP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SpacerVerticalIcon.tsx
+++ b/packages/paste-icons/src/SpacerVerticalIcon.tsx
@@ -30,7 +30,7 @@ const SpacerVerticalIcon = React.forwardRef<HTMLElement, SpacerVerticalIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/StarIcon.tsx
+++ b/packages/paste-icons/src/StarIcon.tsx
@@ -29,7 +29,7 @@ const StarIcon = React.forwardRef<HTMLElement, StarIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/StopIcon.tsx
+++ b/packages/paste-icons/src/StopIcon.tsx
@@ -30,7 +30,7 @@ const StopIcon = React.forwardRef<HTMLElement, StopIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M14.5 4.5h-9a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1v-9a1 1 0 00-1-1z" />

--- a/packages/paste-icons/src/StopScreenShareIcon.tsx
+++ b/packages/paste-icons/src/StopScreenShareIcon.tsx
@@ -30,7 +30,7 @@ const StopScreenShareIcon = React.forwardRef<HTMLElement, StopScreenShareIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/StoreIcon.tsx
+++ b/packages/paste-icons/src/StoreIcon.tsx
@@ -30,7 +30,7 @@ const StoreIcon = React.forwardRef<HTMLElement, StoreIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/StrikethroughIcon.tsx
+++ b/packages/paste-icons/src/StrikethroughIcon.tsx
@@ -30,7 +30,7 @@ const StrikethroughIcon = React.forwardRef<HTMLElement, StrikethroughIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SubscriptIcon.tsx
+++ b/packages/paste-icons/src/SubscriptIcon.tsx
@@ -30,7 +30,7 @@ const SubscriptIcon = React.forwardRef<HTMLElement, SubscriptIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SuccessIcon.tsx
+++ b/packages/paste-icons/src/SuccessIcon.tsx
@@ -29,7 +29,7 @@ const SuccessIcon = React.forwardRef<HTMLElement, SuccessIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SuperscriptIcon.tsx
+++ b/packages/paste-icons/src/SuperscriptIcon.tsx
@@ -30,7 +30,7 @@ const SuperscriptIcon = React.forwardRef<HTMLElement, SuperscriptIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SupportIcon.tsx
+++ b/packages/paste-icons/src/SupportIcon.tsx
@@ -30,7 +30,7 @@ const SupportIcon = React.forwardRef<HTMLElement, SupportIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SupportRequestIcon.tsx
+++ b/packages/paste-icons/src/SupportRequestIcon.tsx
@@ -30,7 +30,7 @@ const SupportRequestIcon = React.forwardRef<HTMLElement, SupportRequestIconProps
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/SystemStatusIcon.tsx
+++ b/packages/paste-icons/src/SystemStatusIcon.tsx
@@ -29,7 +29,7 @@ const SystemStatusIcon = React.forwardRef<HTMLElement, SystemStatusIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TaskIcon.tsx
+++ b/packages/paste-icons/src/TaskIcon.tsx
@@ -29,7 +29,7 @@ const TaskIcon = React.forwardRef<HTMLElement, TaskIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TemplateMessageIcon.tsx
+++ b/packages/paste-icons/src/TemplateMessageIcon.tsx
@@ -30,7 +30,7 @@ const TemplateMessageIcon = React.forwardRef<HTMLElement, TemplateMessageIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextAlignCenterIcon.tsx
+++ b/packages/paste-icons/src/TextAlignCenterIcon.tsx
@@ -30,7 +30,7 @@ const TextAlignCenterIcon = React.forwardRef<HTMLElement, TextAlignCenterIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextAlignJustifyIcon.tsx
+++ b/packages/paste-icons/src/TextAlignJustifyIcon.tsx
@@ -30,7 +30,7 @@ const TextAlignJustifyIcon = React.forwardRef<HTMLElement, TextAlignJustifyIconP
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextAlignLeftIcon.tsx
+++ b/packages/paste-icons/src/TextAlignLeftIcon.tsx
@@ -30,7 +30,7 @@ const TextAlignLeftIcon = React.forwardRef<HTMLElement, TextAlignLeftIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextAlignRightIcon.tsx
+++ b/packages/paste-icons/src/TextAlignRightIcon.tsx
@@ -30,7 +30,7 @@ const TextAlignRightIcon = React.forwardRef<HTMLElement, TextAlignRightIconProps
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextFormatClearIcon.tsx
+++ b/packages/paste-icons/src/TextFormatClearIcon.tsx
@@ -30,7 +30,7 @@ const TextFormatClearIcon = React.forwardRef<HTMLElement, TextFormatClearIconPro
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextFormatIcon.tsx
+++ b/packages/paste-icons/src/TextFormatIcon.tsx
@@ -30,7 +30,7 @@ const TextFormatIcon = React.forwardRef<HTMLElement, TextFormatIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TextHighlightIcon.tsx
+++ b/packages/paste-icons/src/TextHighlightIcon.tsx
@@ -30,7 +30,7 @@ const TextHighlightIcon = React.forwardRef<HTMLElement, TextHighlightIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ThemeIcon.tsx
+++ b/packages/paste-icons/src/ThemeIcon.tsx
@@ -30,7 +30,7 @@ const ThemeIcon = React.forwardRef<HTMLElement, ThemeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ThumbsDownIcon.tsx
+++ b/packages/paste-icons/src/ThumbsDownIcon.tsx
@@ -30,7 +30,7 @@ const ThumbsDownIcon = React.forwardRef<HTMLElement, ThumbsDownIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ThumbsUpIcon.tsx
+++ b/packages/paste-icons/src/ThumbsUpIcon.tsx
@@ -30,7 +30,7 @@ const ThumbsUpIcon = React.forwardRef<HTMLElement, ThumbsUpIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TimeIcon.tsx
+++ b/packages/paste-icons/src/TimeIcon.tsx
@@ -30,7 +30,7 @@ const TimeIcon = React.forwardRef<HTMLElement, TimeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M10.5 5.5a.5.5 0 00-1 0v5a.5.5 0 00.5.5h3.5a.5.5 0 000-1h-3V5.5z" />

--- a/packages/paste-icons/src/TipIcon.tsx
+++ b/packages/paste-icons/src/TipIcon.tsx
@@ -30,7 +30,7 @@ const TipIcon = React.forwardRef<HTMLElement, TipIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TokenIcon.tsx
+++ b/packages/paste-icons/src/TokenIcon.tsx
@@ -30,7 +30,7 @@ const TokenIcon = React.forwardRef<HTMLElement, TokenIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TourIcon.tsx
+++ b/packages/paste-icons/src/TourIcon.tsx
@@ -30,7 +30,7 @@ const TourIcon = React.forwardRef<HTMLElement, TourIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TransferIcon.tsx
+++ b/packages/paste-icons/src/TransferIcon.tsx
@@ -30,7 +30,7 @@ const TransferIcon = React.forwardRef<HTMLElement, TransferIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TranslationIcon.tsx
+++ b/packages/paste-icons/src/TranslationIcon.tsx
@@ -29,7 +29,7 @@ const TranslationIcon = React.forwardRef<HTMLElement, TranslationIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TrendDownIcon.tsx
+++ b/packages/paste-icons/src/TrendDownIcon.tsx
@@ -30,7 +30,7 @@ const TrendDownIcon = React.forwardRef<HTMLElement, TrendDownIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TrendUpIcon.tsx
+++ b/packages/paste-icons/src/TrendUpIcon.tsx
@@ -30,7 +30,7 @@ const TrendUpIcon = React.forwardRef<HTMLElement, TrendUpIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/TriggerIcon.tsx
+++ b/packages/paste-icons/src/TriggerIcon.tsx
@@ -30,7 +30,7 @@ const TriggerIcon = React.forwardRef<HTMLElement, TriggerIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnarchiveIcon.tsx
+++ b/packages/paste-icons/src/UnarchiveIcon.tsx
@@ -30,7 +30,7 @@ const UnarchiveIcon = React.forwardRef<HTMLElement, UnarchiveIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnderlineIcon.tsx
+++ b/packages/paste-icons/src/UnderlineIcon.tsx
@@ -30,7 +30,7 @@ const UnderlineIcon = React.forwardRef<HTMLElement, UnderlineIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UndoIcon.tsx
+++ b/packages/paste-icons/src/UndoIcon.tsx
@@ -30,7 +30,7 @@ const UndoIcon = React.forwardRef<HTMLElement, UndoIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnlockIcon.tsx
+++ b/packages/paste-icons/src/UnlockIcon.tsx
@@ -30,7 +30,7 @@ const UnlockIcon = React.forwardRef<HTMLElement, UnlockIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path fill="currentColor" d="M10.5 12a.5.5 0 00-1 0v2a.5.5 0 001 0v-2z" />

--- a/packages/paste-icons/src/UnorderedListIcon.tsx
+++ b/packages/paste-icons/src/UnorderedListIcon.tsx
@@ -30,7 +30,7 @@ const UnorderedListIcon = React.forwardRef<HTMLElement, UnorderedListIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnpinIcon.tsx
+++ b/packages/paste-icons/src/UnpinIcon.tsx
@@ -29,7 +29,7 @@ const UnpinIcon = React.forwardRef<HTMLElement, UnpinIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnsortedIcon.tsx
+++ b/packages/paste-icons/src/UnsortedIcon.tsx
@@ -30,7 +30,7 @@ const UnsortedIcon = React.forwardRef<HTMLElement, UnsortedIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnstarIcon.tsx
+++ b/packages/paste-icons/src/UnstarIcon.tsx
@@ -30,7 +30,7 @@ const UnstarIcon = React.forwardRef<HTMLElement, UnstarIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UnsubscribeIcon.tsx
+++ b/packages/paste-icons/src/UnsubscribeIcon.tsx
@@ -30,7 +30,7 @@ const UnsubscribeIcon = React.forwardRef<HTMLElement, UnsubscribeIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UploadIcon.tsx
+++ b/packages/paste-icons/src/UploadIcon.tsx
@@ -29,7 +29,7 @@ const UploadIcon = React.forwardRef<HTMLElement, UploadIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UploadToCloudIcon.tsx
+++ b/packages/paste-icons/src/UploadToCloudIcon.tsx
@@ -29,7 +29,7 @@ const UploadToCloudIcon = React.forwardRef<HTMLElement, UploadToCloudIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UpsellIcon.tsx
+++ b/packages/paste-icons/src/UpsellIcon.tsx
@@ -30,7 +30,7 @@ const UpsellIcon = React.forwardRef<HTMLElement, UpsellIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UserIcon.tsx
+++ b/packages/paste-icons/src/UserIcon.tsx
@@ -29,7 +29,7 @@ const UserIcon = React.forwardRef<HTMLElement, UserIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/UsersIcon.tsx
+++ b/packages/paste-icons/src/UsersIcon.tsx
@@ -30,7 +30,7 @@ const UsersIcon = React.forwardRef<HTMLElement, UsersIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VideoOffIcon.tsx
+++ b/packages/paste-icons/src/VideoOffIcon.tsx
@@ -30,7 +30,7 @@ const VideoOffIcon = React.forwardRef<HTMLElement, VideoOffIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VideoOnIcon.tsx
+++ b/packages/paste-icons/src/VideoOnIcon.tsx
@@ -30,7 +30,7 @@ const VideoOnIcon = React.forwardRef<HTMLElement, VideoOnIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VoiceCapableIcon.tsx
+++ b/packages/paste-icons/src/VoiceCapableIcon.tsx
@@ -29,7 +29,7 @@ const VoiceCapableIcon = React.forwardRef<HTMLElement, VoiceCapableIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VoicemailIcon.tsx
+++ b/packages/paste-icons/src/VoicemailIcon.tsx
@@ -29,7 +29,7 @@ const VoicemailIcon = React.forwardRef<HTMLElement, VoicemailIconProps>(
           height="100%"
           viewBox="0 0 20 20"
           fill="none"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VolumeOffIcon.tsx
+++ b/packages/paste-icons/src/VolumeOffIcon.tsx
@@ -29,7 +29,7 @@ const VolumeOffIcon = React.forwardRef<HTMLElement, VolumeOffIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/VolumeOnIcon.tsx
+++ b/packages/paste-icons/src/VolumeOnIcon.tsx
@@ -29,7 +29,7 @@ const VolumeOnIcon = React.forwardRef<HTMLElement, VolumeOnIconProps>(
           width="100%"
           height="100%"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/WarningIcon.tsx
+++ b/packages/paste-icons/src/WarningIcon.tsx
@@ -30,7 +30,7 @@ const WarningIcon = React.forwardRef<HTMLElement, WarningIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/WebCapableIcon.tsx
+++ b/packages/paste-icons/src/WebCapableIcon.tsx
@@ -30,7 +30,7 @@ const WebCapableIcon = React.forwardRef<HTMLElement, WebCapableIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/WinbackIcon.tsx
+++ b/packages/paste-icons/src/WinbackIcon.tsx
@@ -30,7 +30,7 @@ const WinbackIcon = React.forwardRef<HTMLElement, WinbackIconProps>(
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path

--- a/packages/paste-icons/src/ZoomInIcon.tsx
+++ b/packages/paste-icons/src/ZoomInIcon.tsx
@@ -30,7 +30,7 @@ const ZoomInIcon = React.forwardRef<HTMLElement, ZoomInIconProps>(
           height="100%"
           fill="none"
           viewBox="0 0 20 20"
-          aria-labelledby={titleId}
+          aria-labelledby={decorative || title == null ? undefined : titleId}
         >
           {title ? <title id={titleId}>{title}</title> : null}
           <path


### PR DESCRIPTION
[See docs team ticket for context.](https://twilio-productivity.atlassian.net/browse/DOCSPLAT-268)

It looks like Paste Icons assign an `aria-labelledby` attribute to all icons, even if there is no `<title />` element that can be referenced by the matching `titleId`. This is throwing warnings in the 'wave' a11y tool mentioned in our QA ticket for the Twilio Docs but you can see the same issue in the Paste docs or anything else that uses Paste Icons and/or the Button with link functionality (which renders a button containing a `decorative` arrow icon).

My fix is to only assign this aria attribute if there will be a valid `<title />` element to reference, avoiding the a11y error/warning.


Without this change (a page with lots of Buttons as links, which render an `<ArrowForwardIcon decorative />` internally:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/38954129-0ae6-44b3-9c81-74d3b11a2a78">

With this change made directly to the Paste icons source in `node_modules/`:

![image](https://github.com/user-attachments/assets/35cf6514-cda2-4309-af64-048d4e34f9c6)


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
