### PR TITLE
feat(lexical, chat-composer): add autolink prop and LexicalTypeaheadMenuPlugin

### DIFF
--- a/.changeset/sharp-weeks-peel.md
+++ b/.changeset/sharp-weeks-peel.md
@@ -1,0 +1,6 @@
+---
+"@twilio-paste/chat-composer": minor
+"@twilio-paste/core": minor
+---
+
+[Chat Composer] add prop `autoLink` which defaults to `true` to allow users to disable the AutoLink plugin

--- a/packages/paste-core/components/chat-composer/src/ChatComposer.tsx
+++ b/packages/paste-core/components/chat-composer/src/ChatComposer.tsx
@@ -110,6 +110,13 @@ export interface ChatComposerProps extends Omit<ContentEditableProps, "style" | 
   onChange?: OnChangeFunction;
   /**
    *
+   * @default true
+   * @type {boolean}
+   * @memberof ChatComposerProps
+   */
+  autoLink?: boolean;
+  /**
+   *
    * @default null
    * @type {React.MutableRefObject<LexicalEditor | null>}
    * @memberof ChatComposerProps
@@ -123,6 +130,7 @@ export const ChatComposer = React.forwardRef<HTMLDivElement, ChatComposerProps>(
       children,
       element = "CHAT_COMPOSER",
       onChange,
+      autoLink = true,
       placeholder = "",
       initialValue,
       config,
@@ -188,7 +196,7 @@ export const ChatComposer = React.forwardRef<HTMLDivElement, ChatComposerProps>(
             />
             {onChange && <OnChangePlugin onChange={onChange} />}
             <HistoryPlugin />
-            <AutoLinkPlugin />
+            {autoLink && <AutoLinkPlugin />}
             <ToggleEditablePlugin disabled={disabled} />
             {editorInstanceRef && <EditorRefPlugin editorRef={editorInstanceRef} />}
             {children}

--- a/packages/paste-core/components/chat-composer/type-docs.json
+++ b/packages/paste-core/components/chat-composer/type-docs.json
@@ -521,6 +521,12 @@
       "required": false,
       "externalProp": true
     },
+    "autoLink": {
+      "type": "boolean",
+      "defaultValue": true,
+      "required": false,
+      "externalProp": false
+    },
     "autoPlay": {
       "type": "boolean",
       "defaultValue": null,

--- a/packages/paste-libraries/lexical/src/index.tsx
+++ b/packages/paste-libraries/lexical/src/index.tsx
@@ -107,6 +107,7 @@ export { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 export { ClearEditorPlugin } from "@lexical/react/LexicalClearEditorPlugin";
 export { EditorRefPlugin } from "@lexical/react/LexicalEditorRefPlugin";
 export { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+export { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
 
 export type LexicalComposerProps = React.ComponentProps<typeof LexicalComposer>;
 export type OnChangeFunction = React.ComponentProps<typeof OnChangePlugin>["onChange"];


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
