### PR TITLE
fix(docs): change sitemap generation

### DIFF
--- a/packages/paste-website/src/pages/sitemap.xml.tsx
+++ b/packages/paste-website/src/pages/sitemap.xml.tsx
@@ -1,16 +1,19 @@
 import { globby } from "globby-esm";
 import type { GetServerSideProps } from "next";
+import { unstable_noStore as noStore } from "next/cache";
 
 const Sitemap = (): React.ReactElement | null => {
   return null;
 };
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  noStore();
   const BASE_URL = "https://paste.twilio.design";
 
   const paths = await globby(["**/*.js", "!sitemap.xml.js", "!404.js", "!_*.js"], {
     cwd: __dirname,
   });
+
   const staticPaths = paths.map((staticPagePath) => {
     const path = staticPagePath.replace(".js", "");
     const route = path === "index" ? "" : `${path}/`;

--- a/packages/paste-website/src/pages/sitemap.xml.tsx
+++ b/packages/paste-website/src/pages/sitemap.xml.tsx
@@ -10,20 +10,22 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   noStore();
   const BASE_URL = "https://paste.twilio.design";
 
-  const paths = await globby(["**/*.js", "!sitemap.xml.js", "!404.js", "!_*.js"], {
-    cwd: __dirname,
-  });
+  // Get a list of all pages currently in the site, must be mdx and not tsx which they all currently are
+  const uncompiledPaths = await globby(["**/pages/**/*.mdx", "!**/api/**", "!**/pages/404/**"]);
 
-  const staticPaths = paths.map((staticPagePath) => {
-    const path = staticPagePath.replace(".js", "");
-    const route = path === "index" ? "" : `${path}/`;
-
-    return `${BASE_URL}/${route}`;
+  const urlPaths = uncompiledPaths.map((path) => {
+    // Remove `src/pages/`
+    let modifiedPath = path.replace(/^src\/pages\//, "");
+    // Remove `.mdx`
+    modifiedPath = modifiedPath.replace(/\.mdx$/, "");
+    // Remove `/index` if it's at the end of the path
+    modifiedPath = modifiedPath.replace(/\/index$/, "");
+    return `${BASE_URL}/${modifiedPath}`;
   });
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-      ${staticPaths
+      ${urlPaths
         .map((url) => {
           return `
             <url>

--- a/packages/paste-website/src/pages/sitemap.xml.tsx
+++ b/packages/paste-website/src/pages/sitemap.xml.tsx
@@ -25,6 +25,11 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+        <loc>${BASE_URL}</loc>
+        <changefreq>daily</changefreq>
+        <priority>0.7</priority>
+      </url>
       ${urlPaths
         .map((url) => {
           return `


### PR DESCRIPTION
Update how sitemap is populated to avoid using a compiled cache. After investigating it was found that sitemap was only being generated form the next cache of routes visited. This change dynamically generated the sitemap on build for all pages in the /src/pages directory of the website.

before:
![Screenshot 2024-12-17 at 11 16 19 AM](https://github.com/user-attachments/assets/b0282539-6e7f-4b4b-9dee-aab9e51e57c9)

after:
![Screenshot 2024-12-17 at 11 38 00 AM](https://github.com/user-attachments/assets/8fcd9002-5464-4244-986c-e56d1d27e885)
