### PR TITLE
fix(sitemap): ensure all canonical URL

### DIFF
--- a/packages/paste-website/src/pages/sitemap.xml.tsx
+++ b/packages/paste-website/src/pages/sitemap.xml.tsx
@@ -12,9 +12,15 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       ${SITEMAP.map((url) => {
+        let fullUrl = `${BASE_URL}${url}`;
+
+        if (!fullUrl.endsWith("/")) {
+          fullUrl += "/";
+        }
+
         return `
             <url>
-              <loc>${BASE_URL}${url}</loc>
+              <loc>${fullUrl}</loc>
               <changefreq>daily</changefreq>
               <priority>0.7</priority>
             </url>


### PR DESCRIPTION
After reading resources further a lot of references mention that the sitemap.xml should contain all canonical urls (ends with a "/").

I noticed not all of them do in the current deployed one.

preview [sitemap.xml](https://paste-docs-git-canconical-sitemap-urls-twilio.vercel.app/sitemap.xml)

Before:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/8274aa20-b40c-43db-9ec2-17cb4f71228f" />
<img width="760" alt="image" src="https://github.com/user-attachments/assets/e6058de2-eeb2-4512-92a2-e69d4dcc33d6" />

After:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/44838223-3cec-4479-baad-0d3f849fcda9" />
<img width="760" alt="image" src="https://github.com/user-attachments/assets/42689e45-af06-4a17-874f-fdfa2fdebea2" />
