### PR TITLE
fix(tabs): do not scroll to end in some instances

### DIFF
--- a/.changeset/healthy-squids-cheat.md
+++ b/.changeset/healthy-squids-cheat.md
@@ -1,0 +1,8 @@
+---
+"@twilio-paste/code-block": patch
+"@twilio-paste/in-page-navigation": patch
+"@twilio-paste/tabs": patch
+"@twilio-paste/core": patch
+---
+
+[Tabs, CodeBlock, InPageNavigation] fixed a bug where items in the tabs list may not complete the scroll, still showing the overflow right button.

--- a/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
+++ b/packages/paste-core/components/code-block/src/CodeBlockTabList.tsx
@@ -81,7 +81,7 @@ export const CodeBlockTabList = React.forwardRef<HTMLDivElement, CodeBlockTabLis
           <OverflowButton
             position="left"
             onClick={() =>
-              handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, listRef.current)
+              handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
             }
             visible={Boolean(elementOutOBoundsLeft)}
             element={element}
@@ -116,7 +116,7 @@ export const CodeBlockTabList = React.forwardRef<HTMLDivElement, CodeBlockTabLis
           <OverflowButton
             position="right"
             onClick={() =>
-              handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, listRef.current)
+              handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
             }
             visible={Boolean(elementOutOBoundsRight)}
             element={element}

