### PR TITLE
fix(in-page-navigation): modified code so vertical items wrap text

### DIFF
--- a/.changeset/selfish-bottles-argue.md
+++ b/.changeset/selfish-bottles-argue.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/in-page-navigation": minor
+"@twilio-paste/core": minor
+---
+
+[InPageNavigation] modified vertical items to wrap text as opposed to using ellipses

--- a/packages/paste-core/components/in-page-navigation/src/InPageNavigationItem.tsx
+++ b/packages/paste-core/components/in-page-navigation/src/InPageNavigationItem.tsx
@@ -63,6 +63,7 @@ const VERTICAL_BASE_STYLES: BoxStyleProps = {
   paddingRight: "space50",
   borderBottomRightRadius: "borderRadius30",
   borderTopRightRadius: "borderRadius30",
+  whiteSpace: "break-spaces",
   _focus: {
     boxShadow: "shadowFocusInset",
     outline: "none",


### PR DESCRIPTION
Changed `InPageNavigationItem` vertical styles to wrap text instead of using ellipsis