### PR TITLE
Fix Visual Picker Checkbox doesn't work in Firefox when checkbox is clicked on directly

### DIFF
--- a/.changeset/modern-starfishes-matter.md
+++ b/.changeset/modern-starfishes-matter.md
@@ -3,4 +3,4 @@
 "@twilio-paste/core": patch
 ---
 
-[Visual Picker]: Visual Picker Checkbox doesn't work in Firefox when checkbox is clicked on directly
+[Visual Picker]: Fix Visual Picker checkbox doesn't work in firefox when checkbox is clicked on directly

--- a/.changeset/modern-starfishes-matter.md
+++ b/.changeset/modern-starfishes-matter.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/visual-picker": patch
+"@twilio-paste/core": patch
+---
+
+[Visual Picker]: Visual Picker Checkbox doesn't work in Firefox when checkbox is clicked on directly

--- a/packages/paste-core/components/visual-picker/src/VisualPickerCheckbox.tsx
+++ b/packages/paste-core/components/visual-picker/src/VisualPickerCheckbox.tsx
@@ -115,7 +115,7 @@ export const VisualPickerCheckbox = React.forwardRef<HTMLInputElement, VisualPic
         <BaseRadioCheckboxLabel disabled={disabled} htmlFor={checkboxId} id={labelId}>
           <ScreenReaderOnly>{labelText}</ScreenReaderOnly>
           <BaseRadioCheckboxControl
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => e.preventDefault()}
             borderRadius="borderRadius20"
             element={`${element}_CONTROL`}
             disabled={disabled}


### PR DESCRIPTION
closes #3905 