--- a/packages/paste-core/components/code-block/src/utlis.ts
+++ b/packages/paste-core/components/code-block/src/utlis.ts
@@ -17,7 +17,6 @@ export const useElementsOutOfBounds = (): {
     if (scrollContainer && listContainer) {
       const currentScrollContainerRightPosition = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().right;
       const currentScrollContainerXOffset = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().x;
-
       let leftOutOfBounds: HTMLDivElement | null = null;
       let rightOutOfBounds: HTMLDivElement | null = null;
 
@@ -34,10 +33,10 @@ export const useElementsOutOfBounds = (): {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container with some buffer. Also ensure there are
+           * Compares the right side to the end of container. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (right > currentScrollContainerRightPosition + 10 && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }
@@ -76,12 +75,20 @@ export const handleScrollDirection = (
   direction: "left" | "right",
   elementOutOBoundsLeft: HTMLDivElement | null,
   elementOutOBoundsRight: HTMLDivElement | null,
-  listContainer: HTMLElement | null,
+  scrollContainer: HTMLElement | null,
 ): void => {
-  if (listContainer) {
-    const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
-    if (elementToScrollTo) {
-      elementToScrollTo.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-    }
+  const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
+
+  if (scrollContainer && elementToScrollTo) {
+    const elementRect = elementToScrollTo.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const containerScrollLeft = scrollContainer.scrollLeft;
+
+    // Calculate the new scroll position
+    const newScrollLeft =
+      containerScrollLeft + (elementRect.left - containerRect.left) - containerRect.width / 2 + elementRect.width / 2;
+
+    // Set the new scroll position
+    scrollContainer.scrollTo({ left: newScrollLeft, behavior: "smooth" });
   }
 };

--- a/packages/paste-core/components/code-block/src/utlis.ts
+++ b/packages/paste-core/components/code-block/src/utlis.ts
@@ -29,14 +29,14 @@ export const useElementsOutOfBounds = (): {
            * Compares the left side of the tab with the left side of the scrollable container position
            * as the x value will not be 0 due to being offset in the screen.
            */
-          if (x < currentScrollContainerXOffset) {
+          if (Math.round(x) < Math.round(currentScrollContainerXOffset - 28)) {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container. Also ensure there are
+           * Compares the right side to the end of container and button width. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 28) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }

--- a/packages/paste-core/components/in-page-navigation/src/InPageNavigation.tsx
+++ b/packages/paste-core/components/in-page-navigation/src/InPageNavigation.tsx
@@ -196,7 +196,7 @@ const InPageNavigation = React.forwardRef<HTMLDivElement, InPageNavigationProps>
           <OverflowButton
             position="left"
             onClick={() =>
-              handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, listRef.current)
+              handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
             }
             visible={Boolean(elementOutOBoundsLeft)}
             element={element}
@@ -233,7 +233,7 @@ const InPageNavigation = React.forwardRef<HTMLDivElement, InPageNavigationProps>
           <OverflowButton
             position="right"
             onClick={() =>
-              handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, listRef.current)
+              handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
             }
             visible={Boolean(elementOutOBoundsRight)}
             element={element}

--- a/packages/paste-core/components/in-page-navigation/src/utils.ts
+++ b/packages/paste-core/components/in-page-navigation/src/utils.ts
@@ -17,7 +17,6 @@ export const useElementsOutOfBounds = (): {
     if (scrollContainer && listContainer) {
       const currentScrollContainerRightPosition = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().right;
       const currentScrollContainerXOffset = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().x;
-
       let leftOutOfBounds: HTMLDivElement | null = null;
       let rightOutOfBounds: HTMLDivElement | null = null;
 
@@ -34,10 +33,10 @@ export const useElementsOutOfBounds = (): {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container with some buffer. Also ensure there are
+           * Compares the right side to the end of container. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (right > currentScrollContainerRightPosition + 10 && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }
@@ -76,12 +75,20 @@ export const handleScrollDirection = (
   direction: "left" | "right",
   elementOutOBoundsLeft: HTMLDivElement | null,
   elementOutOBoundsRight: HTMLDivElement | null,
-  listContainer: HTMLElement | null,
+  scrollContainer: HTMLElement | null,
 ): void => {
-  if (listContainer) {
-    const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
-    if (elementToScrollTo) {
-      elementToScrollTo.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-    }
+  const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
+
+  if (scrollContainer && elementToScrollTo) {
+    const elementRect = elementToScrollTo.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const containerScrollLeft = scrollContainer.scrollLeft;
+
+    // Calculate the new scroll position
+    const newScrollLeft =
+      containerScrollLeft + (elementRect.left - containerRect.left) - containerRect.width / 2 + elementRect.width / 2;
+
+    // Set the new scroll position
+    scrollContainer.scrollTo({ left: newScrollLeft, behavior: "smooth" });
   }
 };

--- a/packages/paste-core/components/in-page-navigation/src/utils.ts
+++ b/packages/paste-core/components/in-page-navigation/src/utils.ts
@@ -29,14 +29,14 @@ export const useElementsOutOfBounds = (): {
            * Compares the left side of the tab with the left side of the scrollable container position
            * as the x value will not be 0 due to being offset in the screen.
            */
-          if (x < currentScrollContainerXOffset) {
+          if (Math.round(x) < Math.round(currentScrollContainerXOffset - 28)) {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container. Also ensure there are
+           * Compares the right side to the end of container and button width. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 28) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -116,7 +116,9 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
     <Box display="flex" overflow="hidden">
       <OverflowButton
         position="left"
-        onClick={() => handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, ref.current)}
+        onClick={() =>
+          handleScrollDirection("left", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
+        }
         visible={Boolean(elementOutOBoundsLeft)}
         element={element}
         showShadow={showShadow}
@@ -147,7 +149,9 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
       </Box>
       <OverflowButton
         position="right"
-        onClick={() => handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, ref.current)}
+        onClick={() =>
+          handleScrollDirection("right", elementOutOBoundsLeft, elementOutOBoundsRight, scrollableRef.current)
+        }
         visible={Boolean(elementOutOBoundsRight)}
         element={element}
         showShadow={showShadow}

--- a/packages/paste-core/components/tabs/src/TabList.tsx
+++ b/packages/paste-core/components/tabs/src/TabList.tsx
@@ -79,7 +79,7 @@ const HorizontalTabList: React.FC<React.PropsWithChildren<{ variant?: Variants; 
   };
 
   React.useEffect(() => {
-    if (ref.current) {
+    if (ref.current && scrollableRef.current) {
       scrollableRef.current?.addEventListener("scroll", handleScrollEvent);
       window.addEventListener("resize", handleScrollEvent);
       determineElementsOutOfBounds(scrollableRef.current, ref.current);

--- a/packages/paste-core/components/tabs/src/utils.ts
+++ b/packages/paste-core/components/tabs/src/utils.ts
@@ -35,14 +35,14 @@ export const useElementsOutOfBounds = (): {
            * Compares the left side of the tab with the left side of the scrollable container position
            * as the x value will not be 0 due to being offset in the screen.
            */
-          if (x < currentScrollContainerXOffset) {
+          if (Math.round(x) < Math.round(currentScrollContainerXOffset - 28)) {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container. Also ensure there are
+           * Compares the right side to the end of container and button width. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 28) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }

--- a/packages/paste-core/components/tabs/src/utils.ts
+++ b/packages/paste-core/components/tabs/src/utils.ts
@@ -23,7 +23,6 @@ export const useElementsOutOfBounds = (): {
     if (scrollContainer && listContainer) {
       const currentScrollContainerRightPosition = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().right;
       const currentScrollContainerXOffset = (scrollContainer as HTMLDivElement)?.getBoundingClientRect().x;
-
       let leftOutOfBounds: HTMLDivElement | null = null;
       let rightOutOfBounds: HTMLDivElement | null = null;
 
@@ -40,10 +39,10 @@ export const useElementsOutOfBounds = (): {
             leftOutOfBounds = tab;
           }
           /**
-           * Compares the right side to the end of container with some buffer. Also ensure there are
+           * Compares the right side to the end of container. Also ensure there are
            * no value set as it loops through the array we don't want it to override the first value out of bounds.
            */
-          if (right > currentScrollContainerRightPosition + 10 && !rightOutOfBounds) {
+          if (Math.round(right) > Math.round(currentScrollContainerRightPosition + 1) && !rightOutOfBounds) {
             rightOutOfBounds = tab;
           }
         }
@@ -82,12 +81,20 @@ export const handleScrollDirection = (
   direction: "left" | "right",
   elementOutOBoundsLeft: HTMLDivElement | null,
   elementOutOBoundsRight: HTMLDivElement | null,
-  listContainer: HTMLElement | null,
+  scrollContainer: HTMLElement | null,
 ): void => {
-  if (listContainer) {
-    const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
-    if (elementToScrollTo) {
-      elementToScrollTo.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-    }
+  const elementToScrollTo = direction === "left" ? elementOutOBoundsLeft : elementOutOBoundsRight;
+
+  if (scrollContainer && elementToScrollTo) {
+    const elementRect = elementToScrollTo.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const containerScrollLeft = scrollContainer.scrollLeft;
+
+    // Calculate the new scroll position
+    const newScrollLeft =
+      containerScrollLeft + (elementRect.left - containerRect.left) - containerRect.width / 2 + elementRect.width / 2;
+
+    // Set the new scroll position
+    scrollContainer.scrollTo({ left: newScrollLeft, behavior: "smooth" });
   }
 };


### PR DESCRIPTION
Fix the scroll logic so it's on the container itself and reduce the comparison threshold for right overflow button.

customer reported screen recording of not being able to completely scroll:

https://private-user-images.githubusercontent.com/10288627/383905054-3f987474-c635-46a6-b5f0-526d8d826e3c.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzEwODQxNTMsIm5iZiI6MTczMTA4Mzg1MywicGF0aCI6Ii8xMDI4ODYyNy8zODM5MDUwNTQtM2Y5ODc0NzQtYzYzNS00NmE2LWI1ZjAtNTI2ZDhkODI2ZTNjLm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDExMDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMTA4VDE2MzczM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTY5Y2QxZDA3MDIxZGY1YTlmNjU4ODQ3YzQwZDMyYTcxMTgyOGIxYzA4ODlmN2E0YzVjMjgwNzA1MGY1NzJjYmUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.nS9CJUmMbYHZ688LzkXFyT6yq6xhsbP0Mi9fs6I6Aaw
